### PR TITLE
fix: update tool_calls condition and add css requiredCompleteFieldSelectors

### DIFF
--- a/packages/frameworks/vue/src/chat/CustomModelProvider.ts
+++ b/packages/frameworks/vue/src/chat/CustomModelProvider.ts
@@ -253,7 +253,7 @@ export class CustomModelProvider extends BaseModelProvider {
           }
           onReasoningEnd();
 
-          if (tool_calls) {
+          if (tool_calls?.length) {
             onToolCall(tool_calls, delta);
             patternExtractor.reset();
           } else if (tool_calls_result) {

--- a/packages/frameworks/vue/src/renderer/config.ts
+++ b/packages/frameworks/vue/src/renderer/config.ts
@@ -2,6 +2,7 @@ export const requiredCompleteFieldSelectors = [
   '[componentName=Img] > props > src',
   'componentName',
   'style',
+  'css',
   '[type=JSFunction]',
   '[type=JSExpression]',
   '[type=JSSlot][value=]',

--- a/packages/frameworks/vue/src/renderer/config.ts
+++ b/packages/frameworks/vue/src/renderer/config.ts
@@ -2,7 +2,7 @@ export const requiredCompleteFieldSelectors = [
   '[componentName=Img] > props > src',
   'componentName',
   'style',
-  'css',
+  '[componentName=Page] > css',
   '[type=JSFunction]',
   '[type=JSExpression]',
   '[type=JSSlot][value=]',


### PR DESCRIPTION
1、修改tool_calls处理的判断条件，解决当tool_calls和content字段同时出现时无法正常渲染的问题
2、requiredCompleteFieldSelectors添加条件，使返回的css需完成后才渲染

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved safety of chat tool-call handling to prevent errors from missing or empty tool call data.
* **New Features**
  * Renderer validation now requires a Page CSS field to ensure page styling is present during rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->