### PR TITLE
fix: fix schemaJson end flag logic error

### DIFF
--- a/docs/src/guide/angular/start-with-renderer.md
+++ b/docs/src/guide/angular/start-with-renderer.md
@@ -53,6 +53,9 @@ export async function fetchSchemaStream(
   const isSchemaJsonEnd = (str: string): boolean => {
     const index = str.lastIndexOf('\n');
     if (index === -1) return false;
+    if (str.includes(`\n${endFlag}`)) {
+      return true;
+    }
     const newStr = str.slice(index).trim().substring(0, endFlag.length);
     return endFlag.startsWith(newStr);
   };

--- a/docs/src/guide/renderer-with-tiny-robot.md
+++ b/docs/src/guide/renderer-with-tiny-robot.md
@@ -49,6 +49,9 @@ function useSchemaStream() {
   const isSchemaJsonEnd = (str: string): boolean => {
     const index = str.lastIndexOf('\n');
     if (index === -1) return false;
+    if (str.includes(`\n${endFlag}`)) {
+      return true;
+    }
     const newStr = str.slice(index).trim().substring(0, endFlag.length);
     return endFlag.startsWith(newStr);
   };

--- a/docs/src/guide/start-with-renderer.md
+++ b/docs/src/guide/start-with-renderer.md
@@ -47,6 +47,9 @@ export async function fetchSchemaStream(
   const isSchemaJsonEnd = (str: string): boolean => {
     const index = str.lastIndexOf('\n');
     if (index === -1) return false;
+    if (str.includes(`\n${endFlag}`)) {
+      return true;
+    }
     const newStr = str.slice(index).trim().substring(0, endFlag.length);
     return endFlag.startsWith(newStr);
   };

--- a/packages/frameworks/angular/src/fetch-schema-stream.ts
+++ b/packages/frameworks/angular/src/fetch-schema-stream.ts
@@ -43,6 +43,9 @@ export async function fetchSchemaStream(
     const isSchemaJsonEnd = (str: string): boolean => {
       const index = str.lastIndexOf('\n');
       if (index === -1) return false;
+      if (str.includes(`\n${endFlag}`)) {
+        return true;
+      }
       const newStr = str.slice(index).trim().substring(0, endFlag.length);
       return endFlag.startsWith(newStr);
     };

--- a/packages/frameworks/vue/src/chat/useSchemaStream.ts
+++ b/packages/frameworks/vue/src/chat/useSchemaStream.ts
@@ -38,6 +38,9 @@ export default function useSchemaStream() {
     if (index === -1) {
       return false
     }
+    if (str.includes(`\n${endFlag}`)) {
+      return true;
+    }
     const newStr = str.slice(index).trim().substring(0, endFlag.length)
     return endFlag.startsWith(newStr)
   }


### PR DESCRIPTION
修复schemaJson结束标志判读逻辑错误。
在流式返回吞吐量较大的情况下。比如流式返回的chunk为 "\n```  # title \n"
此时结束标记已经完整，且出现了新的\n。导致原本逻辑判断错误，认为这个chunk不是结束标记。

修改方案：先判断一下是否包含完整的结束标志，如果是直接返回true