### PR TITLE
chore(homepage): update @opentiny/genui-sdk-vue to version 1.1.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -659,8 +659,8 @@ importers:
   sites/homepage/web:
     dependencies:
       '@opentiny/genui-sdk-vue':
-        specifier: 1.0.0
-        version: 1.0.0(@opentiny/vue-renderless@3.28.2)(typescript@5.9.3)(vite@7.3.0(@types/node@17.0.45)(less@4.5.1)(sass@1.97.1)(terser@5.44.1)(tsx@4.21.0))
+        specifier: 1.1.0
+        version: 1.1.0(typescript@5.9.3)(vite@7.3.0(@types/node@17.0.45)(less@4.5.1)(sass@1.97.1)(terser@5.44.1)(tsx@4.21.0))
       '@opentiny/vue':
         specifier: ~3.28.0
         version: 3.28.0
@@ -2511,8 +2511,8 @@ packages:
   '@opentiny/fluent-editor@3.25.6':
     resolution: {integrity: sha512-RHXb7JKKWntia7HM/yJAQQYFWZz+3Ieq65FHhJNhrkLy3Quv/SQb46YbpHhVmJGlDkUHBxLZe3/GrwCpn/0XVw==}
 
-  '@opentiny/genui-sdk-vue@1.0.0':
-    resolution: {integrity: sha512-8yYf4pg5Z2wDUqA5ig32jgX3van73BOi8p/cZ/eIkuik8BrLIj+NMCn0NRUTi9YZuaiDU6LtZ7NaNUNzbdsQUA==}
+  '@opentiny/genui-sdk-vue@1.1.0':
+    resolution: {integrity: sha512-08H0fc274qlW6LmrzdNyBhjv92vjGiKlOahrwBOCM54wWPSD2dDJhX6aBxyz4nrWE3vZ/ifYwW6USDWZTW6f2g==}
 
   '@opentiny/ng-accordion@1.0.3':
     resolution: {integrity: sha512-45v5Is3bF+SVjQhCu7StEfHAvAR5oZLjQXoYds1KRzLZk7u6EyOikW5m4XKmi8/8vplU+NlCQZZ5/5jh2HZBPQ==}
@@ -11145,7 +11145,7 @@ snapshots:
       lodash-es: 4.17.22
       quill: 2.0.3
 
-  '@opentiny/genui-sdk-vue@1.0.0(@opentiny/vue-renderless@3.28.2)(typescript@5.9.3)(vite@7.3.0(@types/node@17.0.45)(less@4.5.1)(sass@1.97.1)(terser@5.44.1)(tsx@4.21.0))':
+  '@opentiny/genui-sdk-vue@1.1.0(typescript@5.9.3)(vite@7.3.0(@types/node@17.0.45)(less@4.5.1)(sass@1.97.1)(terser@5.44.1)(tsx@4.21.0))':
     dependencies:
       '@opentiny/tiny-engine-builtin-component': 2.9.0(@opentiny/vue-icon@3.28.3)(@opentiny/vue-renderless@3.28.2)(@opentiny/vue@3.28.0)(vite@7.3.0(@types/node@17.0.45)(less@4.5.1)(sass@1.97.1)(terser@5.44.1)(tsx@4.21.0))(vue@3.5.26(typescript@5.9.3))
       '@opentiny/tiny-robot': 0.3.3(vue@3.5.26(typescript@5.9.3))
@@ -11160,13 +11160,13 @@ snapshots:
       '@opentiny/vue-chart-radar': 3.14.0
       '@opentiny/vue-chart-ring': 3.14.0
       '@opentiny/vue-icon': 3.28.3
+      '@opentiny/vue-renderless': 3.28.2
       '@opentiny/vue-select': 3.28.0
       '@opentiny/vue-tabs': 3.28.0
       '@opentiny/vue-theme': 3.28.0
       uuid: 11.1.0
       vue: 3.5.26(typescript@5.9.3)
     transitivePeerDependencies:
-      - '@opentiny/vue-renderless'
       - debug
       - typescript
       - vite

--- a/sites/homepage/web/package.json
+++ b/sites/homepage/web/package.json
@@ -16,7 +16,7 @@
     "@opentiny/vue-button-group": "~3.28.0",
     "@opentiny/vue-button": "~3.28.0",
     "@opentiny/vue-tooltip": "~3.28.0",
-    "@opentiny/genui-sdk-vue": "1.0.0",
+    "@opentiny/genui-sdk-vue": "1.1.0",
     "highlight.js": "^11.5.1",
     "vue": "~3.4.32"
   },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated UI component library dependency to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->