### PR TITLE
fix: template pc render

### DIFF
--- a/sites/playground/web/src/components/genui-template/GenuiTemplate.vue
+++ b/sites/playground/web/src/components/genui-template/GenuiTemplate.vue
@@ -17,7 +17,15 @@ const { isMobile } = useIsMobile();
 
 const TinyCloseIcon = iconClose();
 
-const { currentSchema, setCurrentSchema, setCurrentPreviewSchema, currentPreviewSchema, templateConversationState, conversation, currentCardId } = useTemplate();
+const {
+  currentSchema,
+  setCurrentSchema,
+  setCurrentPreviewSchema,
+  currentPreviewSchema,
+  templateConversationState,
+  conversation,
+  currentCardId,
+} = useTemplate();
 const props = defineProps<{
   theme: 'light' | 'dark' | 'lite' | 'auto';
 }>();
@@ -48,7 +56,9 @@ const latestSchemaCardId = computed(() => {
   return schemaMessage?.cardId ?? '';
 });
 // 仅当正在查看历史版本时显示“返回最新版本/应用此版本”
-const showReturnLatestButton = computed(() => Boolean(currentCardId.value && latestSchemaCardId.value && currentCardId.value !== latestSchemaCardId.value));
+const showReturnLatestButton = computed(() =>
+  Boolean(currentCardId.value && latestSchemaCardId.value && currentCardId.value !== latestSchemaCardId.value),
+);
 // 历史版本在未“应用此版本”前禁止编辑
 const isHistoryVersionApplied = ref(true);
 const isSchemaEditorReadonly = computed(() => showReturnLatestButton.value && !isHistoryVersionApplied.value);
@@ -266,22 +276,38 @@ onUnmounted(() => {
       <div class="schema-version-container" v-show="schemaEditorVisible && !isMobile">
         <div class="schema-version-container__header">
           <span class="schema-version-container__title">查看 Schema</span>
-          <tiny-button type="text" class="genui-schema-toolbar-close-btn" :icon="TinyCloseIcon" aria-label="关闭"
-            @click="closeSchemaEditorView" />
+          <tiny-button
+            type="text"
+            class="genui-schema-toolbar-close-btn"
+            :icon="TinyCloseIcon"
+            aria-label="关闭"
+            @click="closeSchemaEditorView"
+          />
         </div>
         <div class="schema-version-container__editor">
           <code-editor v-model:value="schemaEditor" language="json" theme="vs" :options="editorOptions" />
         </div>
       </div>
     </div>
-    <genui-template-mobile-sheet v-if="isMobile" :visible="isMobile && schemaEditorVisible"
-      :json-editor-open="mobileSchemaJsonEditorOpen" :panel-style="mobileSheetPanelStyle"
-      :show-return-latest-button="showReturnLatestButton" :current-preview-schema="currentPreviewSchema"
-      :schema-editor="schemaEditor" :editor-options="editorOptions" :view-schema-icon="viewSchemaIcon"
-      :close-icon="TinyCloseIcon" @update:json-editor-open="mobileSchemaJsonEditorOpen = $event"
-      @update:schema-editor="schemaEditor = $event" @mask-click="onMobileSheetMaskClick"
-      @grab-touch-start="onMobileSheetGrabTouchStart" @close="closeSchemaEditorView"
-      @apply-current-version="applyCurrentVersion" @reset-to-latest-version="resetToLatestVersion" />
+    <genui-template-mobile-sheet
+      v-if="isMobile"
+      :visible="isMobile && schemaEditorVisible"
+      :json-editor-open="mobileSchemaJsonEditorOpen"
+      :panel-style="mobileSheetPanelStyle"
+      :show-return-latest-button="showReturnLatestButton"
+      :current-preview-schema="currentPreviewSchema"
+      :schema-editor="schemaEditor"
+      :editor-options="editorOptions"
+      :view-schema-icon="viewSchemaIcon"
+      :close-icon="TinyCloseIcon"
+      @update:json-editor-open="mobileSchemaJsonEditorOpen = $event"
+      @update:schema-editor="schemaEditor = $event"
+      @mask-click="onMobileSheetMaskClick"
+      @grab-touch-start="onMobileSheetGrabTouchStart"
+      @close="closeSchemaEditorView"
+      @apply-current-version="applyCurrentVersion"
+      @reset-to-latest-version="resetToLatestVersion"
+    />
     <template v-else>
       <div class="genui-schema-template-item renderer-container" v-if="currentSchema && rendererPanelVisible">
         <div class="renderer-container-wrapper">
@@ -292,10 +318,16 @@ onUnmounted(() => {
             </button>
             <div class="top-button-group-right">
               <tiny-button v-if="showReturnLatestButton" round @click="resetToLatestVersion">返回最新版本</tiny-button>
-              <tiny-button v-if="showReturnLatestButton" type="primary" round
-                @click="applyCurrentVersion">应用此版本</tiny-button>
-              <tiny-button type="text" class="genui-schema-toolbar-close-btn" :icon="TinyCloseIcon" aria-label="关闭预览区"
-                @click="closeRendererPanel" />
+              <tiny-button v-if="showReturnLatestButton" type="primary" round @click="applyCurrentVersion">
+                应用此版本
+              </tiny-button>
+              <tiny-button
+                type="text"
+                class="genui-schema-toolbar-close-btn"
+                :icon="TinyCloseIcon"
+                aria-label="关闭预览区"
+                @click="closeRendererPanel"
+              />
             </div>
           </div>
           <schema-renderer class="schema-renderer" :content="currentPreviewSchema" :generating="false" />
@@ -414,7 +446,6 @@ onUnmounted(() => {
     }
   }
 }
-
 
 .genui-template-chat {
   width: 100%;

--- a/sites/playground/web/src/components/genui-template/GenuiTemplate.vue
+++ b/sites/playground/web/src/components/genui-template/GenuiTemplate.vue
@@ -372,7 +372,6 @@ onUnmounted(() => {
       min-height: 0;
       display: flex;
       flex-direction: column;
-      text-align: center;
       position: relative;
 
       .top-button-group {

--- a/sites/playground/web/src/components/genui-template/GenuiTemplate.vue
+++ b/sites/playground/web/src/components/genui-template/GenuiTemplate.vue
@@ -309,7 +309,7 @@ onUnmounted(() => {
       @reset-to-latest-version="resetToLatestVersion"
     />
     <template v-else>
-      <div class="genui-schema-template-item renderer-container" v-if="currentSchema && rendererPanelVisible">
+      <div class="genui-schema-template-item renderer-container" v-if="currentPreviewSchema && rendererPanelVisible">
         <div class="renderer-container-wrapper">
           <div class="top-button-group">
             <button type="button" class="schema-toggle-text" @click="toggleSchemaEditor">
@@ -317,8 +317,8 @@ onUnmounted(() => {
               查看 JSON
             </button>
             <div class="top-button-group-right">
-              <tiny-button v-if="showReturnLatestButton" round @click="resetToLatestVersion">返回最新版本</tiny-button>
-              <tiny-button v-if="showReturnLatestButton" type="primary" round @click="applyCurrentVersion">
+              <tiny-button v-if="showReturnLatestButton" type="primary" round @click="resetToLatestVersion">返回最新版本</tiny-button>
+              <tiny-button v-if="showReturnLatestButton" round @click="applyCurrentVersion">
                 应用此版本
               </tiny-button>
               <tiny-button

--- a/sites/playground/web/src/components/genui-template/GenuiTemplateChat.vue
+++ b/sites/playground/web/src/components/genui-template/GenuiTemplateChat.vue
@@ -141,7 +141,6 @@ const schemaCardRenderer = async (props: any) => {
     // 给每个组件添加 id
     const schemaWithId = generateIdForComponents(target);
     setCurrentPreviewSchema(schemaWithId);
-
   } catch (error) {
     console.error('schemaCardRenderer error ===>', error);
     errorMessagesMap.value.set(props.cardId, error.message);
@@ -261,7 +260,8 @@ const messageRenderers = {
       prevSchema: prevSchema.value,
       errorMessagesMap: errorMessagesMap.value,
       messages: messages.value,
-      onSchemaVersionToggle: (schema: Record<string, unknown>, cardId: string) => emit('schema-version-toggle', schema, cardId),
+      onSchemaVersionToggle: (schema: Record<string, unknown>, cardId: string) =>
+        emit('schema-version-toggle', schema, cardId),
     });
   },
   'schema-card': (props) => {
@@ -273,7 +273,8 @@ const messageRenderers = {
       prevSchema: prevSchema.value,
       errorMessagesMap: errorMessagesMap.value,
       messages: messages.value,
-      onSchemaVersionToggle: (schema: Record<string, unknown>, cardId: string) => emit('schema-version-toggle', schema, cardId),
+      onSchemaVersionToggle: (schema: Record<string, unknown>, cardId: string) =>
+        emit('schema-version-toggle', schema, cardId),
     });
   },
 };
@@ -399,21 +400,45 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div class="tg-chat-container" :class="{ 'dark': TinyGenuiConfig?.theme === 'dark' }">
-    <div class="messages-container" ref="messagesContainer">
+  <div
+    class="tg-chat-container"
+    :class="{ 'dark': TinyGenuiConfig?.theme === 'dark' }"
+  >
+    <div
+      class="messages-container"
+      ref="messagesContainer"
+    >
       <tr-bubble-provider :content-renderers="messageRenderers">
-        <tr-bubble-list v-if="showMessages.length" :items="showMessages" :roles="roles" auto-scroll> </tr-bubble-list>
+        <tr-bubble-list
+          v-if="showMessages.length"
+          :items="showMessages"
+          :roles="roles"
+          auto-scroll
+        >
+        </tr-bubble-list>
       </tr-bubble-provider>
     </div>
     <div class="sender-container">
-      <div :class="['scroll-to-bottom-button', { 'is-generating': generating }]" v-show="!isLastMessageInBottom"
-        @click="scrollToBottom">
+      <div
+        :class="['scroll-to-bottom-button', { 'is-generating': generating }]"
+        v-show="!isLastMessageInBottom"
+        @click="scrollToBottom"
+      >
         <IconArrowDown class="icon-arrow-down" />
       </div>
-      <tr-sender v-model="inputMessage"
-        :placeholder="GeneratingStatus.includes(messageManager.messageState.status) ? '正在思考中...' : '请输入您的问题～'"
-        :clearable="true" :loading="GeneratingStatus.includes(messageManager.messageState.status)" :showWordLimit="true"
-        :maxLength="5000" @clear="clearInputMessage" @submit="handleSendMessage" @cancel="messageManager.abortRequest">
+      <tr-sender
+        v-model="inputMessage"
+        :placeholder="
+          GeneratingStatus.includes(messageManager.messageState.status) ? '正在思考中...' : '请输入您的问题～'
+        "
+        :clearable="true"
+        :loading="GeneratingStatus.includes(messageManager.messageState.status)"
+        :showWordLimit="true"
+        :maxLength="5000"
+        @clear="clearInputMessage"
+        @submit="handleSendMessage"
+        @cancel="messageManager.abortRequest"
+      >
       </tr-sender>
     </div>
   </div>
@@ -464,15 +489,14 @@ onUnmounted(() => {
 }
 
 :deep(.tr-bubble[data-role='assistant'] .tr-bubble__content-items) {
-
   // 匹配：type非空 + 排除 schema-card/loading-text 这两个值
-  >[type]:not([type='']):not([type='schema-card']):not([type='loading-text']) {
+  > [type]:not([type='']):not([type='schema-card']):not([type='loading-text']) {
     display: var(--thinking-display, initial);
   }
 }
 
 :deep(.tr-bubble__step-tool) {
-  &+.tr-bubble__step-tool {
+  & + .tr-bubble__step-tool {
     margin-top: 16px;
   }
 }
@@ -531,13 +555,15 @@ onUnmounted(() => {
   border: 1px solid var(--sender-border-color);
   z-index: 1000;
 
-  &>svg {
+  & > svg {
     width: 20px;
     height: 20px;
   }
 
   &:hover {
-    box-shadow: 0px 10px 20px 0px #0000001a, 0px 0px 1px 0px #00000026;
+    box-shadow:
+      0px 10px 20px 0px #0000001a,
+      0px 0px 1px 0px #00000026;
   }
 
   &.is-generating {
@@ -571,7 +597,7 @@ onUnmounted(() => {
       z-index: 1;
     }
 
-    &>svg {
+    & > svg {
       z-index: 2;
     }
   }

--- a/sites/playground/web/src/components/genui-template/GenuiTemplateChat.vue
+++ b/sites/playground/web/src/components/genui-template/GenuiTemplateChat.vue
@@ -16,7 +16,7 @@ import { GeneratingStatus, STATUS } from '@opentiny/tiny-robot-kit';
 import type { ChatMessage } from '@opentiny/tiny-robot-kit';
 import { IconAi, IconUser, IconArrowDown } from '@opentiny/tiny-robot-svgs';
 import type { BubbleRoleConfig } from '@opentiny/tiny-robot';
-import { requiredCompleteFieldSelectors, scrollEnd, throttle } from '@opentiny/genui-sdk-vue';
+import { requiredCompleteFieldSelectors, scrollEnd, throttle, GENUI_CONFIG } from '@opentiny/genui-sdk-vue';
 import type { IMessage } from '@opentiny/genui-sdk-vue';
 import copy from 'clipboard-copy';
 import type { INotificationPayload, IMessageItem, IJsonPatchMessageItem, ISchemaCardMessageItem } from './chat.types';
@@ -45,7 +45,7 @@ const props = defineProps<{
 
 const emit = defineEmits(['schema-version-toggle']);
 
-const TinyGenuiConfig: any = inject('TinyGenuiConfig');
+const TinyGenuiConfig: any = inject(GENUI_CONFIG, null);
 const { setColorMode } = useTheme();
 const prevSchema = ref<string>('');
 const errorMessagesMap = ref<Map<string, string>>(new Map());

--- a/sites/playground/web/src/components/genui-template/GenuiTemplateChat.vue
+++ b/sites/playground/web/src/components/genui-template/GenuiTemplateChat.vue
@@ -37,7 +37,7 @@ import { emitter } from './template-chat-event-emitter';
 import useIcon from '../../use-icon';
 
 const { addIcons } = useIcon();
-addIcons(IconAi, IconUser);
+addIcons(IconAi, IconUser, IconArrowDown);
 
 const props = defineProps<{
   messages?: IMessage[];
@@ -448,6 +448,10 @@ onUnmounted(() => {
 .tg-chat-container {
   --ti-gen-chat-container-bg-color: #f0f0f0;
   --thinking-display: initial;
+  --sender-bg: url('./assets/sender-light.svg') no-repeat center;
+  --sender-border-color: #e5e5e5;
+  --generating-bg-before: linear-gradient(90deg, #fff, #a2c7f4);
+  --generating-bg-after: #fff;
   box-sizing: border-box;
   height: 100%;
   color: var(--tr-text-primary);
@@ -456,9 +460,12 @@ onUnmounted(() => {
   display: flex;
   flex-direction: column;
   overflow: auto;
-
   &.dark {
     --ti-gen-chat-container-bg-color: #191919;
+    --sender-bg: url('./assets/sender-dark.svg') no-repeat center;
+    --sender-border-color: #333;
+    --generating-bg-before: linear-gradient(90deg, #262626, #808080);
+    --generating-bg-after: #191919;
   }
 }
 

--- a/sites/playground/web/src/components/genui-template/GenuiTemplateMobileSheet.vue
+++ b/sites/playground/web/src/components/genui-template/GenuiTemplateMobileSheet.vue
@@ -75,10 +75,7 @@ const handleJsonEditorChange = (value: string) => {
             </div>
           </div>
           <div
-            :class="[
-              'schema-mobile-sheet__body',
-              { 'schema-mobile-sheet__body--with-footer': showReturnLatestButton },
-            ]"
+            :class="['schema-mobile-sheet__body', { 'schema-mobile-sheet__body--with-footer': showReturnLatestButton }]"
           >
             <div
               v-if="currentPreviewSchema"
@@ -92,10 +89,7 @@ const handleJsonEditorChange = (value: string) => {
               />
             </div>
             <Transition name="schema-mobile-json">
-              <div
-                v-show="jsonEditorOpen"
-                class="schema-mobile-sheet__editor schema-mobile-sheet__editor--layer"
-              >
+              <div v-show="jsonEditorOpen" class="schema-mobile-sheet__editor schema-mobile-sheet__editor--layer">
                 <code-editor
                   :value="schemaEditor"
                   language="json"
@@ -107,15 +101,11 @@ const handleJsonEditorChange = (value: string) => {
             </Transition>
           </div>
           <div v-if="showReturnLatestButton" class="schema-mobile-sheet__footer">
-            <tiny-button
-              type="primary"
-              round
-              class="schema-mobile-sheet__latest-btn"
-              @click="emit('apply-current-version')"
-            >
+            <tiny-button round class="schema-mobile-sheet__latest-btn" @click="emit('apply-current-version')">
               应用此版本
             </tiny-button>
             <tiny-button
+              type="primary"
               round
               class="schema-mobile-sheet__latest-btn"
               @click="emit('reset-to-latest-version')"
@@ -351,7 +341,9 @@ const handleJsonEditorChange = (value: string) => {
 
 .schema-mobile-json-enter-active,
 .schema-mobile-json-leave-active {
-  transition: opacity 0.2s ease, transform 0.22s ease;
+  transition:
+    opacity 0.2s ease,
+    transform 0.22s ease;
 }
 
 .schema-mobile-json-enter-from,

--- a/sites/playground/web/src/components/genui-template/SchemaVersionCard.vue
+++ b/sites/playground/web/src/components/genui-template/SchemaVersionCard.vue
@@ -57,17 +57,10 @@ const handleDev = () => {
 </script>
 
 <template>
-  <div
-    class="schema-version-card"
-    @click="handleClick"
-  >
+  <div :class="['schema-version-card', isMobile ? 'is-mobile' : '']" @click="handleClick">
     <div class="schema-version-card-main">
       <div class="schema-version-card-icon">
-        <img
-          :src="docIcon"
-          alt="schema card"
-          class="schema-version-card-icon-image"
-        />
+        <img :src="docIcon" alt="schema card" class="schema-version-card-icon-image" />
       </div>
       <div class="schema-version-card-content">
         <div class="schema-version-card-content-title">
@@ -80,24 +73,12 @@ const handleDev = () => {
       </div>
     </div>
     <div class="schema-version-card-footer">
-      <div
-        v-if="isDev && props.type === 'json-patch' && !generating && !isMobile"
-        class="icons-wrap"
-      >
-        <div
-          class="icon-item"
-          title="调试 jsonPatch"
-          @click.stop="handleDev"
-        >
+      <div v-if="isDev && props.type === 'json-patch' && !generating && !isMobile" class="icons-wrap">
+        <div class="icon-item" title="调试 jsonPatch" @click.stop="handleDev">
           <TinyIconRichTextCodeView />
         </div>
       </div>
-      <div
-        v-if="errorMessage"
-        class="error-message"
-      >
-        解析失败
-      </div>
+      <div v-if="errorMessage" class="error-message">解析失败</div>
     </div>
   </div>
   <JsonPatchDev
@@ -110,8 +91,8 @@ const handleDev = () => {
 
 <style scoped lang="less">
 .schema-version-card {
-  width: 100%;
-  max-width: 300px;
+  width: 330px;
+  max-width: 330px;
   box-sizing: border-box;
   border-radius: 12px;
   position: relative;
@@ -120,6 +101,11 @@ const handleDev = () => {
   display: flex;
   flex-direction: column;
   padding: 16px;
+
+  &.is-mobile {
+    width: 100%;
+    max-width: 300px;
+  }
 
   &-main {
     display: flex;

--- a/sites/playground/web/src/components/genui-template/SchemaVersionCard.vue
+++ b/sites/playground/web/src/components/genui-template/SchemaVersionCard.vue
@@ -29,7 +29,7 @@ const { getMessageByCardId } = useTemplate();
 const generatedTime = computed(() => props.generatedTime ?? '');
 const generating = computed(() => !generatedTime.value);
 
-const docIcon = computed(() => props.type === 'schema-card' ? docCardIcon : docEditIcon);
+const docIcon = computed(() => (props.type === 'schema-card' ? docCardIcon : docEditIcon));
 
 // 判断当前为开发环境
 const isDev = import.meta.env.MODE === 'development';
@@ -57,10 +57,17 @@ const handleDev = () => {
 </script>
 
 <template>
-  <div class="schema-version-card" @click="handleClick">
+  <div
+    class="schema-version-card"
+    @click="handleClick"
+  >
     <div class="schema-version-card-main">
       <div class="schema-version-card-icon">
-        <img :src="docIcon" alt="schema card" class="schema-version-card-icon-image" />
+        <img
+          :src="docIcon"
+          alt="schema card"
+          class="schema-version-card-icon-image"
+        />
       </div>
       <div class="schema-version-card-content">
         <div class="schema-version-card-content-title">
@@ -73,16 +80,32 @@ const handleDev = () => {
       </div>
     </div>
     <div class="schema-version-card-footer">
-      <div v-if="isDev && props.type === 'json-patch' && !generating && !isMobile" class="icons-wrap">
-        <div class="icon-item" title="调试 jsonPatch" @click.stop="handleDev">
+      <div
+        v-if="isDev && props.type === 'json-patch' && !generating && !isMobile"
+        class="icons-wrap"
+      >
+        <div
+          class="icon-item"
+          title="调试 jsonPatch"
+          @click.stop="handleDev"
+        >
           <TinyIconRichTextCodeView />
         </div>
       </div>
-      <div v-if="errorMessage" class="error-message">解析失败</div>
+      <div
+        v-if="errorMessage"
+        class="error-message"
+      >
+        解析失败
+      </div>
     </div>
   </div>
-  <JsonPatchDev v-model:visible="visible" :currentSchema="currentSchema" :jsonPatch="jsonPatch"
-    :prevSchema="prevSchema" />
+  <JsonPatchDev
+    v-model:visible="visible"
+    :currentSchema="currentSchema"
+    :jsonPatch="jsonPatch"
+    :prevSchema="prevSchema"
+  />
 </template>
 
 <style scoped lang="less">

--- a/sites/playground/web/src/components/genui-template/TemplateSchemaMessageRenderer.vue
+++ b/sites/playground/web/src/components/genui-template/TemplateSchemaMessageRenderer.vue
@@ -4,6 +4,7 @@ import { GenuiRenderer } from '@opentiny/genui-sdk-vue';
 import type { IMessageItem, IJsonPatchMessageItem, ISchemaCardMessageItem } from './chat.types';
 import { jsonPatchDeduplicator } from './json-patch-deduplicator';
 import SchemaVersionCard from './SchemaVersionCard.vue';
+import { useIsMobile } from '../../use-mobile';
 
 const props = defineProps<{
   itemProps: any;
@@ -16,6 +17,8 @@ const props = defineProps<{
 const emit = defineEmits<{
   (event: 'schema-version-toggle', schema: Record<string, unknown>, cardId: string): void;
 }>();
+
+const { isMobile } = useIsMobile();
 
 const generating = computed(() => !props.itemProps?.generatedTime);
 
@@ -58,7 +61,7 @@ const handleSchemaVersionCardClick = (cardId: string) => {
 </script>
 
 <template>
-  <div v-if="generating">
+  <div v-if="generating && isMobile">
     <genui-renderer v-bind="genuiRendererProps" />
   </div>
   <schema-version-card


### PR DESCRIPTION
1. 修复 pc 端模板生成过程，还原为在右侧渲染；
2. 修改“应用此版本”、“还原到最新版本”按钮类型；
3. 格式化 sfc - template 中多属性换行；
4. 修复展开更多图标显示问题。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved template/layout formatting across template components for maintainability.

* **Style**
  * Updated card sizing, mobile layout behavior, CSS variables, and transition/selector formatting for consistent visuals.
  * Minor adjustment that may change alignment in template items.

* **Bug Fixes**
  * Fixed preview panel visibility so previews appear under the correct conditions.
  * Adjusted the "Apply this version" button styling which may alter its appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->