### PR TITLE
fix(homepage): optimize homepage first frame and links

### DIFF
--- a/sites/homepage/web/src/components/HomeGuide.vue
+++ b/sites/homepage/web/src/components/HomeGuide.vue
@@ -7,7 +7,7 @@ import genuiChatIcon from '@/assets/genui_chat_icon.svg';
 import genuiInusecon from '@/assets/genui_inuse_icon.svg';
 import gneuiSettingsIcon from '@/assets/genui_settings_icon.svg';
 import { guideCodeMap } from '@/config';
-import { LinkKey, openLink } from '@/utils/link';
+import { LinkKey, linkMap } from '@/utils/link';
 import HomeGuideCard from './HomeGuideCard.vue';
 import HomeGuideMobile from './HomeGuideMobile.vue';
 
@@ -82,12 +82,12 @@ const handleGuideCardClick = (index: number) => {
           :active="activeCard === 2"
           @click="handleGuideCardClick(2)"
         />
-        <tiny-button
-          class="home-guide-content-left-button"
-          round
-          @click="openLink(LinkKey.ChatDoc)"
-          >开发文档</tiny-button
-        >
+        <a :href="linkMap[LinkKey.ChatDoc]" target="_blank" class="btn-link">
+          <tiny-button
+            class="home-guide-content-left-button"
+            round
+            >开发文档</tiny-button>
+        </a>
       </div>
       <div class="home-guide-content-right">
         <div class="home-guide-content-right-framework">

--- a/sites/homepage/web/src/components/HomeLink.vue
+++ b/sites/homepage/web/src/components/HomeLink.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { LinkKey, openLink } from '@/utils/link';
+  import { LinkKey, linkMap } from '@/utils/link';
   import { TinyButton } from '@opentiny/vue';
   </script>
   
@@ -11,14 +11,25 @@
           增强大模型对话显示与交互，打造极致顺滑的智能体验
         </div>
         <div class="home-link-button-group">
-          <tiny-button type="primary" size="medium" round @click="openLink(LinkKey.Playground)">立即体验</tiny-button>
-          <tiny-button size="medium" round @click="openLink(LinkKey.DevDoc)">产品文档</tiny-button>
+          <a :href="linkMap[LinkKey.Playground]" target="_blank" class="btn-link">
+            <tiny-button type="primary" size="medium" round>立即体验</tiny-button>
+          </a>
+          <a :href="linkMap[LinkKey.DevDoc]" target="_blank" class="btn-link">
+            <tiny-button size="medium" round>产品文档</tiny-button>
+          </a>
         </div>
       </div>
     </section>
   </template>
   
   <style lang="less" scoped>
+  
+  .btn-link {
+    + .btn-link {
+      margin-left: 16px;
+    }
+  }
+
   .home-link {
     width: 100%;
     display: flex;

--- a/sites/homepage/web/src/utils/link.ts
+++ b/sites/homepage/web/src/utils/link.ts
@@ -9,7 +9,7 @@ export const linkMap = {
   defineTheme: `${DOC_DOMAIN}/genui-sdk/examples/config-provider/theme`,
   defineComponent: `${DOC_DOMAIN}/genui-sdk/examples/chat/custom-components`,
   defineAction: `${DOC_DOMAIN}/genui-sdk/examples/chat/custom-actions`,
-  multiTechnology: `${DOC_DOMAIN}/genui-sdk/components/angular-renderer`,
+  multiTechnology: `${DOC_DOMAIN}/genui-sdk/components/angular/renderer`,
   moreFeatures: `${DOC_DOMAIN}/genui-sdk/examples/chat/custom-examples`,
 };
 

--- a/sites/homepage/web/src/views/home.vue
+++ b/sites/homepage/web/src/views/home.vue
@@ -6,7 +6,7 @@ import genuiAbility2 from "@/assets/genui_ability_2.png";
 import genuiAbility3 from "@/assets/genui_ability_3.svg";
 import genuiActionVedioCover from '@/assets/genui_action_vedio_cover.webp';
 import genuiFlowVedioCover from '@/assets/genui_flow_vedio_cover.svg';
-import { LinkKey, openLink } from "@/utils/link";
+import { LinkKey, linkMap } from "@/utils/link";
 import HomeAbility from "@/components/HomeAbility.vue";
 import HomeGuide from "@/components/HomeGuide.vue";
 import HomeFeature from "@/components/HomeFeature.vue";
@@ -59,12 +59,12 @@ const flowVideoSource = 'https://tinyengine-assets.obs.cn-north-4.myhuaweicloud.
           为用户打造极致顺滑的智能体验，给开发者提供强大的定制能力与生态兼容性
         </div>
         <div class="operation-button-group">
-          <tiny-button round type="primary" size="medium" @click="openLink(LinkKey.DevDoc)"
-            >开发文档</tiny-button
-          >
-          <tiny-button round size="medium" @click="openLink(LinkKey.Playground)"
-            >演练场</tiny-button
-          >
+          <a :href="linkMap[LinkKey.DevDoc]" target="_blank" class="btn-link">
+            <tiny-button round type="primary" size="medium">开发文档</tiny-button>
+          </a>
+          <a :href="linkMap[LinkKey.Playground]" target="_blank" class="btn-link">
+            <tiny-button round size="medium">演练场</tiny-button>
+          </a>
         </div>
       </div>
       <div class="home-core-right">
@@ -180,6 +180,12 @@ const flowVideoSource = 'https://tinyengine-assets.obs.cn-north-4.myhuaweicloud.
   background-color: var(--bg-color);
   overflow-x: hidden;
 
+  .btn-link {
+    + .btn-link {
+      margin-left: 16px;
+    }
+  }
+
   .home-core {
     display: flex;
     align-items: center;
@@ -190,6 +196,12 @@ const flowVideoSource = 'https://tinyengine-assets.obs.cn-north-4.myhuaweicloud.
     background-position: center;
     background-repeat: no-repeat;
     padding: 10% 12.5%;
+
+    // 开启gpu加速，优化首屏滚动卡顿
+    will-change: transform;
+    transform: translateZ(0);
+    backface-visibility: hidden;
+    perspective: 1000;
 
     &-left {
       display: flex;


### PR DESCRIPTION
1、优化宣传页首屏滚动卡顿问题
2、按钮包裹a标签。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected an external documentation URL path.

* **User Experience**
  * Buttons linking to docs and the playground now open the target pages in new browser tabs.

* **Styling**
  * Improved spacing for adjacent action buttons.

* **Performance Improvements**
  * Applied GPU-acceleration styling to enhance initial page rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->