### PR TITLE
fix(playground/web): fix footer tooltip theme mode change

### DIFF
--- a/sites/playground/web/src/components/AssistantFooter.vue
+++ b/sites/playground/web/src/components/AssistantFooter.vue
@@ -15,7 +15,7 @@ const vAutoTip = AutoTip;
 const genuiConfig: any = inject(GENUI_CONFIG, null);
 
 const tooltipEffect = computed(() => {
-  return genuiConfig.theme === 'dark' ? 'light' : 'dark';
+  return genuiConfig.value.theme === 'dark' ? 'dark' : 'light';
 });
 
 const RefreshIcon = iconRefresh();

--- a/sites/playground/web/src/components/AssistantFooter.vue
+++ b/sites/playground/web/src/components/AssistantFooter.vue
@@ -12,10 +12,10 @@ import { vFocusHoverSync } from './v-focus-hover-sync';
 const props = defineProps<IBubbleSlotsProps>();
 
 const vAutoTip = AutoTip;
-const genuiConfig: any = inject(GENUI_CONFIG, null);
+const genuiConfig: any = inject(GENUI_CONFIG, {});
 
 const tooltipEffect = computed(() => {
-  return genuiConfig.value.theme === 'dark' ? 'dark' : 'light';
+  return genuiConfig.value?.theme === 'dark' ? 'dark' : 'light';
 });
 
 const RefreshIcon = iconRefresh();

--- a/sites/playground/web/src/components/UserFooter.vue
+++ b/sites/playground/web/src/components/UserFooter.vue
@@ -14,7 +14,7 @@ const generating = computed(() => GeneratingStatus.includes(props.messageManager
 const genuiConfig: any = inject(GENUI_CONFIG, {});
 
 const tooltipEffect = computed(() => {
-  return genuiConfig.value.theme === 'dark' ? 'dark' : 'light';
+  return genuiConfig.value?.theme === 'dark' ? 'dark' : 'light';
 });
 
 

--- a/sites/playground/web/src/components/UserFooter.vue
+++ b/sites/playground/web/src/components/UserFooter.vue
@@ -14,7 +14,7 @@ const generating = computed(() => GeneratingStatus.includes(props.messageManager
 const genuiConfig: any = inject(GENUI_CONFIG, {});
 
 const tooltipEffect = computed(() => {
-  return genuiConfig.theme === 'dark' ? 'light' : 'dark';
+  return genuiConfig.value.theme === 'dark' ? 'dark' : 'light';
 });
 
 


### PR DESCRIPTION
修复演练场tooltip主题切换时显示异常问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tooltips now reliably reflect dark and light theme modes, including when theme config is absent — ensuring consistent tooltip styling across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->