### PR TITLE
fix(genui-sdk-vue): fix reasoning duplicate at chatConfig.showThinkingResult is undefined and fix dark mode

### DIFF
--- a/packages/frameworks/vue/src/chat/GenuiChat.vue
+++ b/packages/frameworks/vue/src/chat/GenuiChat.vue
@@ -490,7 +490,7 @@ defineExpose({
   <div
     class="tg-chat-container"
     :class="{ 'dark': genuiConfig?.theme === 'dark' }"
-    :style="props.chatConfig?.showThinkingResult ? { '--thinking-display': 'none' } : {}"
+    :style="!props.chatConfig?.showThinkingResult ? { '--thinking-display': 'none' } : {}"
   >
     <div
       class="messages-container"

--- a/packages/frameworks/vue/src/chat/GenuiChat.vue
+++ b/packages/frameworks/vue/src/chat/GenuiChat.vue
@@ -490,7 +490,7 @@ defineExpose({
   <div
     class="tg-chat-container"
     :class="{ 'dark': genuiConfig?.theme === 'dark' }"
-    :style="props.chatConfig?.showThinkingResult === false ? { '--thinking-display': 'none' } : {}"
+    :style="props.chatConfig?.showThinkingResult ? { '--thinking-display': 'none' } : {}"
   >
     <div
       class="messages-container"

--- a/packages/frameworks/vue/src/chat/renderer/ReasoningRenderer.vue
+++ b/packages/frameworks/vue/src/chat/renderer/ReasoningRenderer.vue
@@ -73,15 +73,15 @@ const MarkdownContent = (markdownProps: { content: string }) =>
 .header {
   font-size: 16px;
   line-height: 1.5;
-  color: #595959;
+  color: var(--tr-text-secondary);
   display: flex;
   align-items: center;
   gap: 8px;
   cursor: pointer;
 
   &:hover {
-    color: #191919;
-    fill: #191919;
+    color: var(--tr-text-primary);
+    fill: var(--tr-text-primary);
   }
 
   .icon-and-text {
@@ -112,7 +112,7 @@ const MarkdownContent = (markdownProps: { content: string }) =>
 }
 
 .detail {
-  color: #595959;
+  color: var(--tr-text-secondary);
   margin-block: 8px;
   display: flex;
   gap: 8px;
@@ -148,7 +148,7 @@ const MarkdownContent = (markdownProps: { content: string }) =>
       width: 4px;
       height: 4px;
       border-radius: 50%;
-      background-color: #191919;
+      background-color: var(--tr-text-primary);
     }
 
     .border-line {


### PR DESCRIPTION
1、修复reasoing内容在chatConfig.showThinkingResult未配置时会重复的问题
2、优化reasoing内容暗黑模式显示

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed thinking/result display logic so hidden state respects configuration when the setting is absent or falsy.

* **Style**
  * Replaced fixed dark colors in the reasoning panel with theme variables for consistent, theme-aware text and indicator colors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->