### PR TITLE
feat(playground): add finishInfo popover

### DIFF
--- a/packages/core/src/protocols/chat.ts
+++ b/packages/core/src/protocols/chat.ts
@@ -31,6 +31,32 @@ export interface IStreamDelta {
   }>;
 }
 
+/**
+ * 单次流式响应中的一条 choice（与 OpenAI chat.completion.chunk 对齐）
+ */
+export interface IChatStreamChoice {
+  index: number;
+  delta?: IStreamDelta;
+  finish_reason?: string | null;
+}
+
+/**
+ * 单次 SSE data 行解析后的完整负载（含 id、model、choices 等顶层字段）
+ */
+export interface IStreamData {
+  id?: string;
+  object?: string;
+  model?: string;
+  type?: string;
+  created?: number;
+  choices?: IChatStreamChoice[];
+  usage?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+    total_tokens?: number;
+  };
+}
+
 export interface ISchemaCardMessageItem {
   type: 'schema-card';
   content: string;
@@ -72,6 +98,7 @@ export interface IChatMessage {
   role: 'assistant';
   content: string;
   messages: IMessageItem[];
+  [customKey: string]: any;
 }
 
 /**

--- a/packages/frameworks/vue/src/chat/CustomModelProvider.ts
+++ b/packages/frameworks/vue/src/chat/CustomModelProvider.ts
@@ -2,7 +2,7 @@ import { BaseModelProvider, type ChatCompletionRequest, type ChatCompletionRespo
 import { chat } from './chat-api';
 import type { IChatConfig, ICustomComponentItem, CustomFetch, ICustomActionItem } from './chat.types';
 import type { IGenPromptSnippet, IGenPromptExample } from '@opentiny/genui-sdk-core';
-import type { IStreamDelta, IChatMessage } from '@opentiny/genui-sdk-core';
+import type { IChatMessage, IStreamData } from '@opentiny/genui-sdk-core';
 import type { IResponseHandler } from './response-handler';
 
 async function readChunk(reader: ReadableStreamDefaultReader<Uint8Array>, handler: (data: string) => void) {
@@ -46,7 +46,7 @@ export class CustomModelProvider extends BaseModelProvider {
   private customActions: ICustomActionItem[];
   private chatConfig: IChatConfig;
   private customFetch?: CustomFetch;
-  protected responseHandlers: IResponseHandler<IStreamDelta>[] = [];
+  protected responseHandlers: IResponseHandler<IStreamData>[] = [];
   constructor({ url, model, temperature, chatConfig, customComponents, customSnippets, customExamples, customActions, customFetch }: ICustomModelProviderOptions) {
     super({ provider: 'custom' });
     this.url = url;
@@ -57,7 +57,7 @@ export class CustomModelProvider extends BaseModelProvider {
     this.customExamples = customExamples;
     this.customActions = customActions;
     this.chatConfig = chatConfig;
-    this.customFetch = customFetch;
+    this.customFetch = customFetch; 
   }
   validateRequest(_: ChatCompletionRequest) { }
 
@@ -65,7 +65,7 @@ export class CustomModelProvider extends BaseModelProvider {
     this.model = model;
     this.temperature = temperature;
   }
-  setResponseHandlers(handlers: IResponseHandler<IStreamDelta>[]) {
+  setResponseHandlers(handlers: IResponseHandler<IStreamData>[]) {
     this.responseHandlers = handlers;
   }
 
@@ -124,17 +124,16 @@ export class CustomModelProvider extends BaseModelProvider {
     
   }
 
-  handlerChunk(data: string, context: any) {
+  handlerChunk(rawData: string, context: any) {
     try {
-      const chunk = JSON.parse(data);
-      const delta = chunk.choices?.[0]?.delta || {};
-    
+      const streamData = JSON.parse(rawData) as IStreamData;
+
       for (const handler of this.responseHandlers) {
-        if (handler.match(delta, context)) {
-          const handled = handler.handler(delta,  context);
+        if (handler.match(streamData, context)) {
+          const handled = handler.handler(streamData, context);
           if (handled) break;
         } else if (handler.notMatchHandler) {
-          const handled = handler.notMatchHandler(delta, context);
+          const handled = handler.notMatchHandler(streamData, context);
           if (handled) break;
         }
       }

--- a/packages/frameworks/vue/src/chat/GenuiChat.vue
+++ b/packages/frameworks/vue/src/chat/GenuiChat.vue
@@ -472,7 +472,9 @@ defineExpose({
   setInputMessage,
   handleNewConversation,
   getConversation: () => conversation,
+  // experimental, not stable
   getResponseHandlers: () => responseHandlers.value,
+  // experimental, not stable
   setResponseHandlers: (handlers: IResponseHandler<IStreamData>[]) => {
     responseHandlers.value = handlers;
     customModelProvider.setResponseHandlers(handlers);

--- a/packages/frameworks/vue/src/chat/GenuiChat.vue
+++ b/packages/frameworks/vue/src/chat/GenuiChat.vue
@@ -30,7 +30,7 @@ import { emitter } from './event-emitter';
 import type { IChatProps, ICustomActionItem, IRolesConfig } from './chat.types';
 import GeneratingComponent from './GeneratingComponent.vue';
 import { useChatAction } from './continue-chat-action';
-import type { IMessageItem, IStreamDelta } from '@opentiny/genui-sdk-core';
+import type { IMessageItem, IStreamData } from '@opentiny/genui-sdk-core';
 import type { IRendererProps } from '../renderer';
 import { GenuiRenderer } from '../renderer';
 import ErrorText from './ErrorText.vue';
@@ -95,7 +95,7 @@ const wrapSlots = (slots: any) => {
       });
       const slotFn = toSlotFunction(slots[key]);
       if (slotFn) {
-        return slotFn({ ...props, isFinished: isFinished.value, messageManager: messageManager.value });
+        return slotFn({ ...props, isFinished: isFinished.value, messageManager: messageManager.value, chatMessage: messageManager.value.messages.value[props.index] });
       }
       return null;
     };
@@ -238,7 +238,7 @@ const messageRenderers = {
   'error-text': ErrorText,
 };
 
-const responseHandlers: Ref<IResponseHandler<IStreamDelta>[]> = ref(defaultResponseHandlers);
+const responseHandlers: Ref<IResponseHandler<IStreamData>[]> = ref(defaultResponseHandlers);
 
 
 const customModelProvider = new CustomModelProvider({
@@ -473,7 +473,7 @@ defineExpose({
   handleNewConversation,
   getConversation: () => conversation,
   getResponseHandlers: () => responseHandlers.value,
-  setResponseHandlers: (handlers: IResponseHandler<IStreamDelta>[]) => {
+  setResponseHandlers: (handlers: IResponseHandler<IStreamData>[]) => {
     responseHandlers.value = handlers;
     customModelProvider.setResponseHandlers(handlers);
   },

--- a/packages/frameworks/vue/src/chat/chat.types.ts
+++ b/packages/frameworks/vue/src/chat/chat.types.ts
@@ -8,6 +8,7 @@ import type {
   IGenPromptSnippet,
   IGenPromptExample,
   IGenPromptAction,
+  IChatMessage,
 } from '@opentiny/genui-sdk-core';
 
 export interface ICustomActionItem extends IGenPromptAction {
@@ -47,6 +48,7 @@ export interface IBubbleSlotsProps {
   bubbleProps: BubbleProps;
   isFinished: boolean;
   messageManager: UseMessageReturn;
+  chatMessage: IChatMessage;
 }
 
 /**

--- a/packages/frameworks/vue/src/chat/response-handler.ts
+++ b/packages/frameworks/vue/src/chat/response-handler.ts
@@ -1,4 +1,4 @@
-import { IChatMessage, IMessageItem, IStreamDelta, PatternExtractor } from "@opentiny/genui-sdk-core";
+import { IChatMessage, IMessageItem, IStreamDelta, IStreamData, PatternExtractor } from "@opentiny/genui-sdk-core";
 import { reactive, toRaw } from "vue";
 import { v4 as uuidv4 } from 'uuid';
 import { emitter } from './event-emitter';
@@ -9,9 +9,13 @@ export interface IResponseHandler<T> {
   match: (data: T, context: any) => boolean;
   handler: (data: T, context: any) => boolean;
   notMatchHandler?: (data: T, context: any) => boolean;
-  start?: (mcontext: any, handlers: { onData: (data: T) => void, onDone: () => void, onError: (error: Error) => void }) => void;
+  start?: (context: any, handlers: { onData: (data: IChatMessage) => void, onDone: () => void, onError: (error: Error) => void }) => void;
   end?: (context: any) => void;
 }
+
+const getStreamDelta = (data: IStreamData): IStreamDelta => {
+  return data.choices?.[0]?.delta ?? {};
+};
 
 function onToolResult(toolCallsResult: any[], delta: IStreamDelta, toolCallIdMap: Record<string, IMessageItem & { type: 'tool' }>, chatMessage: IChatMessage, addToolCallContext: boolean) {
   const {
@@ -136,11 +140,11 @@ function onSchemaJSON(content: string, delta: IStreamDelta, chatMessage: IChatMe
   emitNotification(delta, chatMessage);
 }
 
-export const defaultResponseHandlers: IResponseHandler<IStreamDelta>[] = [
+export const defaultResponseHandlers: IResponseHandler<IStreamData>[] = [
   {
     name: 'init',
-    match: (data: IStreamDelta, context: any) => false,
-    handler: (data: IStreamDelta, context: any) => false,
+    match: (data: IStreamData, context: any) => false,
+    handler: (data: IStreamData, context: any) => false,
     start: (context: any, handlers: { onData: (data: IChatMessage) => void, onDone: () => void, onError: (error: Error) => void }) => {
       const chatMessage = reactive<IChatMessage>({
         role: 'assistant',
@@ -162,27 +166,42 @@ export const defaultResponseHandlers: IResponseHandler<IStreamDelta>[] = [
     },
   },
   {
-    name: 'reasoning',
-    match: (data: IStreamDelta, context: any) => {
-      return data.reasoning_content !== undefined;
+    name: 'finish-info',
+    match: (data: IStreamData, context: any) => {
+      const { choices, usage } = data;
+      return choices?.[0]?.finish_reason && Boolean(usage);
     },
-    handler: (data: IStreamDelta, context: any) => {
-      onReasoningContent(data.reasoning_content, context.chatMessage);
-      emitNotification(data, context.chatMessage);
+    handler: (data: IStreamData, context: any) => {
+      context.chatMessage.finishInfo = data;
       return true;
     },
-    notMatchHandler: (data: IStreamDelta, context: any) => {
+  },
+  {
+    name: 'reasoning',
+    match: (data: IStreamData, context: any) => {
+      const delta = getStreamDelta(data);
+      return delta.reasoning_content !== undefined;
+    },
+    handler: (data: IStreamData, context: any) => {
+      const delta = getStreamDelta(data);
+      onReasoningContent(delta.reasoning_content, context.chatMessage);
+      emitNotification(delta, context.chatMessage);
+      return true;
+    },
+    notMatchHandler: (data: IStreamData, context: any) => {
       onReasoningEnd(context.chatMessage);
       return false;
     },
   },
   {
     name: 'toolCall',
-    match: (data: IStreamDelta, context: any) => {
-      return data.tool_calls?.length > 0;
+    match: (data: IStreamData, context: any) => {
+      const delta = getStreamDelta(data);
+      return delta.tool_calls?.length > 0;
     },
-    handler: (data: IStreamDelta, context: any) => {
-      onToolCall(data.tool_calls, data, context.toolCallIdMap, context.chatMessage, context.toolCallStatus);
+    handler: (data: IStreamData, context: any) => {
+      const delta = getStreamDelta(data);
+      onToolCall(delta.tool_calls, delta, context.toolCallIdMap, context.chatMessage, context.toolCallStatus);
       return true;
     },
     start: (context: any, handlers: { onData: (data: IChatMessage) => void, onDone: () => void, onError: (error: Error) => void }) => {
@@ -192,23 +211,27 @@ export const defaultResponseHandlers: IResponseHandler<IStreamDelta>[] = [
   },
   {
     name: 'toolResult',
-    match: (data: IStreamDelta, context: any) => {
-      return data.tool_calls_result?.length > 0;
+    match: (data: IStreamData, context: any) => {
+      const delta = getStreamDelta(data);
+      return delta.tool_calls_result?.length > 0;
     },
-    handler: (data: IStreamDelta, context: any) => {
-      onToolResult(data.tool_calls_result, data, context.toolCallIdMap, context.chatMessage, context.chatConfig.addToolCallContext);
+    handler: (data: IStreamData, context: any) => {
+      const delta = getStreamDelta(data);
+      onToolResult(delta.tool_calls_result, delta, context.toolCallIdMap, context.chatMessage, context.chatConfig.addToolCallContext);
       return true;
     },
   },
   {
     name: 'content',
-    match: (data: IStreamDelta, context: any) => {
-      return data.content !== undefined;
+    match: (data: IStreamData, context: any) => {
+      const delta = getStreamDelta(data);
+      return delta.content !== undefined;
     },
-    handler: (data: IStreamDelta, context: any) => {
-      context.delta = data;
-      context.patternExtractor.handleContent(data.content)
-      context.chatMessage.content += data.content;
+    handler: (data: IStreamData, context: any) => {
+      const delta = getStreamDelta(data);
+      context.delta = delta;
+      context.patternExtractor.handleContent(delta.content)
+      context.chatMessage.content += delta.content;
       return true;
     },
     start: (context: any, handlers: { onData: (data: IChatMessage) => void, onDone: () => void, onError: (error: Error) => void }) => {

--- a/sites/playground/web/src/components/AssistantFooter.vue
+++ b/sites/playground/web/src/components/AssistantFooter.vue
@@ -5,6 +5,7 @@ import { AutoTip } from '@opentiny/vue-directive';
 import { ref, computed } from 'vue';
 import copy from 'clipboard-copy';
 import type { IBubbleSlotsProps } from './common.types';
+import FinishInfo from './FinishInfo.vue';
 const props = defineProps<IBubbleSlotsProps>();
 
 const vAutoTip = AutoTip;
@@ -63,6 +64,7 @@ const refresh = () => {
       @click="copyContent"
     >
     </tiny-button>
+    <FinishInfo style="margin-left: 8px;" :data="props.chatMessage.finishInfo" />
   </div>
 </template>
 <style lang="scss" scoped>

--- a/sites/playground/web/src/components/FinishInfo.vue
+++ b/sites/playground/web/src/components/FinishInfo.vue
@@ -87,6 +87,7 @@ function formatInt(n: number) {
     </template>
     <template #reference>
       <tiny-button
+        aria-label="本轮对话统计信息"
         type="text"
         :icon="InfoIcon"
       >

--- a/sites/playground/web/src/components/FinishInfo.vue
+++ b/sites/playground/web/src/components/FinishInfo.vue
@@ -1,0 +1,175 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { TinyPopover, TinyButton } from '@opentiny/vue';
+import { iconInfoCircle } from '@opentiny/vue-icon';
+
+const InfoIcon = iconInfoCircle();
+
+
+export interface ChatCompletionFinishChunk {
+  object?: string;
+  model?: string;
+  created?: number;
+  choices?: Array<{
+    index?: number;
+    delta?: Record<string, unknown>;
+    finish_reason?: string | null;
+  }>;
+  usage?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+    total_tokens?: number;
+  };
+}
+
+const props = defineProps<{
+  data: ChatCompletionFinishChunk | null | undefined;
+}>();
+
+const usage = computed(() => props.data?.usage);
+
+const finishReason = computed(() => props.data?.choices?.[0]?.finish_reason ?? undefined);
+
+const createdLabel = computed(() => {
+  const t = props.data?.created;
+  if (t == null) return '';
+  const d = new Date(t);
+  return Number.isNaN(d.getTime()) ? String(t) : d.toLocaleString();
+});
+
+function formatInt(n: number) {
+  return n.toLocaleString();
+}
+</script>
+
+<template>
+  <tiny-popover
+    v-if="data"
+    trigger="hover"
+    placement="bottom-start"
+    width="auto"
+    :visible-arrow="false"
+    popper-class="finish-statistic-popover"
+  >
+    <template #default>
+      <div class="finish-statistic-panel">
+        <div class="panel-title">对话信息</div>
+        <dl class="stat-list">
+          <div v-if="data.model" class="stat-row">
+            <dt>模型</dt>
+            <dd>{{ data.model }}</dd>
+          </div>
+          <div v-if="finishReason != null && finishReason !== ''" class="stat-row">
+            <dt>结束原因</dt>
+            <dd>{{ finishReason }}</dd>
+          </div>
+          <div v-if="data.created != null" class="stat-row">
+            <dt>时间</dt>
+            <dd>{{ createdLabel }}</dd>
+          </div>
+          <template v-if="usage">
+            <div v-if="usage.prompt_tokens != null" class="stat-row">
+              <dt>输入 Token</dt>
+              <dd>{{ formatInt(usage.prompt_tokens) }}</dd>
+            </div>
+            <div v-if="usage.completion_tokens != null" class="stat-row">
+              <dt>输出 Token</dt>
+              <dd>{{ formatInt(usage.completion_tokens) }}</dd>
+            </div>
+            <div v-if="usage.total_tokens != null" class="stat-row stat-row--emphasis">
+              <dt>总计 Token</dt>
+              <dd>{{ formatInt(usage.total_tokens) }}</dd>
+            </div>
+          </template>
+        </dl>
+      </div>
+    </template>
+    <template #reference>
+      <tiny-button
+        type="text"
+        :icon="InfoIcon"
+      >
+      </tiny-button>
+    </template>
+  </tiny-popover>
+</template>
+
+<style scoped>
+.finish-statistic-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 28px;
+  padding: 0 8px;
+  border: none;
+  background: transparent;
+  color: #666;
+  cursor: pointer;
+  border-radius: 6px;
+  font-size: 12px;
+  transition: background-color 0.2s, color 0.2s;
+}
+
+.finish-statistic-trigger:hover {
+  background-color: #f5f5f5;
+  color: #333;
+}
+
+.finish-statistic-trigger-icon {
+  flex-shrink: 0;
+}
+
+.finish-statistic-panel {
+  min-width: 220px;
+  padding: 2px 0;
+}
+
+.panel-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: #1a1a1a;
+  margin-bottom: 10px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid #eee;
+}
+
+.stat-list {
+  margin: 0;
+}
+
+.stat-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+  margin: 0;
+  padding: 6px 0;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.stat-row dt {
+  margin: 0;
+  color: #888;
+  font-weight: normal;
+  flex-shrink: 0;
+}
+
+.stat-row dd {
+  margin: 0;
+  color: #333;
+  text-align: right;
+  word-break: break-all;
+}
+
+.stat-row--emphasis dd {
+  font-weight: 600;
+  color: #1890ff;
+}
+</style>
+
+<style>
+.finish-statistic-popover.tiny-popover.tiny-popper {
+  padding: 12px 14px;
+}
+</style>

--- a/sites/playground/web/src/components/FinishInfo.vue
+++ b/sites/playground/web/src/components/FinishInfo.vue
@@ -33,7 +33,8 @@ const finishReason = computed(() => props.data?.choices?.[0]?.finish_reason ?? u
 const createdLabel = computed(() => {
   const t = props.data?.created;
   if (t == null) return '';
-  const d = new Date(t);
+  const ms = t < 1e12 ? t * 1000 : t;
+  const d = new Date(ms);
   return Number.isNaN(d.getTime()) ? String(t) : d.toLocaleString();
 });
 

--- a/sites/playground/web/src/components/common.types.ts
+++ b/sites/playground/web/src/components/common.types.ts
@@ -1,8 +1,11 @@
+import type { IChatMessage } from "@opentiny/genui-sdk-core";
+
 export interface IBubbleSlotsProps {
   index: number;
   bubbleProps: { [key: string]: any };
   isFinished: boolean;
   messageManager: { [key: string]: any };
+  chatMessage: IChatMessage;
 }
 
 export interface IRendererSlotsProps {

--- a/sites/playground/web/src/components/genui-template/GenuiTemplateChat.vue
+++ b/sites/playground/web/src/components/genui-template/GenuiTemplateChat.vue
@@ -4,7 +4,7 @@ import type { Ref } from 'vue';
 import '@opentiny/tiny-robot/dist/style.css';
 import * as jsonPatchFormatter from 'jsondiffpatch/formatters/jsonpatch';
 import type { JsonPatchOp } from 'jsondiffpatch/formatters/jsonpatch-apply';
-import { DeltaPatcher } from '@opentiny/genui-sdk-core';
+import { DeltaPatcher, type IChatMessage } from '@opentiny/genui-sdk-core';
 import {
   TrBubbleList,
   TrSender,
@@ -85,6 +85,7 @@ const roles: Record<string, BubbleRoleConfig> = {
           index: slotProps.index,
           isFinished,
           messageManager: messageManager.value,
+          chatMessage: messageManager.value.messages.value[slotProps.index] as IChatMessage,
           onRefresh: handleRefresh,
           onCopy: handleCopy,
         });

--- a/sites/playground/web/src/components/genui-template/GenuiTemplateChat.vue
+++ b/sites/playground/web/src/components/genui-template/GenuiTemplateChat.vue
@@ -85,7 +85,7 @@ const roles: Record<string, BubbleRoleConfig> = {
           index: slotProps.index,
           isFinished,
           messageManager: messageManager.value,
-          chatMessage: messageManager.value.messages.value[slotProps.index] as IChatMessage,
+          chatMessage: (messageManager.value.messages.value[slotProps.index] || {}) as IChatMessage,
           onRefresh: handleRefresh,
           onCopy: handleCopy,
         });


### PR DESCRIPTION
新增本轮对话结束信息展示
<img width="1699" height="1318" alt="image" src="https://github.com/user-attachments/assets/642345e2-28b3-4ac9-a45b-55861054fbce" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conversation info popover in the assistant footer showing model, finish reason, timestamp, and token usage.
  * Finish-info display component added to message UI.

* **Improvements**
  * Streaming now delivers fuller message payloads so handlers and UI receive richer context.
  * Chat messages can include arbitrary custom fields and bubble slot renderers now receive the full message object.
  * Finish-info is propagated into messages for display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->