### PR TITLE
feat(playground/web): add v-focus-hover-sync directive to  show tooltip on element focus

### DIFF
--- a/sites/playground/web/src/components/AssistantFooter.vue
+++ b/sites/playground/web/src/components/AssistantFooter.vue
@@ -7,6 +7,7 @@ import copy from 'clipboard-copy';
 import type { IBubbleSlotsProps } from './common.types';
 import { useGenerateMore } from '../continue-writing';
 import FinishInfo from './FinishInfo.vue';
+import { vFocusHoverSync } from './v-focus-hover-sync';
 const props = defineProps<IBubbleSlotsProps>();
 
 const vAutoTip = AutoTip;
@@ -67,6 +68,7 @@ const { markGenerateMore, revertGenerateMore } = useGenerateMore(props.messageMa
       type="text"
       :icon="RefreshIcon"
       v-auto-tip="{ always: true, content: '刷新', effect: 'light' }"
+      v-focus-hover-sync
       @click="refresh"
     >
     </tiny-button>
@@ -74,6 +76,7 @@ const { markGenerateMore, revertGenerateMore } = useGenerateMore(props.messageMa
       type="text"
       :icon="CopyIcon"
       v-auto-tip="{ always: true, content: copyTooltip, effect: 'light' }"
+      v-focus-hover-sync
       @click="copyContent"
     >
     </tiny-button>
@@ -83,6 +86,7 @@ const { markGenerateMore, revertGenerateMore } = useGenerateMore(props.messageMa
       type="text"
       :icon="ArrowRightIcon"
       v-auto-tip="{ always: true, content: '继续生成（实验特性）', effect: 'light' }"
+      v-focus-hover-sync
       @click="markGenerateMore"
     >
     </tiny-button>
@@ -91,6 +95,7 @@ const { markGenerateMore, revertGenerateMore } = useGenerateMore(props.messageMa
       type="text"
       :icon="ArrowLeftIcon"
       v-auto-tip="{ always: true, content: '撤回上次继续生成（实验特性）', effect: 'light' }"
+      v-focus-hover-sync
       @click="revertGenerateMore"
     >
     </tiny-button>

--- a/sites/playground/web/src/components/FinishInfo.vue
+++ b/sites/playground/web/src/components/FinishInfo.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue';
 import { TinyPopover, TinyButton } from '@opentiny/vue';
 import { iconInfoCircle } from '@opentiny/vue-icon';
+import { vFocusHoverSync } from './v-focus-hover-sync';
 
 const InfoIcon = iconInfoCircle();
 
@@ -90,6 +91,7 @@ function formatInt(n: number) {
         aria-label="本轮对话统计信息"
         type="text"
         :icon="InfoIcon"
+        v-focus-hover-sync
       >
       </tiny-button>
     </template>

--- a/sites/playground/web/src/components/v-focus-hover-sync.ts
+++ b/sites/playground/web/src/components/v-focus-hover-sync.ts
@@ -1,0 +1,17 @@
+export const vFocusHoverSync = {
+  mounted(el) {
+    el.addEventListener('focus', () => {
+      el.dispatchEvent(new MouseEvent('mouseenter', {
+        bubbles: false,
+        cancelable: true,
+      }))
+    })
+
+    el.addEventListener('blur', () => {
+      el.dispatchEvent(new MouseEvent('mouseleave', {
+        bubbles: false,
+        cancelable: true,
+      }))
+    })
+  }
+}


### PR DESCRIPTION
添加自定义指令，使tab切换焦点时能够展示tooltip

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Interactive button controls now feature synchronized focus and hover states for improved visual feedback and user interaction consistency across the application interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->