### PR TITLE
feat: add thinkTagWrap handle logic to show reasoning renderer

### DIFF
--- a/packages/core/src/stream-pattern-extractor/common.ts
+++ b/packages/core/src/stream-pattern-extractor/common.ts
@@ -1,0 +1,5 @@
+export function getPartialStartRegString(flag: string) {
+    return flag.split('').reverse().reduce((acc, cur) => {
+      return `${cur}(${acc})?`;
+    }, '');
+  }

--- a/packages/core/src/stream-pattern-extractor/common.ts
+++ b/packages/core/src/stream-pattern-extractor/common.ts
@@ -3,3 +3,4 @@ export function getPartialStartRegString(flag: string) {
       return `${cur}(${acc})?`;
     }, '');
   }
+  

--- a/packages/core/src/stream-pattern-extractor/common.ts
+++ b/packages/core/src/stream-pattern-extractor/common.ts
@@ -1,6 +1,8 @@
 export function getPartialStartRegString(flag: string) {
-    return flag.split('').reverse().reduce((acc, cur) => {
+  return flag
+    .split('')
+    .reverse()
+    .reduce((acc, cur) => {
       return `${cur}(${acc})?`;
     }, '');
-  }
-  
+}

--- a/packages/core/src/stream-pattern-extractor/index.ts
+++ b/packages/core/src/stream-pattern-extractor/index.ts
@@ -2,3 +2,4 @@ export * from './pattern-extractor';
 export * from './schema-json-pattern';
 export * from './stream-pattern-extractor';
 export * from './think-tag-wrap-pattern';
+export * from './common';

--- a/packages/core/src/stream-pattern-extractor/index.ts
+++ b/packages/core/src/stream-pattern-extractor/index.ts
@@ -1,3 +1,4 @@
 export * from './pattern-extractor';
 export * from './schema-json-pattern';
 export * from './stream-pattern-extractor';
+export * from './think-tag-wrap-pattern';

--- a/packages/core/src/stream-pattern-extractor/schema-json-pattern.ts
+++ b/packages/core/src/stream-pattern-extractor/schema-json-pattern.ts
@@ -1,9 +1,4 @@
-export function getPartialStartRegString(flag: string) {
-  return flag.split('').reverse().reduce((acc, cur) => {
-    return `${cur}(${acc})?`;
-  }, '');
-}
-
+import { getPartialStartRegString } from "./common";
 export class SchemaJsonPattern {
   protected startFlag: string = '```schemaJson';
   protected startRegex: RegExp = new RegExp(`${this.startFlag}`);

--- a/packages/core/src/stream-pattern-extractor/think-tag-wrap-pattern.ts
+++ b/packages/core/src/stream-pattern-extractor/think-tag-wrap-pattern.ts
@@ -1,0 +1,19 @@
+export class ThinkTagWrapPattern {
+  protected thinkStartFlag: string = '<think>';
+  protected thinkEndFlag: string = '</think>';
+  protected startRegex: RegExp = new RegExp(`${this.thinkStartFlag}`);
+  protected endRegex: RegExp = new RegExp(`${this.thinkEndFlag}`);
+
+  get regExpMap() {
+    return {
+      start: {
+        full: this.startRegex,
+        partial: this.startRegex,
+      },
+      end: {
+        full: this.endRegex,
+        partial: this.endRegex,
+      },
+    }
+  }
+}

--- a/packages/core/src/stream-pattern-extractor/think-tag-wrap-pattern.ts
+++ b/packages/core/src/stream-pattern-extractor/think-tag-wrap-pattern.ts
@@ -1,18 +1,21 @@
+import { getPartialStartRegString } from "./common";
 export class ThinkTagWrapPattern {
   protected thinkStartFlag: string = '<think>';
   protected thinkEndFlag: string = '</think>';
   protected startRegex: RegExp = new RegExp(`${this.thinkStartFlag}`);
   protected endRegex: RegExp = new RegExp(`${this.thinkEndFlag}`);
+  protected partialStartRegex: RegExp = new RegExp(`${getPartialStartRegString(this.thinkStartFlag)}$`);
+  protected partialEndRegex: RegExp = new RegExp(`${getPartialStartRegString(this.thinkEndFlag)}$`);
 
   get regExpMap() {
     return {
       start: {
         full: this.startRegex,
-        partial: this.startRegex,
+        partial: this.partialStartRegex,
       },
       end: {
         full: this.endRegex,
-        partial: this.endRegex,
+        partial: this.partialEndRegex,
       },
     }
   }

--- a/packages/frameworks/vue/src/chat/renderer/ReasoningRenderer.vue
+++ b/packages/frameworks/vue/src/chat/renderer/ReasoningRenderer.vue
@@ -1,19 +1,28 @@
 <script setup lang="ts">
-import { IconArrowDown } from '@opentiny/tiny-robot-svgs'
-import { ref } from 'vue'
-import { useI18n } from '../i18n'
+import { IconArrowDown } from '@opentiny/tiny-robot-svgs';
+import { BubbleMarkdownContentRenderer } from '@opentiny/tiny-robot';
+import { ref } from 'vue';
+import { useI18n } from '../i18n';
 
 const props = defineProps<{
-     content: string
-     thinking?: boolean
-  }>()
+  content: string;
+  thinking?: boolean;
+}>();
 
-const open = ref(false)
-const { t } = useI18n()
+const open = ref(false);
+const { t } = useI18n();
 
 const handleClick = () => {
-  open.value = !open.value
-}
+  open.value = !open.value;
+};
+
+const markdownRenderer = new BubbleMarkdownContentRenderer({
+  defaultAttrs: { class: 'markdown-content' },
+  mdConfig: { html: true },
+});
+
+const MarkdownContent = (markdownProps: { content: string }) =>
+  markdownRenderer.render({ content: markdownProps.content });
 </script>
 
 <template>
@@ -51,7 +60,7 @@ const handleClick = () => {
         </div>
         <div class="border-line"></div>
       </div>
-      <p class="detail-content" ref="detailRef">{{ props.content }}</p>
+      <MarkdownContent :content="props.content" class="detail-content" />
     </div>
   </div>
 </template>
@@ -105,22 +114,17 @@ const handleClick = () => {
 .detail {
   color: #595959;
   margin-block: 8px;
-  white-space: pre-line;
   display: flex;
   gap: 8px;
   align-items: center;
+  font-size: 14px;
 
-  p.detail-content {
-    font-size: 14px;
-    line-height: 16px;
-    margin: 0;
-    white-space: pre-wrap;
-    word-break: break-word;
-    max-height: var(--tr-bubble-reasoning-max-height, 300px);
-    overflow-y: auto;
-
-    & + p.detail-content {
-      margin-top: 1em;
+  .detail-content {
+    *:first-child {
+      margin-top: 0;
+    }
+    *:last-child {
+      margin-bottom: 0;
     }
   }
 

--- a/packages/frameworks/vue/src/chat/renderer/ReasoningRenderer.vue
+++ b/packages/frameworks/vue/src/chat/renderer/ReasoningRenderer.vue
@@ -120,10 +120,10 @@ const MarkdownContent = (markdownProps: { content: string }) =>
   font-size: 14px;
 
   .detail-content {
-    *:first-child {
+    > *:first-child {
       margin-top: 0;
     }
-    *:last-child {
+    > *:last-child {
       margin-bottom: 0;
     }
   }

--- a/packages/frameworks/vue/src/chat/response-handler.ts
+++ b/packages/frameworks/vue/src/chat/response-handler.ts
@@ -1,5 +1,5 @@
-import { IChatMessage, IMessageItem, IStreamDelta, PatternExtractor } from "@opentiny/genui-sdk-core";
-import { reactive, toRaw } from "vue";
+import { IChatMessage, IMessageItem, IStreamDelta, PatternExtractor, ThinkTagWrapPattern } from "@opentiny/genui-sdk-core";
+import { reactive, toRaw, watch } from "vue";
 import { v4 as uuidv4 } from 'uuid';
 import { emitter } from './event-emitter';
 import { useI18n } from './i18n';
@@ -95,9 +95,8 @@ function onReasoningContent(reasoningContent: string, chatMessage: IChatMessage)
   }
 };
 
-function onReasoningEnd(chatMessage: IChatMessage) {
-  const lastMessage = chatMessage.messages[chatMessage.messages.length - 1];
-  if (lastMessage?.type === 'reasoning') lastMessage.thinking = false;
+function onReasoningEnd(reasoningMessage: IMessageItem) {
+  if (reasoningMessage?.type === 'reasoning') reasoningMessage.thinking = false;
 };
 
 function emitNotification(delta: IStreamDelta, chatMessage: IChatMessage) {
@@ -171,9 +170,28 @@ export const defaultResponseHandlers: IResponseHandler<IStreamDelta>[] = [
       emitNotification(data, context.chatMessage);
       return true;
     },
-    notMatchHandler: (data: IStreamDelta, context: any) => {
-      onReasoningEnd(context.chatMessage);
-      return false;
+    start: (context: any, handlers: { onData: (data: IChatMessage) => void, onDone: () => void, onError: (error: Error) => void }) => {
+      context.handleReasoning = false;
+      context.unWatchReasoning = watch(context.chatMessage.messages, (newVal) => {
+        if (newVal.length === 0) {
+          return;
+        }
+        if (context.handleReasoning && newVal[newVal.length - 1]?.type !== 'reasoning') {
+          context.handleReasoning = false;
+          const reasoningMessage = context.chatMessage.messages[context.chatMessage.messages.length - 2];
+          onReasoningEnd(reasoningMessage);
+        } else if (!context.handleReasoning && newVal[newVal.length - 1]?.type === 'reasoning') {
+          context.handleReasoning = true;
+        }
+      });
+    },
+    end: (context: any) => {
+      context.unWatchReasoning?.();
+      if (context.handleReasoning) {
+        context.handleReasoning = false;
+        const reasoningMessage = context.chatMessage.messages[context.chatMessage.messages.length - 1];
+        onReasoningEnd(reasoningMessage);
+      }
     },
   },
   {
@@ -212,8 +230,14 @@ export const defaultResponseHandlers: IResponseHandler<IStreamDelta>[] = [
       return true;
     },
     start: (context: any, handlers: { onData: (data: IChatMessage) => void, onDone: () => void, onError: (error: Error) => void }) => {
-      context.patternExtractor = new PatternExtractor({
+      const thinkTagWrapPattern = new ThinkTagWrapPattern();
+      const thinkPatternExtractor = new PatternExtractor({
         onNormalWrite: (value) => onMarkdown(value, context.delta, context.chatMessage),
+        onHandledWrite: (value) => onReasoningContent(value, context.chatMessage),
+        regExpMap: thinkTagWrapPattern.regExpMap,
+      });
+      context.patternExtractor = new PatternExtractor({
+        onNormalWrite: (value) => thinkPatternExtractor.handleContent(value),
         onHandledWrite: (value) => onSchemaJSON(value, context.delta, context.chatMessage),
       });
     },

--- a/packages/frameworks/vue/src/chat/response-handler.ts
+++ b/packages/frameworks/vue/src/chat/response-handler.ts
@@ -82,7 +82,7 @@ function onToolCall(toolCalls: any[], delta: IStreamDelta, toolCallIdMap: Record
 
 };
 
-function onReasoningContent(reasoningContent: string, chatMessage: IChatMessage) {
+function onReasoningContent(reasoningContent: string, delta: IStreamDelta, chatMessage: IChatMessage) {
   const lastMessage = chatMessage.messages[chatMessage.messages.length - 1];
   if (lastMessage?.type === 'reasoning') {
     lastMessage.content += reasoningContent;
@@ -93,6 +93,7 @@ function onReasoningContent(reasoningContent: string, chatMessage: IChatMessage)
       thinking: true,
     });
   }
+  emitNotification(delta, chatMessage);
 };
 
 function onReasoningEnd(reasoningMessage: IMessageItem) {
@@ -166,8 +167,7 @@ export const defaultResponseHandlers: IResponseHandler<IStreamDelta>[] = [
       return data.reasoning_content !== undefined;
     },
     handler: (data: IStreamDelta, context: any) => {
-      onReasoningContent(data.reasoning_content, context.chatMessage);
-      emitNotification(data, context.chatMessage);
+      onReasoningContent(data.reasoning_content, data, context.chatMessage);
       return true;
     },
     start: (context: any, handlers: { onData: (data: IChatMessage) => void, onDone: () => void, onError: (error: Error) => void }) => {
@@ -233,7 +233,7 @@ export const defaultResponseHandlers: IResponseHandler<IStreamDelta>[] = [
       const thinkTagWrapPattern = new ThinkTagWrapPattern();
       const thinkPatternExtractor = new PatternExtractor({
         onNormalWrite: (value) => onMarkdown(value, context.delta, context.chatMessage),
-        onHandledWrite: (value) => onReasoningContent(value, context.chatMessage),
+        onHandledWrite: (value) => onReasoningContent(value, context.delta, context.chatMessage),
         regExpMap: thinkTagWrapPattern.regExpMap,
       });
       context.patternExtractor = new PatternExtractor({

--- a/packages/frameworks/vue/src/chat/response-handler.ts
+++ b/packages/frameworks/vue/src/chat/response-handler.ts
@@ -195,7 +195,7 @@ export const defaultResponseHandlers: IResponseHandler<IStreamData>[] = [
         }
         if (context.handleReasoning && newVal[newVal.length - 1]?.type !== 'reasoning') {
           context.handleReasoning = false;
-          const reasoningMessage = context.chatMessage.messages[context.chatMessage.messages.length - 2];
+          const reasoningMessage = newVal[newVal.length - 2];
           onReasoningEnd(reasoningMessage);
         } else if (!context.handleReasoning && newVal[newVal.length - 1]?.type === 'reasoning') {
           context.handleReasoning = true;
@@ -253,11 +253,10 @@ export const defaultResponseHandlers: IResponseHandler<IStreamData>[] = [
       return true;
     },
     start: (context: any, handlers: { onData: (data: IChatMessage) => void, onDone: () => void, onError: (error: Error) => void }) => {
-      const thinkTagWrapPattern = new ThinkTagWrapPattern();
       const thinkPatternExtractor = new PatternExtractor({
         onNormalWrite: (value) => onMarkdown(value, context.delta, context.chatMessage),
         onHandledWrite: (value) => onReasoningContent(value, context.delta, context.chatMessage),
-        regExpMap: thinkTagWrapPattern.regExpMap,
+        regExpMap: new ThinkTagWrapPattern().regExpMap,
       });
       context.patternExtractor = new PatternExtractor({
         onNormalWrite: (value) => thinkPatternExtractor.handleContent(value),

--- a/packages/frameworks/vue/src/chat/response-handler.ts
+++ b/packages/frameworks/vue/src/chat/response-handler.ts
@@ -203,7 +203,7 @@ export const defaultResponseHandlers: IResponseHandler<IStreamData>[] = [
         } else if (!context.handleReasoning && newVal[newVal.length - 1]?.type === 'reasoning') {
           context.handleReasoning = true;
         }
-      });
+      }, { flush: 'sync' });
     },
     end: (context: any) => {
       context.unWatchReasoning?.();

--- a/packages/frameworks/vue/src/chat/response-handler.ts
+++ b/packages/frameworks/vue/src/chat/response-handler.ts
@@ -88,16 +88,19 @@ function onToolCall(toolCalls: any[], delta: IStreamDelta, toolCallIdMap: Record
 
 function onReasoningContent(reasoningContent: string, delta: IStreamDelta, chatMessage: IChatMessage) {
   const lastMessage = chatMessage.messages[chatMessage.messages.length - 1];
-  if (lastMessage?.type === 'reasoning') {
-    lastMessage.content += reasoningContent;
+  let reasoningMessage = lastMessage
+  if (reasoningMessage?.type === 'reasoning') {
+    reasoningMessage.content += reasoningContent;
   } else {
-    chatMessage.messages.push({
+    reasoningMessage = {
       type: 'reasoning',
       content: reasoningContent,
       thinking: true,
-    });
+    };
+    chatMessage.messages.push(reasoningMessage);
   }
   emitNotification(delta, chatMessage);
+  return reasoningMessage;
 };
 
 function onReasoningEnd(reasoningMessage: IMessageItem) {
@@ -184,7 +187,7 @@ export const defaultResponseHandlers: IResponseHandler<IStreamData>[] = [
     },
     handler: (data: IStreamData, context: any) => {
       const delta = getStreamDelta(data);
-      onReasoningContent(delta.reasoning_content, delta, context.chatMessage);
+      context.reasoningMessage = onReasoningContent(delta.reasoning_content, delta, context.chatMessage);
       return true;
     },
     start: (context: any, handlers: { onData: (data: IChatMessage) => void, onDone: () => void, onError: (error: Error) => void }) => {
@@ -195,8 +198,8 @@ export const defaultResponseHandlers: IResponseHandler<IStreamData>[] = [
         }
         if (context.handleReasoning && newVal[newVal.length - 1]?.type !== 'reasoning') {
           context.handleReasoning = false;
-          const reasoningMessage = newVal[newVal.length - 2];
-          onReasoningEnd(reasoningMessage);
+          onReasoningEnd(context.reasoningMessage);
+          context.unWatchReasoning?.();
         } else if (!context.handleReasoning && newVal[newVal.length - 1]?.type === 'reasoning') {
           context.handleReasoning = true;
         }
@@ -206,8 +209,7 @@ export const defaultResponseHandlers: IResponseHandler<IStreamData>[] = [
       context.unWatchReasoning?.();
       if (context.handleReasoning) {
         context.handleReasoning = false;
-        const reasoningMessage = context.chatMessage.messages[context.chatMessage.messages.length - 1];
-        onReasoningEnd(reasoningMessage);
+        onReasoningEnd(context.reasoningMessage);
       }
     }
   },
@@ -255,7 +257,7 @@ export const defaultResponseHandlers: IResponseHandler<IStreamData>[] = [
     start: (context: any, handlers: { onData: (data: IChatMessage) => void, onDone: () => void, onError: (error: Error) => void }) => {
       const thinkPatternExtractor = new PatternExtractor({
         onNormalWrite: (value) => onMarkdown(value, context.delta, context.chatMessage),
-        onHandledWrite: (value) => onReasoningContent(value, context.delta, context.chatMessage),
+        onHandledWrite: (value) => context.reasoningMessage = onReasoningContent(value, context.delta, context.chatMessage),
         regExpMap: new ThinkTagWrapPattern().regExpMap,
       });
       context.patternExtractor = new PatternExtractor({


### PR DESCRIPTION
1、新增<think>标签处理逻辑，显示思考过程。
2、修改onReasoningEnd调用时机，统一<think>标签包裹和reasoing_content两种方式的end时机

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Publicly expose tag-matching utilities and a think-tag wrapper pattern for improved partial-tag detection.
* **Improvements**
  * Delta-aware reasoning lifecycle with more accurate notifications.
  * Layered, per-message content pipeline for more reliable structured reasoning.
  * Render reasoning content as rich markdown and simplify related styling.
* **Bug Fixes**
  * Fewer misclassifications between reasoning and normal content and more consistent updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->