### PR TITLE
chore(playground): add manual vendor chunk splitting in vite build

### DIFF
--- a/projects/tiny-schema-renderer-ng/angular.json
+++ b/projects/tiny-schema-renderer-ng/angular.json
@@ -186,5 +186,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/sites/playground/web/vite.config.ts
+++ b/sites/playground/web/vite.config.ts
@@ -6,26 +6,27 @@ import { viteGitCommitHashPlugin } from 'vite-commit-hash-plugin';
 
 /** 单独拆包的依赖（chunk 名），其余 node_modules 进 vendor；@opentiny/vue* 统一为 opentiny-vue */
 const VENDOR_CHUNKS = new Set([
-  'vue',
   'opentiny-vue',
   'opentiny-genui-sdk-core',
   'opentiny-genui-sdk-vue',
   'opentiny-tiny-robot',
   'opentiny-tiny-robot-kit',
-  'opentiny-tiny-robot-svgs',
-  'gridstack',
+  'opentiny-tiny-robot-svgs'
 ]);
 
 function createManualChunks() {
-  const pnpmRe = /[\\/]node_modules[\\/]\.pnpm[\\/][^\\/]+[\\/]node_modules[\\/](@[^\\/]+[\\/][^\\/]+|[^\\/]+)/;
-  const nmRe = /[\\/]node_modules[\\/](@[^\\/]+[\\/][^\\/]+|[^\\/]+)/;
+  const s = '[\\/]';
+  const pkg = `(@[^\\/]+${s}[^\\/]+|[^\\/]+)`;
+  const pnpmRegex = new RegExp(`.*node_modules${s}${pkg}`);
 
   return (id: string): string | undefined => {
     if (!id.includes('node_modules')) return undefined;
-    const pkg = id.match(pnpmRe)?.[1] ?? id.match(nmRe)?.[1];
-    if (!pkg || pkg === '.pnpm') return 'vendor';
-    const name = pkg.startsWith('@') ? pkg.slice(1).replace('/', '-') : pkg;
-    if (name === 'opentiny-vue' || name.startsWith('opentiny-vue-')) return 'opentiny-vue';
+
+    const pkgName = id.match(pnpmRegex)?.[1];
+    if (!pkgName) return 'vendor';
+
+    const name = pkgName.startsWith('@') ? pkgName.slice(1).replace('/', '-') : pkgName;
+    if (/^opentiny-vue(-|$)/.test(name)) return 'opentiny-vue';
     return VENDOR_CHUNKS.has(name) ? name : 'vendor';
   };
 }

--- a/sites/playground/web/vite.config.ts
+++ b/sites/playground/web/vite.config.ts
@@ -4,8 +4,34 @@ import tsconfigPaths from 'vite-jsconfig-paths';
 import { nodePolyfills } from 'vite-plugin-node-polyfills';
 import { viteGitCommitHashPlugin } from 'vite-commit-hash-plugin';
 
+/** 单独拆包的依赖（chunk 名），其余 node_modules 进 vendor；@opentiny/vue* 统一为 opentiny-vue */
+const VENDOR_CHUNKS = new Set([
+  'vue',
+  'opentiny-vue',
+  'opentiny-genui-sdk-core',
+  'opentiny-genui-sdk-vue',
+  'opentiny-tiny-robot',
+  'opentiny-tiny-robot-kit',
+  'opentiny-tiny-robot-svgs',
+  'gridstack',
+]);
+
+function createManualChunks() {
+  const pnpmRe = /[\\/]node_modules[\\/]\.pnpm[\\/][^\\/]+[\\/]node_modules[\\/](@[^\\/]+[\\/][^\\/]+|[^\\/]+)/;
+  const nmRe = /[\\/]node_modules[\\/](@[^\\/]+[\\/][^\\/]+|[^\\/]+)/;
+
+  return (id: string): string | undefined => {
+    if (!id.includes('node_modules')) return undefined;
+    const pkg = id.match(pnpmRe)?.[1] ?? id.match(nmRe)?.[1];
+    if (!pkg || pkg === '.pnpm') return 'vendor';
+    const name = pkg.startsWith('@') ? pkg.slice(1).replace('/', '-') : pkg;
+    if (name === 'opentiny-vue' || name.startsWith('opentiny-vue-')) return 'opentiny-vue';
+    return VENDOR_CHUNKS.has(name) ? name : 'vendor';
+  };
+}
+
 // https://vite.dev/config/
-export default defineConfig(({ command, mode }) => {
+export default defineConfig(({ command }) => {
   const plugins = [
     vue({
       template: {
@@ -19,7 +45,6 @@ export default defineConfig(({ command, mode }) => {
     }),
   ];
 
-
   if (command === 'serve') {
     plugins.push(
       tsconfigPaths({
@@ -28,8 +53,18 @@ export default defineConfig(({ command, mode }) => {
       nodePolyfills(), // tiny-schema-renderer 依赖 babel 间接依赖 process.env等内容
     );
   }
+
   return {
     envDir: './env',
     plugins,
+    build: {
+      rollupOptions: {
+        output: {
+          manualChunks: createManualChunks(),
+          chunkFileNames: 'assets/[name]-[hash].js',
+          assetFileNames: 'assets/[name]-[hash][extname]',
+        },
+      },
+    },
   };
 });

--- a/sites/playground/web/vite.config.ts
+++ b/sites/playground/web/vite.config.ts
@@ -15,9 +15,9 @@ const VENDOR_CHUNKS = new Set([
 ]);
 
 function createManualChunks() {
-  const s = '[\\/]';
-  const pkg = `(@[^\\/]+${s}[^\\/]+|[^\\/]+)`;
-  const pnpmRegex = new RegExp(`.*node_modules${s}${pkg}`);
+  const separator = '[\\/]';
+  const pkg = `(@[^\\/]+${separator}[^\\/]+|[^\\/]+)`;
+  const pnpmRegex = new RegExp(`.*node_modules${separator}${pkg}`);
 
   return (id: string): string | undefined => {
     if (!id.includes('node_modules')) return undefined;


### PR DESCRIPTION
分包前:
<img width="599" height="102" alt="分包前" src="https://github.com/user-attachments/assets/80e69036-2442-4c9e-af1b-45fc2e71927d" />

分包后:
<img width="623" height="205" alt="分包后" src="https://github.com/user-attachments/assets/29e22347-c457-4fff-95d2-5d2b306f4ca9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Disabled CLI analytics by default.
  * Optimized bundle chunking strategy for improved build performance and more efficient code splitting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->