### PR TITLE
ci: add VITE_CHAT_TEMPLATE_URL environment  in GitHub Pages deployment action

### DIFF
--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -46,6 +46,7 @@ jobs:
           VITE_CHAT_URL: ${{ vars.PLAYGROUND_BACKEND_URL }}/chat-genui
           VITE_GET_MODELS_URL: ${{ vars.PLAYGROUND_BACKEND_URL }}/get-models
           VITE_CHECK_MCP_URL: ${{ vars.PLAYGROUND_BACKEND_URL }}/check-mcp
+          VITE_CHAT_TEMPLATE_URL: ${{ vars.PLAYGROUND_BACKEND_URL }}/chat-template
         run: node scripts/build-github-pages.mjs
 
       - name: Upload Pages artifact


### PR DESCRIPTION
部署github-page的流水线增加VITE_CHAT_TEMPLATE_URL变量

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to support template checking operations with backend integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->