### PR TITLE
fix(playground-web): fix svg id conflicts

### DIFF
--- a/sites/playground/web/src/App.vue
+++ b/sites/playground/web/src/App.vue
@@ -16,6 +16,12 @@ import McpTools from './components/tab-components/mcpTools.vue';
 import GenuiHistory from './components/tab-components/GenuiHistory.vue';
 import { useInputMessage } from './use-input-message';
 import useTemplate from './components/genui-template/useTemplate';
+import useIcon from './use-icon';
+
+const { topRenderer, addIcons } = useIcon();
+const TopIconsRenderer = topRenderer();
+
+addIcons(IconAi);
 
 let framework = 'Vue'; // Angular
 
@@ -167,6 +173,7 @@ const updateCustomExamples = (list) => {
 </script>
 
 <template>
+  <TopIconsRenderer style="height: 0" />
   <div class="genui-playground">
     <div class="config-tabs" :class="{ 'config-tabs--collapsed': !isOpen }">
       <!-- 头部区域 -->

--- a/sites/playground/web/src/components/genui-template/GenuiTemplateChat.vue
+++ b/sites/playground/web/src/components/genui-template/GenuiTemplateChat.vue
@@ -34,6 +34,10 @@ import SchemaVersionCard from './SchemaVersionCard.vue';
 import useTemplate from './useTemplate';
 import AssistantFooter from './TemplateAssistantFooter.vue';
 import { emitter } from './template-chat-event-emitter';
+import useIcon from '../../use-icon';
+
+const { addIcons } = useIcon();
+addIcons(IconAi, IconUser);
 
 const props = defineProps<{
   messages?: IMessage[];

--- a/sites/playground/web/src/use-icon.ts
+++ b/sites/playground/web/src/use-icon.ts
@@ -1,0 +1,22 @@
+import { defineComponent, h, markRaw, ref, type Ref } from 'vue';
+
+// 解决同个svg引用形状id冲突，不能解决不同svg引用id冲突
+
+const iconMap: Ref<Array<any>> = ref([]);
+export default function useIcon() {
+  function addIcons(...icons: Array<ReturnType<typeof defineComponent>>) {
+    iconMap.value.push(...icons.map((icon) => markRaw(icon)));
+  }
+  function topRenderer() {
+    return () =>
+      h(
+        'div',
+        iconMap.value.map((icon) => h(icon, { style: { width: 0, height: 0 } })),
+      );
+  }
+
+  return {
+    addIcons,
+    topRenderer,
+  };
+}


### PR DESCRIPTION
修复在多个 svg 图标引用时，因 display:none 属性导致 svg 的 id 引用冲突失效问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an icon management system that allows icons to be registered and displayed dynamically across the application, providing flexibility in icon handling
  * Enhanced the chat component with visual avatars for both AI and user messages, improving clarity and making it easier to identify the source of each message at a glance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->