### PR TITLE
fix(genui-sdk-vue): change response handler match conditions to fix error when content is null

### DIFF
--- a/packages/frameworks/vue/src/chat/response-handler.ts
+++ b/packages/frameworks/vue/src/chat/response-handler.ts
@@ -193,7 +193,7 @@ export const defaultResponseHandlers: IResponseHandler<IStreamData>[] = [
     name: 'reasoning',
     match: (data: IStreamData, context: any) => {
       const delta = getStreamDelta(data);
-      return delta.reasoning_content !== undefined;
+      return Boolean(delta.reasoning_content);
     },
     handler: (data: IStreamData, context: any) => {
       const delta = getStreamDelta(data);
@@ -247,7 +247,7 @@ export const defaultResponseHandlers: IResponseHandler<IStreamData>[] = [
     name: 'content',
     match: (data: IStreamData, context: any) => {
       const delta = getStreamDelta(data);
-      return delta.content !== undefined;
+      return Boolean(delta.content);
     },
     handler: (data: IStreamData, context: any) => {
       const delta = getStreamDelta(data);


### PR DESCRIPTION
修改match条件修复当reasoning_content返回null时的报错

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced streaming response processing in the Vue framework to correctly handle empty or falsy values when processing chat messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->