### PR TITLE
fix(genui-sdk-vue): catch rendering error, store state with serializable json

### DIFF
--- a/packages/frameworks/vue/src/chat/GenuiChat.vue
+++ b/packages/frameworks/vue/src/chat/GenuiChat.vue
@@ -137,7 +137,7 @@ const saveState = (context: Record<string | symbol, any>) => {
   const cardId = context[cardIdSymbol];
   const cardMessage = getCardMessage(cardId);
   if (cardMessage) {
-    (cardMessage as any).state = Object.assign({}, context.state || {});
+    (cardMessage as any).state = JSON.parse(JSON.stringify(context.state || {}));
   }
   saveConversations();
 };

--- a/packages/frameworks/vue/src/renderer/SchemaCardRenderer.vue
+++ b/packages/frameworks/vue/src/renderer/SchemaCardRenderer.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { parsePartialJson } from 'ai';
-import { ref, watch, computed, inject, nextTick } from 'vue';
+import { ref, watch, computed, inject, nextTick, onErrorCaptured } from 'vue';
 // @ts-ignore
 import defaultSchemaRenderer, { Mapper } from '@opentiny/tiny-schema-renderer';
 import { DeltaPatcher } from '@opentiny/genui-sdk-core';
@@ -10,6 +10,11 @@ import { GENUI_RENDERER } from '../chat/injection-tokens';
 import type { IRendererProps } from './renderer.types';
 import { cardIdSymbol } from '../chat/useChat';
 import { useI18n } from '../chat/i18n';
+
+onErrorCaptured((error) => {
+  console.error('GenuiRenderer error:', error);
+  return true;
+});
 
 const props = defineProps<IRendererProps>();
 


### PR DESCRIPTION
修复渲染器组件渲染错误引起页面崩溃，
state保存到cardMessage前进行一次序列化，避免structedClone失败

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved state data handling for card messages to ensure proper preservation.

* **Improvements**
  * Enhanced error handling and diagnostics in the renderer component for better troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->