### PR TITLE
fix: resolve svg id conflicts

### DIFF
--- a/sites/playground/web/src/components/genui-template/GenuiTemplateChat.vue
+++ b/sites/playground/web/src/components/genui-template/GenuiTemplateChat.vue
@@ -15,6 +15,7 @@ import {
 import { GeneratingStatus, STATUS } from '@opentiny/tiny-robot-kit';
 import type { ChatMessage } from '@opentiny/tiny-robot-kit';
 import { IconAi, IconUser, IconArrowDown } from '@opentiny/tiny-robot-svgs';
+import SvgIdPrefixer from './SvgIdPrefixer.vue';
 import type { BubbleRoleConfig } from '@opentiny/tiny-robot';
 import { requiredCompleteFieldSelectors, scrollEnd, throttle } from '@opentiny/genui-sdk-vue';
 import type { IMessage } from '@opentiny/genui-sdk-vue';
@@ -71,7 +72,10 @@ const generating = computed(() => GeneratingStatus.includes(conversation.message
 const roles: Record<string, BubbleRoleConfig> = {
   assistant: {
     placement: 'start',
-    avatar: h(IconAi, { style: { fontSize: '32px' } }),
+    avatar: h(SvgIdPrefixer, {
+      icon: IconAi,
+      style: { fontSize: '32px' },
+    }),
     maxWidth: '100%',
     customContentField: 'messages',
     slots: {
@@ -94,7 +98,10 @@ const roles: Record<string, BubbleRoleConfig> = {
   user: {
     placement: 'end',
     maxWidth: '90%',
-    avatar: h(IconUser, { style: { fontSize: '32px' } }),
+    avatar: h(SvgIdPrefixer, {
+      icon: IconUser,
+      style: { fontSize: '32px' },
+    }),
     customContentField: 'messages',
   },
 };
@@ -397,9 +404,12 @@ onUnmounted(() => {
       </tr-bubble-provider>
     </div>
     <div class="sender-container">
-      <div :class="['scroll-to-bottom-button', { 'is-generating': generating }]" v-show="!isLastMessageInBottom"
-        @click="scrollToBottom">
-        <IconArrowDown class="icon-arrow-down" />
+      <div
+        :class="['scroll-to-bottom-button', { 'is-generating': generating }]"
+        v-show="!isLastMessageInBottom"
+        @click="scrollToBottom"
+      >
+        <SvgIdPrefixer :icon="IconArrowDown" class="icon-arrow-down" />
       </div>
       <tr-sender v-model="inputMessage" :placeholder="GeneratingStatus.includes(messageManager.messageState.status) ? '正在思考中...' : '请输入您的问题～'
         " :clearable="true" :loading="GeneratingStatus.includes(messageManager.messageState.status)"

--- a/sites/playground/web/src/components/genui-template/GenuiTemplateChat.vue
+++ b/sites/playground/web/src/components/genui-template/GenuiTemplateChat.vue
@@ -409,7 +409,7 @@ onUnmounted(() => {
         v-show="!isLastMessageInBottom"
         @click="scrollToBottom"
       >
-        <SvgIdPrefixer :icon="IconArrowDown" class="icon-arrow-down" />
+        <IconArrowDown class="icon-arrow-down" />
       </div>
       <tr-sender v-model="inputMessage" :placeholder="GeneratingStatus.includes(messageManager.messageState.status) ? '正在思考中...' : '请输入您的问题～'
         " :clearable="true" :loading="GeneratingStatus.includes(messageManager.messageState.status)"

--- a/sites/playground/web/src/components/genui-template/SvgIdPrefixer.vue
+++ b/sites/playground/web/src/components/genui-template/SvgIdPrefixer.vue
@@ -1,0 +1,91 @@
+<script setup lang="ts">
+import { onMounted, ref, type ComponentPublicInstance } from 'vue';
+
+const props = defineProps<{
+  /**
+   * 真实的图标组件，例如 IconAi / IconUser
+   */
+  icon: any;
+}>();
+
+const wrapperRef = ref<ComponentPublicInstance | null>(null);
+
+const updateSvgIds = () => {
+  const root = (wrapperRef.value as any)?.$el as HTMLElement | null;
+  if (!root) return;
+
+  let svg: SVGSVGElement | null = null;
+
+  if (root instanceof SVGSVGElement) {
+    svg = root as SVGSVGElement;
+  } else {
+    svg = root.querySelector('svg');
+  }
+
+  if (!svg) return;
+
+  const prefix = 'genui-template-svg-';
+
+  const idMap = new Map<string, string>();
+
+  const getNewId = (oldId: string) => {
+    if (!idMap.has(oldId)) {
+      idMap.set(oldId, `${prefix}${oldId}`);
+    }
+    return idMap.get(oldId)!;
+  };
+
+  svg.querySelectorAll<HTMLElement>('[id]').forEach((el) => {
+    const oldId = el.getAttribute('id');
+    if (!oldId) return;
+    const newId = getNewId(oldId);
+    el.setAttribute('id', newId);
+  });
+
+  const replaceIdRefs = (value: string | null) => {
+    if (!value) return value;
+    // 只处理 url(#id) / #id 这种形式
+    return value.replace(/url\(#([^)]+)\)|#([A-Za-z_][\w:-]*)/g, (match, g1, g2) => {
+      const id = g1 || g2;
+      if (!idMap.has(id)) return match;
+      const newId = getNewId(id);
+      if (match.startsWith('url(')) {
+        return `url(#${newId})`;
+      }
+      if (match.startsWith('#')) {
+        return `#${newId}`;
+      }
+      return match;
+    });
+  };
+
+  const attrNames = ['fill', 'stroke', 'filter', 'mask', 'clip-path'];
+
+  svg.querySelectorAll<HTMLElement>('*').forEach((el) => {
+    attrNames.forEach((name) => {
+      const val = el.getAttribute(name);
+      const next = replaceIdRefs(val);
+      if (next !== val && next != null) {
+        el.setAttribute(name, next);
+      }
+    });
+
+    ['href', 'xlink:href'].forEach((name) => {
+      const val = el.getAttribute(name);
+      const next = replaceIdRefs(val);
+      if (next !== val && next != null) {
+        el.setAttribute(name, next);
+      }
+    });
+  });
+};
+
+onMounted(() => {
+  updateSvgIds();
+});
+</script>
+
+<template>
+  <component ref="wrapperRef" :is="icon" />
+</template>
+


### PR DESCRIPTION
修复图标显示异常的问题
@opentiny/tiny-robot-svgs 中的图标内部使用了 id、clipPath、mask 等 SVG 定义，多次渲染同一图标组件时，出现 id 冲突，导致渲染出错。

<img width="2153" height="216" alt="image" src="https://github.com/user-attachments/assets/1b3648f7-6e88-4312-a23a-14902dcc679c" />
修复后：
<img width="2146" height="190" alt="image" src="https://github.com/user-attachments/assets/21b2278b-506c-4c37-ad18-3beccbfc4f37" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new SVG wrapper component for icon rendering with ID namespace management.

* **Refactor**
  * Updated avatar components in the chat interface to use the new SVG wrapper, maintaining the same visual appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->