### PR TITLE
feat(playground): move template current schema to user messages, add assistant message to conversation context

### DIFF
--- a/sites/playground/server/src/chat-template.ts
+++ b/sites/playground/server/src/chat-template.ts
@@ -124,7 +124,14 @@ export const createChatTemplate = () => {
           \`\`\`
           `;
         if (messages.length > 0 && messages[messages.length - 1].role === 'user') {
-          messages[messages.length - 1].content += schemaJsonContext;
+          if (Array.isArray(messages[messages.length - 1].content)) {
+            messages[messages.length - 1].content.push({
+              type: 'text',
+              text: schemaJsonContext,
+            });
+          } else {
+            messages[messages.length - 1].content += schemaJsonContext;
+          }
         } else {
           messages.push({
             role: 'user',

--- a/sites/playground/server/src/chat-template.ts
+++ b/sites/playground/server/src/chat-template.ts
@@ -114,11 +114,29 @@ export const createChatTemplate = () => {
       ${body.templateSchema ? generateJsonPatchPrompt(body.templateSchema) : ''}
       ${specificPrompt}
       ${customSystemPrompt}`;
+
+      const messages = body.messages;
+      if (body.templateSchema) {
+        const schemaJsonContext = `
+          **当前 schemaJson（这是唯一可信的 ID 来源）：**
+          \`\`\`schemaJson
+          ${JSON.stringify(body.templateSchema, null, 2)}
+          \`\`\`
+          `;
+        if (messages.length > 0 && messages[messages.length - 1].role === 'user') {
+          messages[messages.length - 1].content += schemaJsonContext;
+        } else {
+          messages.push({
+            role: 'user',
+            content: schemaJsonContext,
+          });
+        }
+      }
       const options: StreamTextOptions = {
         model,
         temperature,
         system: systemPrompt,
-        messages: body.messages,
+        messages: messages,
         abortSignal: abort.signal,
         tools,
         toolChoice: 'auto',

--- a/sites/playground/server/src/chat-template.ts
+++ b/sites/playground/server/src/chat-template.ts
@@ -111,7 +111,7 @@ export const createChatTemplate = () => {
       );
       const maxSteps = 30;
       const systemPrompt = `${genPrompt(rendererConfig, tgCustomConfig)}
-      ${body.templateSchema ? generateJsonPatchPrompt(body.templateSchema) : ''}
+      ${body.templateSchema ? generateJsonPatchPrompt() : ''}
       ${specificPrompt}
       ${customSystemPrompt}`;
 

--- a/sites/playground/server/src/json-patch-prompt.ts
+++ b/sites/playground/server/src/json-patch-prompt.ts
@@ -11,11 +11,6 @@ export const generateJsonPatchPrompt = (
 3. **如果历史消息中的 ID 与当前 schema 不匹配**：说明 schema 已经更新，必须使用当前 schema 中的新 ID
 4. **验证 ID 存在性**：在使用任何 ID 前，必须确认该 ID 在当前 schema 中存在
 
-**当前 schema（这是唯一可信的 ID 来源）：**
-\`\`\`json
-${JSON.stringify(schema, null, 2)}
-\`\`\`
-
 **重要提醒：**
 - 历史消息中的 ID 可能指向已删除或已修改的组件
 - 历史消息中的 ID 可能与当前 schema 中的组件不匹配

--- a/sites/playground/server/src/json-patch-prompt.ts
+++ b/sites/playground/server/src/json-patch-prompt.ts
@@ -1,5 +1,4 @@
 export const generateJsonPatchPrompt = (
-  schema: any,
 ) => `根据提供的 JSON schema 和修改指令，生成符合 JSON PATCH (RFC 6902) 规范的增量修改操作，使用 \`\`\`jsonPatch\`\`\` 标记包裹输出。
 
 ## ⚠️ 最重要：ID 来源规则（必须严格遵守）

--- a/sites/playground/web/src/components/genui-template/GenuiTemplateChat.vue
+++ b/sites/playground/web/src/components/genui-template/GenuiTemplateChat.vue
@@ -235,10 +235,8 @@ const handleRefresh = ({ index }: { index: number }) => {
 };
 
 const handleCopy = async ({ index }: { index: number }) => {
-  const cardMessage = getCardMessageByIndex(index);
-
   try {
-    await copy(cardMessage?.content);
+    await copy((messages.value[index]?.content as string) || '');
   } catch (error) {
     console.error('复制失败', error);
   }

--- a/sites/playground/web/src/components/genui-template/template-provider.ts
+++ b/sites/playground/web/src/components/genui-template/template-provider.ts
@@ -179,6 +179,7 @@ export class CustomModelProvider extends BaseModelProvider {
             // 模板场景暂不处理 tool_calls_result
           } else if (content !== undefined) {
             currentDelta = delta;
+            chatMessage.content += content;
             schemaJsonExtractor.handleContent(content);
           }
         } catch (e) {


### PR DESCRIPTION
提升演练场模板的对话的连续性
- 把系统提示词中当前schema移动到用户对话之后
- 将系统回复的内容添加到对话上下文，以便于后续对话理解

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming to preserve the full conversation and maintain an up-to-date assistant transcript.

* **Refactor**
  * Inject schema context into chat history as a formatted block for template processing.
  * Simplified prompt generation to exclude embedding the full schema.
  * Simplified clipboard copy to read message content directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->