### PR TITLE
fix(genui-sdk-vue): optimize actions description and add i18n support

### DIFF
--- a/packages/frameworks/vue/src/chat/continue-chat-action.ts
+++ b/packages/frameworks/vue/src/chat/continue-chat-action.ts
@@ -32,7 +32,7 @@ export function useChatAction({
     },
     saveStateAction: {
       name: 'saveState',
-      description: '保存状态， 用于保存组件状态',
+      description: t('saveState.description'),
       execute: (params: any, context: Record<string | symbol, any>) => {
         saveState(context);
       },

--- a/packages/frameworks/vue/src/chat/i18n/en.json
+++ b/packages/frameworks/vue/src/chat/i18n/en.json
@@ -32,6 +32,9 @@
     "messageParam": "Related parameters: ",
     "paramDescription": "Conversation message, can be button text or other content"
   },
+  "saveState": {
+    "description": "Save state, used for saving component state"
+  },
   "toolCall": {
     "context": "Tool name: {toolName}, Tool parameters: {toolParams}, Tool result: {toolResult}"
   },

--- a/packages/frameworks/vue/src/chat/i18n/zh.json
+++ b/packages/frameworks/vue/src/chat/i18n/zh.json
@@ -28,12 +28,12 @@
     "newConversation": "新会话"
   },
   "continueChat": {
-    "description": "继续对话， 用于表单的提交按钮等",
+    "description": "继续对话，用于表单的提交按钮等",
     "messageParam": "相关参数为：",
-    "paramDescription": "对话消息,可以是按钮文本等，也可以是其他内容"
+    "paramDescription": "对话消息，可以是按钮文本等，也可以是其他内容"
   },
   "saveState": {
-    "description": "保存状态， 用于保存组件状态"
+    "description": "保存状态，用于保存组件状态"
   },
   "toolCall": {
     "context": "工具名称：{toolName}，工具参数：{toolParams}，工具结果：{toolResult}"

--- a/packages/frameworks/vue/src/chat/i18n/zh.json
+++ b/packages/frameworks/vue/src/chat/i18n/zh.json
@@ -28,9 +28,12 @@
     "newConversation": "新会话"
   },
   "continueChat": {
-    "description": "继续对话， 框用于表单的提交按钮等",
+    "description": "继续对话， 用于表单的提交按钮等",
     "messageParam": "相关参数为：",
     "paramDescription": "对话消息,可以是按钮文本等，也可以是其他内容"
+  },
+  "saveState": {
+    "description": "保存状态， 用于保存组件状态"
   },
   "toolCall": {
     "context": "工具名称：{toolName}，工具参数：{toolParams}，工具结果：{toolResult}"

--- a/sites/playground/web/src/components/AssistantFooter.vue
+++ b/sites/playground/web/src/components/AssistantFooter.vue
@@ -88,7 +88,7 @@ const { markGenerateMore, revertGenerateMore } = useGenerateMore(props.messageMa
       @click="copyContent"
     >
     </tiny-button>
-    <FinishInfo style="margin-left: 8px;" :data="props.chatMessage.finishInfo" />
+    <FinishInfo style="margin-left: 8px;" :chat-message="props.chatMessage" />
     <tiny-button
       v-if="notFinished"
       :reset-time="0"

--- a/sites/playground/web/src/components/FinishInfo.vue
+++ b/sites/playground/web/src/components/FinishInfo.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
+import type { IChatMessage } from '@opentiny/genui-sdk-core';
 import { computed } from 'vue';
 import { TinyPopover, TinyButton } from '@opentiny/vue';
 import { iconInfoCircle } from '@opentiny/vue-icon';
 import { vFocusHoverSync } from './v-focus-hover-sync';
 
 const InfoIcon = iconInfoCircle();
-
 
 export interface ChatCompletionFinishChunk {
   object?: string;
@@ -24,15 +24,19 @@ export interface ChatCompletionFinishChunk {
 }
 
 const props = defineProps<{
-  data: ChatCompletionFinishChunk | null | undefined;
+  chatMessage: IChatMessage;
 }>();
 
-const usage = computed(() => props.data?.usage);
+const finishChunk = computed(
+  () => props.chatMessage.finishInfo as ChatCompletionFinishChunk | null | undefined,
+);
 
-const finishReason = computed(() => props.data?.choices?.[0]?.finish_reason ?? undefined);
+const usage = computed(() => finishChunk.value?.usage);
+
+const finishReason = computed(() => finishChunk.value?.choices?.[0]?.finish_reason ?? undefined);
 
 const createdLabel = computed(() => {
-  const t = props.data?.created;
+  const t = finishChunk.value?.created;
   if (t == null) return '';
   const ms = t < 1e12 ? t * 1000 : t;
   const d = new Date(ms);
@@ -42,11 +46,19 @@ const createdLabel = computed(() => {
 function formatInt(n: number) {
   return n.toLocaleString();
 }
+
+const titleContent = computed(() => {
+  const base = '对话信息';
+  if (props.chatMessage['originChatMessage'] !== undefined) {
+    return `${base}（含多次生成，仅统计最后一次生成）`;
+  }
+  return base;
+});
 </script>
 
 <template>
   <tiny-popover
-    v-if="data"
+    v-if="finishChunk"
     trigger="hover"
     placement="bottom-start"
     width="auto"
@@ -55,17 +67,17 @@ function formatInt(n: number) {
   >
     <template #default>
       <div class="finish-statistic-panel">
-        <div class="panel-title">对话信息</div>
+        <div class="panel-title">{{ titleContent }}</div>
         <dl class="stat-list">
-          <div v-if="data.model" class="stat-row">
+          <div v-if="finishChunk.model" class="stat-row">
             <dt>模型</dt>
-            <dd>{{ data.model }}</dd>
+            <dd>{{ finishChunk.model }}</dd>
           </div>
           <div v-if="finishReason != null && finishReason !== ''" class="stat-row">
             <dt>结束原因</dt>
             <dd>{{ finishReason }}</dd>
           </div>
-          <div v-if="data.created != null" class="stat-row">
+          <div v-if="finishChunk.created != null" class="stat-row">
             <dt>时间</dt>
             <dd>{{ createdLabel }}</dd>
           </div>


### PR DESCRIPTION
1、优化自定义actions的描述和国际化
2、在含有originChatMessage的情况下，统计信息标题添加仅最后一轮的提示

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localization**
  * Added English and Chinese text for a new "save state" feature and fixed a minor Chinese punctuation/spacing issue.

* **Improvements**
  * Enhanced chat details panel to show clearer context when messages have multiple generations, noting that usage/stats reflect only the latest generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->