### PR TITLE
docs: add API reference and CLI documentation for genui-sdk-server; add schema protocol documentation

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -18,7 +18,6 @@ export default defineConfig({
   vite: {
     server: {
       host: '0.0.0.0', // 允许外部访问
-      port: 3011, // 指定端口号
       open: true, // 开发时自动打开浏览器
     },
   },

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'vitepress';
 import { vitepressDemoPlugin } from 'vitepress-demo-plugin';
-import { tabsMarkdownPlugin } from 'vitepress-plugin-tabs'
+import { tabsMarkdownPlugin } from 'vitepress-plugin-tabs';
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
@@ -18,6 +18,7 @@ export default defineConfig({
   vite: {
     server: {
       host: '0.0.0.0', // 允许外部访问
+      port: 3011, // 指定端口号
       open: true, // 开发时自动打开浏览器
     },
   },
@@ -31,6 +32,7 @@ export default defineConfig({
       { text: '快速开始', link: '/guide/quick-start' },
       { text: '组件文档', link: '/components/renderer' },
       { text: '特性示例', link: '/examples/renderer/custom-actions' },
+      { text: 'Schema 协议', link: '/schema/protocol' },
     ],
     sidebar: {
       '/guide/': [
@@ -46,7 +48,7 @@ export default defineConfig({
       ],
       '/components/': [
         {
-          text: 'Vue组件文档',
+          text: 'Vue 组件文档',
           items: [
             { text: 'GenuiRenderer', link: '/components/renderer' },
             { text: 'GenuiChat', link: '/components/chat' },
@@ -54,9 +56,16 @@ export default defineConfig({
           ],
         },
         {
-          text: 'Angular组件文档',
+          text: 'Angular 组件文档',
           items: [{ text: 'GenuiRenderer(未开放)', link: '/components/angular-renderer' }],
-        }
+        },
+        {
+          text: 'Server 组件文档',
+          items: [
+            { text: 'API 参考', link: '/components/server/api' },
+            { text: 'CLI', link: '/components/server/cli' }
+          ],
+        },
       ],
       '/examples/': [
         {

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -31,7 +31,7 @@ export default defineConfig({
       { text: '快速开始', link: '/guide/quick-start' },
       { text: '组件文档', link: '/components/renderer' },
       { text: '特性示例', link: '/examples/renderer/custom-actions' },
-      { text: 'Schema 协议', link: '/schema/protocol' },
+      { text: '协议规范', link: '/schema/protocol' },
     ],
     sidebar: {
       '/guide/': [
@@ -59,7 +59,7 @@ export default defineConfig({
           items: [{ text: 'GenuiRenderer(未开放)', link: '/components/angular-renderer' }],
         },
         {
-          text: 'Server 组件文档',
+          text: 'Server 库文档',
           items: [
             { text: 'API 参考', link: '/components/server/api' },
             { text: 'CLI', link: '/components/server/cli' }

--- a/docs/src/guide/api.md
+++ b/docs/src/guide/api.md
@@ -1,0 +1,134 @@
+# API 参考
+
+`@opentiny/genui-sdk-server` 提供了用于构建大模型对话 HTTP 服务的组件 API。
+
+## startServer()
+
+启动一个 Express HTTP 服务器，提供大模型对话服务。
+
+- **类型**
+
+```typescript
+function startServer(options: IStartServerOptions): void
+
+interface IStartServerOptions {
+  /** API 基础 URL */
+  baseURL: string;
+  /** API 密钥 */
+  apiKey: string;
+  /** 服务器启动端口，默认 3100 */
+  port?: number;
+  /** 端口被占用时的最大尝试次数，默认 10 */
+  maxAttempts?: number;
+}
+```
+
+- **详细信息**
+
+创建一个 Express 应用并启用 CORS，自动注册对话路由（`/chat/completions`）。如果指定端口被占用，会自动尝试下一个端口（最多尝试 `maxAttempts` 次）。启动成功后会在控制台输出服务器地址。
+
+- **示例**
+
+```typescript
+import { startServer } from '@opentiny/genui-sdk-server';
+
+startServer({
+  port: 3100,
+  baseURL: 'https://api.openai.com/v1',
+  apiKey: 'your-api-key',
+  maxAttempts: 10,
+});
+```
+
+## equipChatCompletions()
+
+为 Express 应用装备对话功能，注册对话路由处理器。
+
+- **类型**
+
+```typescript
+function equipChatCompletions(
+  app: Express,
+  options: IEquipChatCompletionsOptions
+): void
+
+interface IEquipChatCompletionsOptions {
+  /** 路由路径，例如 '/chat/completions' */
+  route: string;
+  /** API 密钥 */
+  apiKey: string;
+  /** API 基础 URL */
+  baseURL: string;
+}
+```
+
+- **详细信息**
+
+创建一个对话请求的实例，创建请求处理器，并将处理器注册到指定的路由路径（POST 方法）。
+
+- **示例**
+
+```typescript
+import express from 'express';
+import { equipChatCompletions } from '@opentiny/genui-sdk-server';
+
+const app = express();
+
+equipChatCompletions(app, {
+  route: '/chat/completions',
+  apiKey: 'your-api-key',
+  baseURL: 'https://api.openai.com/v1',
+});
+
+app.listen(3000);
+```
+
+## createChatCompletionHandler()
+
+创建一个对话请求处理器，用于处理 HTTP 请求并返回流式响应。
+
+- **类型**
+
+```typescript
+function createChatCompletionHandler(
+  config: IChatCompletionHandlerConfig
+): { handler: (req: IncomingMessage, res: ServerResponse) => Promise<void> }
+
+interface IChatCompletionHandlerConfig {
+  chatCompletions: (
+    params: ChatCompletionCreateParamsBase,
+    options?: IRequestOptions
+  ) => Promise<Response>;
+}
+
+interface IRequestOptions {
+  signal?: AbortSignal | undefined | null;
+}
+```
+
+- **详细信息**
+
+解析请求体（JSON 格式），调用对话接口获取流式响应，处理流式响应并转换为 SSE（Server-Sent Events）格式，处理客户端断开连接（自动中止请求），统一的错误处理和格式化。
+
+如果响应不是流式格式，会抛出错误。所有错误都会被捕获并格式化为统一的错误响应。如果响应头已发送，错误会以 SSE 格式追加到流中。
+
+- **示例**
+
+```typescript
+import { createChatCompletionHandler } from '@opentiny/genui-sdk-server';
+import { FetchChatCompletions } from '@opentiny/genui-sdk-chat-completions';
+import http from 'http';
+
+const chatCompletion = new FetchChatCompletions({
+  apiKey: 'your-api-key',
+  baseURL: 'https://api.openai.com/v1',
+});
+
+const { handler } = createChatCompletionHandler({
+  chatCompletions: (params, options) => 
+    chatCompletion.chatStream(params, options),
+});
+
+const server = http.createServer(handler);
+server.listen(3000);
+```

--- a/docs/src/guide/cli.md
+++ b/docs/src/guide/cli.md
@@ -1,0 +1,147 @@
+# CLI
+
+`genui-sdk-server` 是一个全局安装的命令行工具，用于快速启动 GenUI SDK 聊天完成 HTTP 服务。它提供了零配置的服务器启动方式，自动处理环境变量加载、端口冲突检测等功能。
+
+## 安装
+
+通过 npm 或 yarn 全局安装：
+
+```bash
+npm install -g @opentiny/genui-sdk-server
+# 或
+yarn global add @opentiny/genui-sdk-server
+```
+
+安装完成后，你可以在终端中使用 `genui-sdk-server` 命令。
+
+## 快速开始
+
+1. 创建 `.env` 文件并配置必需的环境变量：
+
+```env
+BASE_URL=https://api.openai.com/v1
+API_KEY=your-api-key-here
+PORT=3100
+```
+
+2. 运行命令启动服务：
+
+```bash
+genui-sdk-server
+```
+
+服务启动成功后，会输出服务器地址，例如：
+
+```
+genui-sdk-server is running on http://localhost:3100
+```
+
+## 命令
+
+### genui-sdk-server
+
+启动 GenUI SDK 对话 HTTP 服务。
+
+#### 用法
+
+```bash
+genui-sdk-server [选项]
+```
+
+#### 选项
+
+| 选项 | 简写 | 类型 | 说明 |
+|:---|:---:|:---:|:---|
+| `--envFile <path>` | `-e` | `string` | 自定义环境变量文件路径（默认：当前目录 `.env`） |
+| `--port <port>` | `-p` | `number` | 服务启动端口（默认：3100 或环境变量 `PORT`） |
+| `--help` | `-h` | - | 显示帮助信息 |
+
+#### 环境变量
+
+CLI 工具需要以下环境变量（可通过 `.env` 文件或系统环境变量设置）：
+
+| 变量名 | 必需 | 说明 | 默认值 |
+|:---|:---:|:---|:---|
+| `BASE_URL` | 是 | API 基础 URL，例如 `https://api.openai.com/v1` | - |
+| `API_KEY` | 是 | API 密钥 | - |
+| `PORT` | 否 | 服务启动端口 | `3100` |
+
+**环境变量优先级**：
+
+1. 命令行选项 `--port`（最高优先级）
+2. 环境变量 `PORT`
+3. 默认值 `3100`
+
+#### 功能特性
+
+- **自动端口检测**：如果指定端口被占用，会自动尝试下一个端口（最多尝试 10 次）
+- **环境变量加载**：支持从 `.env` 文件或系统环境变量加载配置
+- **CORS 支持**：自动启用 CORS，允许跨域请求
+- **流式响应**：支持 SSE（Server-Sent Events）格式的流式响应
+
+#### 示例
+
+**基本用法**
+
+使用默认配置启动服务（读取当前目录的 `.env` 文件，端口 3100）：
+
+```bash
+genui-sdk-server
+```
+
+**指定环境变量文件**
+
+使用自定义的环境变量文件：
+
+```bash
+genui-sdk-server -e /path/to/custom/.env
+```
+
+**指定端口**
+
+通过命令行选项指定服务端口：
+
+```bash
+genui-sdk-server -p 3000
+```
+
+**组合使用**
+
+同时指定环境变量文件和端口：
+
+```bash
+genui-sdk-server -e /path/to/.env -p 3000
+```
+
+**使用系统环境变量**
+
+不依赖 `.env` 文件，直接使用系统环境变量：
+
+```bash
+# 设置系统环境变量
+export BASE_URL=https://api.openai.com/v1
+export API_KEY=your-api-key
+export PORT=3000
+
+# 启动服务
+genui-sdk-server
+```
+
+**查看帮助信息**
+
+```bash
+genui-sdk-server --help
+# 或
+genui-sdk-server -h
+```
+
+## 服务端点
+
+启动成功后，服务会提供以下端点：
+
+- **POST** `/chat/completions` - 聊天完成接口，支持流式响应（SSE 格式）
+
+## 相关链接
+
+- [Server API 文档](./api) - 查看组件 API 文档
+- [使用文档](./usage) - 查看详细使用指南

--- a/docs/src/schema/protocol.md
+++ b/docs/src/schema/protocol.md
@@ -1,0 +1,811 @@
+<!-- markdownlint-disable MD041 -->
+<!-- markdownlint-disable MD033 -->
+<div style="text-align: center;">
+  <h1>Schema 协议规范</h1>
+</div>
+
+Schema 协议是一个基于 JSON 的声明式 UI 描述协议，用于定义和渲染用户界面。该协议采用树形结构描述组件层次关系，支持动态数据绑定和事件处理。
+
+## 概述
+
+Schema 协议通过 JSON 对象描述完整的 UI 结构，包括：
+
+- **组件树结构**：通过嵌套的节点对象描述组件的层次关系
+- **组件属性**：每个组件可以配置属性，支持原始值、JS 表达式、JS 函数等
+- **状态管理**：通过 `state` 字段管理页面级别的状态数据
+- **事件处理**：通过 `methods` 字段定义可复用的方法，组件属性可以绑定这些方法
+
+### 设计原则
+
+1. **声明式**：使用声明式结构描述 UI，而非命令式操作
+2. **平台无关**：协议本身不绑定特定框架，通过组件注册表映射到具体实现
+3. **类型安全**：通过类型定义确保 Schema 结构的正确性
+4. **可扩展**：支持自定义组件和属性类型
+
+## 核心概念
+
+### Schema 对象
+
+Schema 是一个 JSON 对象，包含完整的页面定义。它必须包含 `componentName` 字段，通常为 `"Page"`。
+
+### 节点（Node）
+
+节点是组件树中的基本单元，每个节点代表一个 UI 组件。节点包含：
+- `componentName`：组件名称（必需）
+- `id`：节点唯一标识（可选，但建议提供）
+- `props`：组件属性
+- `children`：子节点数组
+- 其他可选字段：`slot`、`loop`、`condition` 等
+
+### 根节点（RootNode）
+
+根节点是 Schema 的顶层节点，除了包含普通节点的所有字段外，还包含页面级别的配置：
+- `state`：全局状态
+- `methods`：方法集合
+- `css`：全局样式
+
+## 数据结构
+
+### RootNode 类型定义
+
+```typescript
+type RootNode = Omit<Node, 'id'> & {
+  id?: string;                    // 根节点可选 id
+  css?: string;                   // 全局 CSS 样式字符串
+  fileName?: string;              // 文件名
+  methods?: Methods;              // 方法集合
+  state?: Record<string, unknown>; // 全局状态
+  schema?: any;                   // 内嵌或外部 Schema
+};
+```
+
+### Node 类型定义
+
+```typescript
+interface Node {
+  id?: string;                    // 节点唯一标识（可选）
+  componentName: string;          // 组件名（必需）
+  props?: Record<string, any> & { 
+    columns?: { slots?: Record<string, any> }[] 
+  };                             // 组件属性集合
+  children?: Node[];              // 子节点数组
+  componentType?: 'Block' | 'PageStart' | 'PageSection'; // 节点类型
+  slot?: string | Record<string, any>; // 插槽内容
+  params?: string[];              // 参数名列表
+  loop?: Record<string, any>;     // 循环渲染配置
+  loopArgs?: string[];            // 循环参数名列表
+  condition?: boolean | Record<string, any>; // 条件渲染配置
+}
+```
+
+### 字段说明
+
+#### 必需字段
+
+- **componentName** (string): 组件名称，必须与客户端组件注册表中的组件名匹配
+
+#### 可选字段
+
+- **id** (string): 节点唯一标识，建议为每个节点提供，便于调试和事件处理
+- **props** (object): 组件属性对象，键为属性名，值为属性值（支持多种类型）
+- **children** (Node[]): 子节点数组，定义组件的子组件
+- **componentType** ('Block' | 'PageStart' | 'PageSection'): 节点类型，通常省略
+- **slot** (string | object): 插槽内容，可以是字符串或对象
+- **params** (string[]): 参数名列表
+- **loop** (object): 循环渲染配置，用于列表渲染
+- **loopArgs** (string[]): 循环参数名列表，如 `["item", "index"]`
+- **condition** (boolean | object): 条件渲染配置，控制组件是否渲染
+
+#### RootNode 特有字段
+
+- **css** (string): 全局 CSS 样式字符串
+- **fileName** (string): 文件名标识
+- **methods** (Methods): 方法集合，定义可复用的函数
+- **state** (Record<string, unknown>): 全局状态对象
+- **schema** (any): 内嵌或外部 Schema
+
+## 属性值类型
+
+属性值（PropValue）支持以下类型：
+
+### 1. 原始值
+
+- `string`: 字符串
+- `number`: 数字
+- `boolean`: 布尔值
+- `null`: null 值
+
+### 2. JS 表达式（JSExpression）
+
+用于动态计算属性值，支持访问状态、执行计算等。
+
+```typescript
+interface JSExpression {
+  type: 'JSExpression';          // 固定为 'JSExpression'
+  value: string;                 // 表达式字符串
+  model?: boolean;               // 是否为双向绑定模型值
+}
+```
+
+**示例：**
+```json
+{
+  "text": {
+    "type": "JSExpression",
+    "value": "this.state.userName + ' - ' + this.state.userHandle"
+  }
+}
+```
+
+**双向绑定示例：**
+```json
+{
+  "value": {
+    "type": "JSExpression",
+    "value": "this.state.inputValue",
+    "model": true
+  }
+}
+```
+
+### 3. JS 函数（JSFunction）
+
+用于定义事件处理函数。
+
+```typescript
+interface JSFunction {
+  type: 'JSFunction';            // 固定为 'JSFunction'
+  value: string;                 // 函数体字符串（可序列化）
+  params?: string[];             // 函数参数名列表
+}
+```
+
+**示例：**
+```json
+{
+  "onClick": {
+    "type": "JSFunction",
+    "value": "function() { alert('按钮被点击'); }",
+    "params": []
+  }
+}
+```
+
+### 4. 插槽（JSSlot）
+
+用于定义插槽内容。
+
+```typescript
+interface JSSlot {
+  type: 'JSSlot';                // 固定为 'JSSlot'
+  value: string | Record<string, any>; // 插槽内容
+}
+```
+
+### 5. 数组和对象
+
+属性值可以是数组或对象，支持嵌套结构。
+
+```json
+{
+  "items": ["item1", "item2", "item3"],
+  "config": {
+    "key1": "value1",
+    "key2": {
+      "type": "JSExpression",
+      "value": "this.state.dynamicValue"
+    }
+  }
+}
+```
+
+### 6. 特殊结构：columns
+
+对于表格等组件，`props` 支持特殊的 `columns` 结构：
+
+```json
+{
+  "props": {
+    "columns": [
+      {
+        "prop": "name",
+        "label": "姓名",
+        "slots": {
+          "default": "custom-name-slot"
+        }
+      }
+    ]
+  }
+}
+```
+
+## 组件渲染
+
+### 基本渲染
+
+组件通过 `componentName` 字段指定要渲染的组件，客户端根据组件注册表查找对应的实现。
+
+```json
+{
+  "componentName": "Text",
+  "id": "text-1",
+  "props": {
+    "text": "Hello World"
+  }
+}
+```
+
+### 嵌套渲染
+
+通过 `children` 字段定义子组件，形成组件树。
+
+```json
+{
+  "componentName": "CanvasFlexBox",
+  "id": "container",
+  "props": {
+    "flexDirection": "column"
+  },
+  "children": [
+    {
+      "componentName": "Text",
+      "id": "title",
+      "props": {
+        "text": "标题"
+      }
+    },
+    {
+      "componentName": "Text",
+      "id": "content",
+      "props": {
+        "text": "内容"
+      }
+    }
+  ]
+}
+```
+
+### 条件渲染
+
+通过 `condition` 字段控制组件是否渲染。
+
+```json
+{
+  "componentName": "Text",
+  "id": "conditional-text",
+  "condition": {
+    "type": "JSExpression",
+    "value": "this.state.isVisible"
+  },
+  "props": {
+    "text": "条件渲染的文本"
+  }
+}
+```
+
+或者使用布尔值：
+
+```json
+{
+  "componentName": "Text",
+  "id": "conditional-text",
+  "condition": true,
+  "props": {
+    "text": "条件渲染的文本"
+  }
+}
+```
+
+### 循环渲染
+
+通过 `loop` 和 `loopArgs` 字段实现列表渲染。
+
+```json
+{
+  "componentName": "div",
+  "id": "list-item",
+  "loop": {
+    "list": {
+      "type": "JSExpression",
+      "value": "this.state.items"
+    }
+  },
+  "loopArgs": ["item", "index"],
+  "props": {
+    "style": "padding: 10px;"
+  },
+  "children": [
+    {
+      "componentName": "Text",
+      "id": "item-text",
+      "props": {
+        "text": {
+          "type": "JSExpression",
+          "value": "item.name"
+        }
+      }
+    }
+  ]
+}
+```
+
+### 插槽渲染
+
+通过 `slot` 字段定义插槽内容。
+
+```json
+{
+  "componentName": "Card",
+  "id": "card-1",
+  "slot": "插槽内容文本"
+}
+```
+
+或者使用对象形式定义多个插槽：
+
+```json
+{
+  "componentName": "Card",
+  "id": "card-1",
+  "slot": {
+    "header": "头部内容",
+    "footer": "底部内容"
+  }
+}
+```
+
+## 状态管理
+
+### 定义状态
+
+在根节点的 `state` 字段中定义全局状态。
+
+```json
+{
+  "componentName": "Page",
+  "state": {
+    "userName": "张三",
+    "userAge": 25,
+    "isLoggedIn": true,
+    "userProfile": {
+      "name": "张三",
+      "email": "zhangsan@example.com"
+    }
+  }
+}
+```
+
+### 使用状态
+
+在组件属性中通过 JS 表达式访问状态，使用 `this.state` 来访问状态值。
+
+```json
+{
+  "componentName": "Text",
+  "id": "user-name",
+  "props": {
+    "text": {
+      "type": "JSExpression",
+      "value": "this.state.userName"
+    }
+  }
+}
+```
+
+### 双向绑定
+
+对于表单组件，使用 `model: true` 实现双向绑定。
+
+```json
+{
+  "componentName": "Input",
+  "id": "user-input",
+  "props": {
+    "value": {
+      "type": "JSExpression",
+      "value": "this.state.inputValue",
+      "model": true
+    }
+  }
+}
+```
+
+## 事件处理
+
+### 定义方法
+
+在根节点的 `methods` 字段中定义可复用的方法。
+
+```json
+{
+  "componentName": "Page",
+  "methods": {
+    "handleClick": {
+      "type": "JSFunction",
+      "value": "function() { alert('按钮被点击'); }",
+      "params": []
+    },
+    "handleSubmit": {
+      "type": "JSFunction",
+      "value": "function(data) { console.log('提交数据:', data); }",
+      "params": ["data"]
+    }
+  }
+}
+```
+
+### 绑定事件
+
+在组件属性中绑定事件处理函数。
+
+**方式一：引用 methods 中的方法**
+```json
+{
+  "componentName": "TinyButton",
+  "id": "submit-btn",
+  "props": {
+    "text": "提交",
+    "onClick": {
+      "type": "JSExpression",
+      "value": "this.handleSubmit"
+    }
+  }
+}
+```
+
+**方式二：直接定义 JSFunction**
+```json
+{
+  "componentName": "TinyButton",
+  "id": "submit-btn",
+  "props": {
+    "text": "提交",
+    "onClick": {
+      "type": "JSFunction",
+      "value": "function() { console.log('提交按钮被点击'); }",
+      "params": []
+    }
+  }
+}
+```
+
+## 完整示例
+
+### 示例 1：简单页面
+
+```json
+{
+  "componentName": "Page",
+  "fileName": "SimplePage",
+  "css": ".page-base-style {\n  padding: 24px;\n  background: #FFFFFF;\n}",
+  "props": {
+    "className": "page-base-style"
+  },
+  "children": [
+    {
+      "componentName": "CanvasFlexBox",
+      "id": "container",
+      "props": {
+        "flexDirection": "column",
+        "justifyContent": "center",
+        "alignItems": "center"
+      },
+      "children": [
+        {
+          "componentName": "Text",
+          "id": "title",
+          "props": {
+            "text": "欢迎使用 Schema 协议",
+            "style": "font-size: 24px; font-weight: bold; margin-bottom: 20px;"
+          }
+        },
+        {
+          "componentName": "Text",
+          "id": "subtitle",
+          "props": {
+            "text": "这是一个基于声明式 Schema 的 UI 渲染协议",
+            "style": "font-size: 16px; color: #666;"
+          }
+        }
+      ]
+    }
+  ],
+  "state": {},
+  "methods": {},
+  "id": "body"
+}
+```
+
+### 示例 2：带状态和事件的页面
+
+```json
+{
+  "componentName": "Page",
+  "fileName": "UserProfile",
+  "css": ".page-base-style {\n  padding: 24px;\n}",
+  "props": {
+    "className": "page-base-style"
+  },
+  "state": {
+    "userName": "张三",
+    "userAvatar": "https://www.example.com/avatar.jpg",
+    "userBio": "全栈开发工程师"
+  },
+  "methods": {
+    "handleClick": {
+      "type": "JSFunction",
+      "value": "function() { alert('按钮被点击了！'); }",
+      "params": []
+    }
+  },
+  "children": [
+    {
+      "componentName": "CanvasFlexBox",
+      "id": "profile-container",
+      "props": {
+        "flexDirection": "column",
+        "alignItems": "center",
+        "gap": "20px"
+      },
+      "children": [
+        {
+          "componentName": "img",
+          "id": "avatar",
+          "props": {
+            "src": {
+              "type": "JSExpression",
+              "value": "this.state.userAvatar"
+            },
+            "style": "width: 100px; height: 100px; border-radius: 50%;"
+          }
+        },
+        {
+          "componentName": "Text",
+          "id": "name",
+          "props": {
+            "text": {
+              "type": "JSExpression",
+              "value": "this.state.userName"
+            },
+            "style": "font-size: 24px; font-weight: bold;"
+          }
+        },
+        {
+          "componentName": "Text",
+          "id": "bio",
+          "props": {
+            "text": {
+              "type": "JSExpression",
+              "value": "this.state.userBio"
+            },
+            "style": "font-size: 16px; color: #666;"
+          }
+        },
+        {
+          "componentName": "TinyButton",
+          "id": "action-btn",
+          "props": {
+            "text": "点击我",
+            "onClick": {
+              "type": "JSExpression",
+              "value": "this.handleClick"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "id": "body"
+}
+```
+
+### 示例 3：带循环渲染的列表
+
+```json
+{
+  "componentName": "Page",
+  "fileName": "ProductList",
+  "state": {
+    "products": [
+      { "id": 1, "name": "产品A", "price": 100 },
+      { "id": 2, "name": "产品B", "price": 200 },
+      { "id": 3, "name": "产品C", "price": 300 }
+    ]
+  },
+  "children": [
+    {
+      "componentName": "CanvasFlexBox",
+      "id": "product-list",
+      "props": {
+        "flexDirection": "column",
+        "gap": "10px"
+      },
+      "children": [
+        {
+          "componentName": "div",
+          "id": "product-item",
+          "loop": {
+            "list": {
+              "type": "JSExpression",
+              "value": "this.state.products"
+            }
+          },
+          "loopArgs": ["item", "index"],
+          "props": {
+            "style": "padding: 10px; border: 1px solid #ddd; border-radius: 4px;"
+          },
+          "children": [
+            {
+              "componentName": "Text",
+              "id": "product-name",
+              "props": {
+                "text": {
+                  "type": "JSExpression",
+                  "value": "item.name"
+                },
+                "style": "font-size: 18px; font-weight: bold;"
+              }
+            },
+            {
+              "componentName": "Text",
+              "id": "product-price",
+              "props": {
+                "text": {
+                  "type": "JSExpression",
+                  "value": "'价格: ¥' + item.price"
+                },
+                "style": "font-size: 16px; color: #666;"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "methods": {},
+  "id": "body"
+}
+```
+
+## 类型定义
+
+### 完整 TypeScript 类型定义
+
+```typescript
+// JS 表达式
+export type JSExpression = { 
+  type: 'JSExpression'; 
+  value: string; 
+  model?: boolean 
+};
+
+// JS 函数
+export type JSFunction = { 
+  type: 'JSFunction'; 
+  value: string; 
+  params?: string[] 
+};
+
+// 插槽
+export type JSSlot = { 
+  type: 'JSSlot'; 
+  value: string | Record<string, any> 
+};
+
+// 方法集合
+export type Methods = Record<string, JSFunction>;
+
+// 属性值类型（递归）
+export type PropValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JSExpression
+  | JSFunction
+  | JSSlot
+  | PropValue[]
+  | Record<string, PropValue>;
+
+// 节点接口
+export interface Node {
+  id?: string;                    // 节点唯一标识（可选）
+  componentName: string;           // 组件名（必需）
+  props?: Record<string, any> & { 
+    columns?: { slots?: Record<string, any> }[] 
+  };                              // 组件属性集合
+  children?: Node[];              // 子节点数组
+  componentType?: 'Block' | 'PageStart' | 'PageSection'; // 节点类型
+  slot?: string | Record<string, any>; // 插槽内容
+  params?: string[];               // 参数名列表
+  loop?: Record<string, any>;      // 循环渲染配置
+  loopArgs?: string[];             // 循环参数名列表
+  condition?: boolean | Record<string, any>; // 条件渲染配置
+}
+
+// 根节点类型
+export type RootNode = Omit<Node, 'id'> & {
+  id?: string;                    // 根节点可选 id
+  css?: string;                   // 全局 CSS 样式字符串
+  fileName?: string;              // 文件名
+  methods?: Methods;               // 方法集合
+  state?: Record<string, unknown>; // 全局状态
+  schema?: any;                    // 内嵌或外部 Schema
+};
+```
+
+## 常用组件
+
+### 布局组件
+
+- **CanvasFlexBox**: 弹性布局容器
+  - `flexDirection`: 主轴方向（'row' | 'column'）
+  - `justifyContent`: 主轴对齐方式
+  - `alignItems`: 交叉轴对齐方式
+  - `wrap`: 是否换行
+  - `gap`: 间距
+
+- **div**: 通用容器
+  - `style`: 内联样式字符串
+  - `className`: CSS 类名
+
+### 基础组件
+
+- **Text**: 文本组件
+  - `text`: 文本内容
+  - `style`: 样式字符串
+
+- **img**: 图片组件
+  - `src`: 图片地址
+  - `alt`: 替代文本
+  - `style`: 样式字符串
+
+### 业务组件
+
+- **TinyTabs**: 标签页组件
+  - `modelValue`: 当前激活的标签
+  - `className`: CSS 类名
+
+- **TinyTabItem**: 标签页项
+  - `title`: 标签标题
+  - `name`: 标签名称
+
+- **TinyCarousel**: 轮播图组件
+  - `height`: 高度
+  - `autoplay`: 是否自动播放
+  - `interval`: 切换间隔（毫秒）
+
+- **TinyCarouselItem**: 轮播图项
+  - `title`: 项标题
+
+- **TinyButton**: 按钮组件
+  - `text`: 按钮文本
+  - `onClick`: 点击事件处理函数
+
+## 常见问题
+
+### Q: 如何实现组件间的数据传递？
+
+A: 通过 `state` 字段定义全局状态，子组件通过 JS 表达式使用 `this.state` 访问状态。
+
+### Q: 如何实现条件渲染？
+
+A: 使用节点的 `condition` 字段，可以是布尔值或 JS 表达式。
+
+### Q: 如何实现列表渲染？
+
+A: 使用节点的 `loop` 和 `loopArgs` 字段，`loop` 指定数据源，`loopArgs` 指定循环变量名。
+
+### Q: 如何实现双向绑定？
+
+A: 在 JSExpression 中设置 `model: true`，适用于表单组件。
+
+### Q: 如何定义组件的事件处理？
+
+A: 有两种方式：
+1. 在根节点的 `methods` 中定义方法，然后在组件属性中使用 `this.方法名` 引用（如 `this.handleClick`）
+2. 直接在组件属性中定义 JSFunction
+
+## 参考
+
+- [TinyEngine 协议规范](https://opentiny.design/tiny-engine#/protocol)

--- a/docs/src/schema/protocol.md
+++ b/docs/src/schema/protocol.md
@@ -124,6 +124,7 @@ interface JSExpression {
   type: 'JSExpression';          // 固定为 'JSExpression'
   value: string;                 // 表达式字符串
   model?: boolean;               // 是否为双向绑定模型值
+  params?: string[];                // 作用域插槽传递的参数
 }
 ```
 
@@ -156,7 +157,6 @@ interface JSExpression {
 interface JSFunction {
   type: 'JSFunction';            // 固定为 'JSFunction'
   value: string;                 // 函数体字符串（可序列化）
-  params?: string[];             // 函数参数名列表
 }
 ```
 
@@ -165,8 +165,7 @@ interface JSFunction {
 {
   "onClick": {
     "type": "JSFunction",
-    "value": "function() { alert('按钮被点击'); }",
-    "params": []
+    "value": "function() { alert('按钮被点击'); }"
   }
 }
 ```
@@ -419,16 +418,16 @@ interface JSSlot {
 ```json
 {
   "componentName": "Page",
+  "state": {
+    "formData": {
+      "name": "",
+      "email": ""
+    }
+  },
   "methods": {
-    "handleClick": {
-      "type": "JSFunction",
-      "value": "function() { alert('按钮被点击'); }",
-      "params": []
-    },
     "handleSubmit": {
       "type": "JSFunction",
-      "value": "function(data) { console.log('提交数据:', data); }",
-      "params": ["data"]
+      "value": "function($event) { console.log('触发的事件对象', $event); console.log('提交数据:', this.state.formData); }"
     }
   }
 }
@@ -462,8 +461,7 @@ interface JSSlot {
     "text": "提交",
     "onClick": {
       "type": "JSFunction",
-      "value": "function() { console.log('提交按钮被点击'); }",
-      "params": []
+      "value": "function() { console.log('提交按钮被点击'); }"
     }
   }
 }
@@ -534,8 +532,7 @@ interface JSSlot {
   "methods": {
     "handleClick": {
       "type": "JSFunction",
-      "value": "function() { alert('按钮被点击了！'); }",
-      "params": []
+      "value": "function() { alert('按钮被点击了！'); }"
     }
   },
   "children": [
@@ -676,14 +673,14 @@ interface JSSlot {
 export type JSExpression = { 
   type: 'JSExpression'; 
   value: string; 
-  model?: boolean 
+  model?: boolean;
+  params?: string[];
 };
 
 // JS 函数
 export type JSFunction = { 
   type: 'JSFunction'; 
   value: string; 
-  params?: string[] 
 };
 
 // 插槽


### PR DESCRIPTION
1. 增加server包api描述，包含 API 参考和 CLI
2.  增加 schema 协议规范说明

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "协议规范" navigation section for protocol documentation.
  * Introduced new "Server 库文档" group with API 参考 and CLI guides.
  * Documented server API surfaces with function signatures, behavior notes, and usage examples.
  * Added a comprehensive CLI guide covering installation, configuration, and commands.
  * Published detailed JSON-based schema protocol documentation for declarative UI rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->