### PR TITLE
feat(render-config): add TinyRadioGroup component with configuration options and properties

### DIFF
--- a/packages/frameworks/vue/src/renderer/config.ts
+++ b/packages/frameworks/vue/src/renderer/config.ts
@@ -13,6 +13,7 @@ export const requiredCompleteFieldSelectors = [
   '[componentName=TinyNumeric] > props > modelValue',
   '[componentName^=TinyChart] > props > *',
   '[componentName=TinyForm] > props > labelPosition',
+  '[componentName=TinyRadioGroup] > props > options > *',
   // ng element version
   '[componentName=img] > props > src',
   '[componentName] > props > ngModel',

--- a/packages/materials/vue-opentiny-vue/src/render-config/bundle.json
+++ b/packages/materials/vue-opentiny-vue/src/render-config/bundle.json
@@ -6673,7 +6673,7 @@
                       }
                     },
                     "description": {
-                      "zh_CN": "输入框尺寸。该属性的可选值为 medium / small / mini"
+                      "zh_CN": "输入框尺寸。该属性的可选值为： medium 、small 、 mini"
                     },
                     "labelPosition": "left"
                   }
@@ -7622,7 +7622,7 @@
                       "props": {}
                     },
                     "description": {
-                      "zh_CN": "设置打开时的值(Boolean / String / Number)"
+                      "zh_CN": "设置打开时的值，可能的类型为：Boolean 、 String 、 Number"
                     },
                     "labelPosition": "left"
                   },
@@ -7642,7 +7642,7 @@
                       "props": {}
                     },
                     "description": {
-                      "zh_CN": "设置关闭时的值(Boolean / String / Number)"
+                      "zh_CN": "设置关闭时的值，可能的类型为：Boolean 、 String 、 Number"
                     },
                     "labelPosition": "left"
                   },
@@ -10010,7 +10010,7 @@
                               }
                             },
                             "description": {
-                              "zh_CN": "设置内置列的类型，该属性的可选值为 index（序号）/ selection（复选框）/ radio（单选框）/ expand（展开行）"
+                              "zh_CN": "设置内置列的类型，该属性的可选值为 index（序号）、 selection（复选框）、 radio（单选框）、 expand（展开行）"
                             },
                             "labelPosition": "left"
                           },
@@ -10088,7 +10088,7 @@
                               }
                             },
                             "description": {
-                              "zh_CN": "设置内置列的内容超出部分显示省略号配置，该属性的可选值为 ellipsis（只显示省略号）/ title（显示为原生 title）/ tooltip（显示为 tooltip 提示）"
+                              "zh_CN": "设置内置列的内容超出部分显示省略号配置，该属性的可选值为： ellipsis(只显示省略号） 、 title(显示为原生 title) 、 tooltip(显示为 tooltip 提示）"
                             },
                             "labelPosition": "top"
                           }
@@ -12220,7 +12220,7 @@
                       }
                     },
                     "description": {
-                      "zh_CN": "触发方式，该属性的可选值为 click / focus / hover / manual，该属性的默认值为 click"
+                      "zh_CN": "触发方式，该属性的可选值为： click 、 focus 、 hover 、 manual，该属性的默认值为 click"
                     },
                     "labelPosition": "left"
                   },
@@ -12757,7 +12757,7 @@
                       }
                     },
                     "description": {
-                      "zh_CN": "日期框尺寸。该属性的可选值为 medium / small / mini"
+                      "zh_CN": "日期框尺寸。该属性的可选值为： medium 、 small 、 mini"
                     },
                     "labelPosition": "left"
                   }
@@ -13110,7 +13110,7 @@
                       }
                     },
                     "description": {
-                      "zh_CN": "输入框尺寸。该属性的可选值为 medium / small / mini"
+                      "zh_CN": "输入框尺寸。该属性的可选值为： medium 、small 、 mini"
                     },
                     "labelPosition": "left"
                   },

--- a/packages/materials/vue-opentiny-vue/src/render-config/bundle.json
+++ b/packages/materials/vue-opentiny-vue/src/render-config/bundle.json
@@ -7622,7 +7622,7 @@
                       "props": {}
                     },
                     "description": {
-                      "zh_CN": "设置打开时的值，可能的类型为：Boolean 、 String 、 Number"
+                      "zh_CN": "设置打开时的值，类型为：Boolean | String | Number"
                     },
                     "labelPosition": "left"
                   },
@@ -7642,7 +7642,7 @@
                       "props": {}
                     },
                     "description": {
-                      "zh_CN": "设置关闭时的值，可能的类型为：Boolean 、 String 、 Number"
+                      "zh_CN": "设置关闭时的值，类型为：Boolean | String | Number"
                     },
                     "labelPosition": "left"
                   },

--- a/packages/materials/vue-opentiny-vue/src/render-config/extend.json
+++ b/packages/materials/vue-opentiny-vue/src/render-config/extend.json
@@ -422,6 +422,217 @@
               }
             }
           }
+        },
+        {
+          "name": {
+            "zh_CN": "单选按钮组"
+          },
+          "component": "TinyRadioGroup",
+          "icon": "radio-group",
+          "description": "用于在一组选项中进行单选。",
+          "doc_url": "https://www.opentiny.design/tiny-vue/components/radio",
+          "screenshot": "",
+          "tags": "",
+          "keywords": "",
+          "dev_mode": "proCode",
+          "npm": {
+          },
+          "group": "component",
+          "configure": {
+          },
+          "schema": {
+            "properties": [
+              {
+                "label": {
+                  "zh_CN": "基础属性"
+                },
+                "description": {
+                  "zh_CN": "基础属性"
+                },
+                "content": [
+                  {
+                    "property": "modelValue",
+                    "label": {
+                      "text": {
+                        "zh_CN": "绑定值"
+                      }
+                    },
+                    "required": true,
+                    "readOnly": false,
+                    "disabled": false,
+                    "description": {
+                      "zh_CN": "单选框组的绑定值"
+                    }
+                  },
+                  {
+                    "property": "options",
+                    "label": {
+                      "text": {
+                        "zh_CN": "选项列表"
+                      }
+                    },
+                    "defaultValue": [
+                      {
+                        "label": "选项1"
+                      },
+                      {
+                        "label": "选项2"
+                      }
+                    ],
+                    "required": true,
+                    "readOnly": false,
+                    "disabled": false,
+                    "description": {
+                      "zh_CN": "单选按钮选项列表，支持 IRadioGroupOptions[]"
+                    }
+                  },
+                  {
+                    "property": "disabled",
+                    "label": {
+                      "text": {
+                        "zh_CN": "禁用"
+                      }
+                    },
+                    "required": false,
+                    "readOnly": false,
+                    "disabled": false,
+                    "description": {
+                      "zh_CN": "是否禁用整个单选组"
+                    }
+                  },
+                  {
+                    "property": "type",
+                    "label": {
+                      "text": {
+                        "zh_CN": "展示形式"
+                      }
+                    },
+                    "required": false,
+                    "readOnly": false,
+                    "disabled": false,
+                    "widget": {
+                      "component": "ButtonGroupConfigurator",
+                      "props": {
+                        "options": [
+                          {
+                            "label": "radio",
+                            "value": "radio"
+                          },
+                          {
+                            "label": "button",
+                            "value": "button"
+                          }
+                        ]
+                      }
+                    },
+                    "description": {
+                      "zh_CN": "单选组的展示形式（单选框 / 按钮）"
+                    },
+                    "labelPosition": "left"
+                  },
+                  {
+                    "property": "size",
+                    "label": {
+                      "text": {
+                        "zh_CN": "尺寸"
+                      }
+                    },
+                    "required": false,
+                    "readOnly": false,
+                    "disabled": false,
+                    "cols": 12,
+                    "widget": {
+                      "component": "SelectConfigurator",
+                      "props": {
+                        "options": [
+                          {
+                            "label": "medium",
+                            "value": "medium"
+                          },
+                          {
+                            "label": "small",
+                            "value": "small"
+                          },
+                          {
+                            "label": "mini",
+                            "value": "mini"
+                          }
+                        ]
+                      }
+                    },
+                    "description": {
+                      "zh_CN": "单选组尺寸"
+                    },
+                    "labelPosition": "left"
+                  },
+                  {
+                    "property": "vertical",
+                    "label": {
+                      "text": {
+                        "zh_CN": "垂直排列"
+                      }
+                    },
+                    "required": false,
+                    "readOnly": false,
+                    "disabled": false,
+                    "description": {
+                      "zh_CN": "是否垂直展示单选按钮"
+                    }
+                  }
+                ]
+              }
+            ],
+            "events": {
+              "onChange": {
+                "label": {
+                  "zh_CN": "选中值变化时触发"
+                },
+                "description": {
+                  "zh_CN": "选中值变化时触发"
+                },
+                "type": "event",
+                "functionInfo": {
+                  "params": [
+                    {
+                      "name": "value",
+                      "type": "string",
+                      "defaultValue": "",
+                      "description": {
+                        "zh_CN": "当前选中的值"
+                      }
+                    }
+                  ],
+                  "returns": {
+                  }
+                },
+                "defaultValue": ""
+              },
+              "onUpdate:modelValue": {
+                "label": {
+                  "zh_CN": "绑定值更新时触发"
+                },
+                "description": {
+                  "zh_CN": "v-model 对应的值更新时触发"
+                },
+                "type": "event",
+                "functionInfo": {
+                  "params": [
+                    {
+                      "name": "value",
+                      "type": "string",
+                      "defaultValue": "",
+                      "description": {
+                        "zh_CN": "更新后的绑定值"
+                      }
+                    }
+                  ],
+                  "returns": {
+                  }
+                },
+                "defaultValue": ""
+              }
+            }
+          }
         }
       ],
       "snippets": [

--- a/packages/materials/vue-opentiny-vue/src/render-config/extend.json
+++ b/packages/materials/vue-opentiny-vue/src/render-config/extend.json
@@ -471,19 +471,12 @@
                         "zh_CN": "选项列表"
                       }
                     },
-                    "defaultValue": [
-                      {
-                        "label": "选项1"
-                      },
-                      {
-                        "label": "选项2"
-                      }
-                    ],
+                    "defaultValue": [],
                     "required": true,
                     "readOnly": false,
                     "disabled": false,
                     "description": {
-                      "zh_CN": "单选按钮选项列表，支持 IRadioGroupOptions[]"
+                      "zh_CN": "单选按钮选项列表，配置单选组的值、文本和点击事件。示例：[{label: '1', text: '选项1', events: {click: () => {console.log('点击选项1')}}}]"
                     }
                   },
                   {
@@ -526,9 +519,8 @@
                       }
                     },
                     "description": {
-                      "zh_CN": "单选组的展示形式（单选框 / 按钮）, 对应的可选值分别是 radio / button"
-                    },
-                    "labelPosition": "left"
+                      "zh_CN": "单选组的展示形式,可选值为：radio(单选框) / button(按钮、选项式)"
+                    }
                   },
                   {
                     "property": "size",
@@ -736,7 +728,7 @@
           "children": [
             {
               "name": {
-                "zh_CN": "有序列表"
+                "zh_CN": "无序列表"
               },
               "snippetName": "ul",
               "schema": {
@@ -770,6 +762,67 @@
                     "children": "有序列表项2"
                   }
                 ]
+              }
+            }
+          ]
+        },
+        {
+          "group": "RadioGroup",
+          "label": {
+            "zh_CN": "单选按钮组"
+          },
+          "children": [
+            {
+              "name": {
+                "zh_CN": "基础单选组"
+              },
+              "snippetName": "TinyRadioGroup",
+              "schema": {
+                "componentName": "TinyRadioGroup",
+                "props": {
+                  "modelValue": "1",
+                  "options": [
+                    {
+                      "label": "1",
+                      "text": "选项1"
+                    },
+                    {
+                      "label": "2",
+                      "text": "选项2"
+                    },
+                    {
+                      "label": "3",
+                      "text": "选项3"
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "name": {
+                "zh_CN": "选项式单选组"
+              },
+              "snippetName": "TinyRadioGroup",
+              "schema": {
+                "componentName": "TinyRadioGroup",
+                "props": {
+                  "modelValue": "2",
+                  "type": "button",
+                  "options": [
+                    {
+                      "label": "1",
+                      "text": "选项1"
+                    },
+                    {
+                      "label": "2",
+                      "text": "选项2"
+                    },
+                    {
+                      "label": "3",
+                      "text": "选项3"
+                    }
+                  ]
+                }
               }
             }
           ]

--- a/packages/materials/vue-opentiny-vue/src/render-config/extend.json
+++ b/packages/materials/vue-opentiny-vue/src/render-config/extend.json
@@ -519,7 +519,7 @@
                       }
                     },
                     "description": {
-                      "zh_CN": "单选组的展示形式,可选值为：radio(单选框) / button(按钮、选项式)"
+                      "zh_CN": "单选组的展示形式,可选值为：radio(单选框) 、 button(按钮、选项式)"
                     }
                   },
                   {
@@ -553,7 +553,7 @@
                       }
                     },
                     "description": {
-                      "zh_CN": "单选组尺寸, 可选值有 medium / small / mini"
+                      "zh_CN": "单选组尺寸, 可选值有 medium 、 small 、 mini"
                     }
                   },
                   {

--- a/packages/materials/vue-opentiny-vue/src/render-config/extend.json
+++ b/packages/materials/vue-opentiny-vue/src/render-config/extend.json
@@ -526,7 +526,7 @@
                       }
                     },
                     "description": {
-                      "zh_CN": "单选组的展示形式（单选框 / 按钮）"
+                      "zh_CN": "单选组的展示形式（单选框 / 按钮）, 对应的可选值分别是 radio / button"
                     },
                     "labelPosition": "left"
                   },
@@ -561,9 +561,8 @@
                       }
                     },
                     "description": {
-                      "zh_CN": "单选组尺寸"
-                    },
-                    "labelPosition": "left"
+                      "zh_CN": "单选组尺寸, 可选值有 medium / small / mini"
+                    }
                   },
                   {
                     "property": "vertical",

--- a/packages/materials/vue-opentiny-vue/src/render-config/white-list.ts
+++ b/packages/materials/vue-opentiny-vue/src/render-config/white-list.ts
@@ -36,6 +36,7 @@ export const whiteList = [
   'TinyButton',
   'TinyInput',
   'TinyRadio',
+  'TinyRadioGroup',
   'TinySelect',
   'TinySwitch',
   'TinySearch',


### PR DESCRIPTION
新增TinyRadioGroup的物料描述

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "单选按钮组" (TinyRadioGroup) component with configurable options, size, type (button/standard), vertical/horizontal layout, and emits change and model-update events.

* **Documentation / Examples**
  * Added demo examples and catalog entries showcasing basic and option-style radio group usages.

* **Chores**
  * Updated Chinese localization wording and added TinyRadioGroup to the public component whitelist; extended completeness checks for its options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->