### PR TITLE
fix(genui-sdk-vue): reasoning context and height limit and background-clip: text add fallback color

### DIFF
--- a/packages/frameworks/vue/src/chat/GeneratingComponent.vue
+++ b/packages/frameworks/vue/src/chat/GeneratingComponent.vue
@@ -57,17 +57,36 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <div v-if="loadingText" class="loading-container" type="loading-text">{{ loadingText }}</div>
+  <div v-if="loadingText" class="loading-wrapper">
+    <div  class="loading-container" type="loading-text">{{ loadingText }}</div>
+  </div>
 </template>
 <style scoped lang="less">
+.loading-wrapper {
+  width: fit-content;
+  max-width: 100%;
+  overflow: hidden;
+  direction: rtl;
+}
 .loading-container[type='loading-text'] {
   margin: 10px 0;
-  background: linear-gradient(90deg, #666 0%, #666 45%, #999 50%, #999 55%, #666 60%, #666 100%);
-  background-size: 200% 100%;
-  -webkit-background-clip: text;
-  background-clip: text;
-  -webkit-text-fill-color: transparent;
-  animation: text-shimmer 6s linear infinite;
+  color: #666;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  direction: ltr;
+  display: inline-block;
+}
+
+@supports ((background-clip: text)) {
+  .loading-container[type='loading-text'] {
+    background: linear-gradient(90deg, #666 0%, #666 45%, #999 50%, #999 55%, #666 60%, #666 100%);
+    background-size: 200% 100%;
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    animation: text-shimmer 6s linear infinite;
+  }
 }
 
 @keyframes text-shimmer {

--- a/packages/frameworks/vue/src/chat/renderer/ReasoningRenderer.vue
+++ b/packages/frameworks/vue/src/chat/renderer/ReasoningRenderer.vue
@@ -120,6 +120,8 @@ const MarkdownContent = (markdownProps: { content: string }) =>
   font-size: 14px;
 
   .detail-content {
+    max-height: 300px;
+    overflow-y: auto;
     > *:first-child {
       margin-top: 0;
     }

--- a/sites/homepage/web/src/views/home.vue
+++ b/sites/homepage/web/src/views/home.vue
@@ -237,15 +237,20 @@ const { isMobile } = useMobile();
       line-height: var(--line-height-title-lg);
       font-weight: 700;
       text-align: left;
-      background-clip: text;
-      -webkit-background-clip: text;
-      -webkit-text-fill-color: transparent;
-      background: linear-gradient(90deg, rgba(188, 67, 203, 1), rgba(14, 112, 255, 1) 92%);
-      background-clip: text;
+      color: rgba(14, 112, 255, 1);
       margin-bottom: 26px;
       white-space: nowrap;
       animation: slideUpFromBottom 1.2s cubic-bezier(0.16, 1, 0.3, 1) 0.28s forwards;
       opacity: 0;
+    }
+
+    @supports ((background-clip: text)) {
+      .home-core-subtitle {
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
+        background: linear-gradient(90deg, rgba(188, 67, 203, 1), rgba(14, 112, 255, 1) 92%);
+        background-clip: text;
+      }
     }
 
     &-decsription {


### PR DESCRIPTION
1、思考内容增加高度限制和滚动条
2、  showThinkingResult 为false时，仅展示单行文本
3、渐变文字增加兜底策略，不支持时显示纯色


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Improved loading text display with enhanced overflow handling and text truncation
  * Added scrolling support to reasoning detail content for better readability
  * Enhanced subtitle styling with gradient effects and automatic browser compatibility fallbacks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->