### PR TITLE
fix(homepage): hide Playground link in home.vue

### DIFF
--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -46,6 +46,7 @@ jobs:
           VITE_CHAT_URL: ${{ vars.PLAYGROUND_BACKEND_URL }}/chat-genui
           VITE_GET_MODELS_URL: ${{ vars.PLAYGROUND_BACKEND_URL }}/get-models
           VITE_CHECK_MCP_URL: ${{ vars.PLAYGROUND_BACKEND_URL }}/check-mcp
+          VITE_BUILD_MODE: github-pages
         run: node scripts/build-github-pages.mjs
 
       - name: Upload Pages artifact

--- a/sites/homepage/web/src/components/HomeLink.vue
+++ b/sites/homepage/web/src/components/HomeLink.vue
@@ -9,6 +9,8 @@ const { isMobile } = useMobile();
 const buttonSize = computed(() => {
   return isMobile.value ? 'medium' : 'large';
 });
+
+const isGithubPages = import.meta.env.VITE_BUILD_MODE === 'github-pages';
 </script>
 
 <template>
@@ -23,7 +25,7 @@ const buttonSize = computed(() => {
         <div>打造极致顺滑的智能体验</div>
       </div>
       <div class="home-link-button-group">
-        <a :href="linkMap[LinkKey.Playground]" target="_blank" class="btn-link">
+        <a v-if="isGithubPages" :href="linkMap[LinkKey.Playground]" target="_blank" class="btn-link">
           <tiny-button type="primary" :size="buttonSize" round>立即体验</tiny-button>
         </a>
         <a :href="linkMap[LinkKey.DevDoc]" target="_blank" class="btn-link">

--- a/sites/homepage/web/src/views/home.vue
+++ b/sites/homepage/web/src/views/home.vue
@@ -50,6 +50,7 @@ const { isMobile } = useMobile();
 const buttonSize = computed(() => {
   return isMobile.value ? 'default' : 'medium';
 });
+const isGithubPages = import.meta.env.VITE_BUILD_MODE === 'github-pages';
 </script>
 
 <template>
@@ -64,7 +65,7 @@ const buttonSize = computed(() => {
           <a :href="linkMap[LinkKey.DevDoc]" target="_blank" class="btn-link">
             <tiny-button :reset-time="0" round type="primary" :size="buttonSize">开发文档</tiny-button>
           </a>
-          <a :href="linkMap[LinkKey.Playground]" target="_blank" class="btn-link">
+          <a v-if="isGithubPages" :href="linkMap[LinkKey.Playground]" target="_blank" class="btn-link">
             <tiny-button :reset-time="0" round ghost :size="buttonSize">演练场</tiny-button>
           </a>
           <a href="https://github.com/opentiny/genui-sdk" target="_blank" class="btn-link">


### PR DESCRIPTION
非github-page部署隐藏演练场入口

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Playground link is now available on GitHub Pages deployment.

* **Chores**
  * Updated environment-specific build configuration for deployment targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->