### PR TITLE
fix(genui-template): update styles 

### DIFF
--- a/sites/playground/web/src/components/genui-template/GenuiTemplate.vue
+++ b/sites/playground/web/src/components/genui-template/GenuiTemplate.vue
@@ -11,6 +11,7 @@ import GenuiTemplateChat from './GenuiTemplateChat.vue';
 import GenuiTemplateMobileSheet from './GenuiTemplateMobileSheet.vue';
 import useTemplate from './useTemplate';
 import { useIsMobile } from '../../use-mobile';
+import { useMonacoPlaygroundTheme } from './use-monaco-playground-theme';
 import viewSchemaIcon from '../../assets/images/view-schema.svg';
 
 const { isMobile } = useIsMobile();
@@ -29,6 +30,8 @@ const {
 const props = defineProps<{
   theme: 'light' | 'dark' | 'lite' | 'auto';
 }>();
+
+const monacoTheme = useMonacoPlaygroundTheme(() => props.theme);
 
 // 桌面：右侧预览列是否展开（关闭后仅占聊天列；切换会话或点击版本卡片会重新展开）
 const rendererPanelVisible = ref(true);
@@ -285,7 +288,7 @@ onUnmounted(() => {
           />
         </div>
         <div class="schema-version-container__editor">
-          <code-editor v-model:value="schemaEditor" language="json" theme="vs" :options="editorOptions" />
+          <code-editor v-model:value="schemaEditor" language="json" :theme="monacoTheme" :options="editorOptions" />
         </div>
       </div>
     </div>
@@ -298,6 +301,7 @@ onUnmounted(() => {
       :current-preview-schema="currentPreviewSchema"
       :schema-editor="schemaEditor"
       :editor-options="editorOptions"
+      :playground-theme="theme"
       :view-schema-icon="viewSchemaIcon"
       :close-icon="TinyCloseIcon"
       @update:json-editor-open="mobileSchemaJsonEditorOpen = $event"

--- a/sites/playground/web/src/components/genui-template/GenuiTemplate.vue
+++ b/sites/playground/web/src/components/genui-template/GenuiTemplate.vue
@@ -367,12 +367,12 @@ onUnmounted(() => {
 
     &-wrapper {
       background-color: #ffffff;
-      border-radius: 16px;
       height: 100%;
       min-height: 0;
       display: flex;
       flex-direction: column;
       position: relative;
+      border-left: 1px solid rgb(232, 232, 232);
 
       .top-button-group {
         flex-shrink: 0;
@@ -381,7 +381,6 @@ onUnmounted(() => {
         min-height: @schema-toolbar-height;
         max-height: @schema-toolbar-height;
         border-bottom: 1px solid rgb(232, 232, 232);
-        border-left: 1px solid rgb(232, 232, 232);
         padding: 0 24px;
         display: flex;
         align-items: center;
@@ -404,11 +403,14 @@ onUnmounted(() => {
           font: inherit;
           text-align: inherit;
           color: #191919;
+          text-decoration: none;
           cursor: pointer;
           user-select: none;
 
           &:hover {
-            color: #1890ff;
+            color: #191919;
+            text-decoration: underline;
+            text-underline-offset: 2px;
           }
 
           &:focus-visible {
@@ -429,7 +431,6 @@ onUnmounted(() => {
         flex: 1;
         padding: 20px;
         overflow: auto;
-        border-left: 1px solid rgb(232, 232, 232);
         box-sizing: border-box;
       }
     }

--- a/sites/playground/web/src/components/genui-template/GenuiTemplateMobileSheet.vue
+++ b/sites/playground/web/src/components/genui-template/GenuiTemplateMobileSheet.vue
@@ -263,11 +263,18 @@ const handleJsonEditorChange = (value: string) => {
     color: #191919;
     font-size: 14px;
     line-height: 22px;
+    text-decoration: none;
     cursor: pointer;
     user-select: none;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+
+    &:hover {
+      color: #191919;
+      text-decoration: underline;
+      text-underline-offset: 2px;
+    }
 
     &:focus-visible {
       outline: 2px solid #1890ff;
@@ -287,11 +294,15 @@ const handleJsonEditorChange = (value: string) => {
     padding: 6px 4px;
     border: none;
     background: transparent;
-    font-size: 14px;
+    font-size: 16px;
     line-height: 22px;
-    color: #1890ff;
+    color: #191919;
     cursor: pointer;
     white-space: nowrap;
+
+    &:hover {
+      color: #191919;
+    }
   }
 
   &__body {

--- a/sites/playground/web/src/components/genui-template/GenuiTemplateMobileSheet.vue
+++ b/sites/playground/web/src/components/genui-template/GenuiTemplateMobileSheet.vue
@@ -3,6 +3,7 @@ import { CodeEditor } from 'monaco-editor-vue3';
 import { GenuiRenderer as SchemaRenderer } from '@opentiny/genui-sdk-vue';
 import { TinyButton } from '@opentiny/vue';
 import type { CSSProperties } from 'vue';
+import { useMonacoPlaygroundTheme, type PlaygroundColorTheme } from './use-monaco-playground-theme';
 
 const props = defineProps<{
   visible: boolean;
@@ -12,9 +13,12 @@ const props = defineProps<{
   currentPreviewSchema: Record<string, unknown> | null;
   schemaEditor: string;
   editorOptions: Record<string, unknown>;
+  playgroundTheme: PlaygroundColorTheme;
   viewSchemaIcon: string;
   closeIcon: unknown;
 }>();
+
+const monacoTheme = useMonacoPlaygroundTheme(() => props.playgroundTheme);
 
 const emit = defineEmits<{
   (event: 'update:jsonEditorOpen', value: boolean): void;
@@ -93,7 +97,7 @@ const handleJsonEditorChange = (value: string) => {
                 <code-editor
                   :value="schemaEditor"
                   language="json"
-                  theme="vs"
+                  :theme="monacoTheme"
                   :options="editorOptions"
                   @update:value="handleJsonEditorChange"
                 />

--- a/sites/playground/web/src/components/genui-template/JsonPatchDev.vue
+++ b/sites/playground/web/src/components/genui-template/JsonPatchDev.vue
@@ -2,6 +2,7 @@
 import { ref, watch } from 'vue';
 import { TinyDialogBox, TinyButton } from '@opentiny/vue';
 import { CodeEditor } from 'monaco-editor-vue3';
+import { useMonacoPlaygroundTheme } from './use-monaco-playground-theme';
 import * as jsonDiffPatch from 'jsondiffpatch';
 import * as jsonPatchFormatter from 'jsondiffpatch/formatters/jsonpatch';
 import type { JsonPatchOp } from 'jsondiffpatch/formatters/jsonpatch-apply';
@@ -14,6 +15,9 @@ const props = defineProps<{
 }>();
 
 const visible = defineModel<boolean>({ default: false });
+
+/** 在 #tiny-genui-config-provider 内，随 Provider 解析后的 theme 切换 Monaco（auto 已是 light/dark） */
+const monacoTheme = useMonacoPlaygroundTheme();
 
 const editorOptions = {
   fontSize: 14,
@@ -101,7 +105,7 @@ watch(
           class="json-patch-dev-content-editor"
           v-model:value="left"
           language="json"
-          theme="vs"
+          :theme="monacoTheme"
           :options="editorOptions"
         />
       </div>
@@ -111,7 +115,7 @@ watch(
           class="json-patch-dev-content-editor"
           v-model:value="jsonPatch"
           language="json"
-          theme="vs"
+          :theme="monacoTheme"
           :options="editorOptions"
         />
       </div>
@@ -121,7 +125,7 @@ watch(
           class="json-patch-dev-content-editor"
           v-model:value="right"
           language="json"
-          theme="vs"
+          :theme="monacoTheme"
           :options="editorOptions"
         />
       </div>

--- a/sites/playground/web/src/components/genui-template/SchemaVersionCard.vue
+++ b/sites/playground/web/src/components/genui-template/SchemaVersionCard.vue
@@ -171,11 +171,21 @@ const handleDev = () => {
     }
 
     .icon-item {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
       padding: 12px;
       text-align: right;
-      color: var(--tr-text-secondary, inherit);
+      cursor: pointer;
+      color: var(--tr-text-secondary, rgb(128, 128, 128));
+
+      :deep(svg),
+      :deep(svg path) {
+        fill: currentColor;
+      }
 
       &:hover {
+        color: var(--tr-text-primary, rgb(25, 25, 25));
         background-color: var(--tr-container-bg-default-2, #f0f0f0);
       }
     }

--- a/sites/playground/web/src/components/genui-template/SchemaVersionCard.vue
+++ b/sites/playground/web/src/components/genui-template/SchemaVersionCard.vue
@@ -97,7 +97,8 @@ const handleDev = () => {
   border-radius: 12px;
   position: relative;
   cursor: pointer;
-  background-color: #fff;
+  /* 与主 chat 助手气泡等内容区一致（由 GenuiConfigProvider / ThemeProvider 注入 --tr-*） */
+  background-color: var(--tr-bubble-content-bg, #fff);
   display: flex;
   flex-direction: column;
   padding: 16px;
@@ -137,7 +138,7 @@ const handleDev = () => {
       font-size: 14px;
       font-weight: 600;
       line-height: 22px;
-      color: rgb(25, 25, 25);
+      color: var(--tr-text-primary, rgb(25, 25, 25));
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
@@ -146,7 +147,7 @@ const handleDev = () => {
     &-time {
       font-size: 12px;
       line-height: 18px;
-      color: rgb(128, 128, 128);
+      color: var(--tr-text-secondary, rgb(128, 128, 128));
     }
   }
 
@@ -172,9 +173,10 @@ const handleDev = () => {
     .icon-item {
       padding: 12px;
       text-align: right;
+      color: var(--tr-text-secondary, inherit);
 
       &:hover {
-        background-color: #f0f0f0;
+        background-color: var(--tr-container-bg-default-2, #f0f0f0);
       }
     }
   }

--- a/sites/playground/web/src/components/genui-template/use-monaco-playground-theme.ts
+++ b/sites/playground/web/src/components/genui-template/use-monaco-playground-theme.ts
@@ -1,0 +1,39 @@
+import { computed, inject, onMounted, onUnmounted, ref, type ComputedRef } from 'vue';
+import { GENUI_CONFIG } from '@opentiny/genui-sdk-vue';
+
+export type PlaygroundColorTheme = 'light' | 'dark' | 'lite' | 'auto';
+
+function useSystemPrefersDark() {
+  const prefersDark = ref(false);
+  let mql: MediaQueryList | null = null;
+  const sync = () => {
+    if (typeof window === 'undefined') return;
+    prefersDark.value = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  };
+  onMounted(() => {
+    if (typeof window === 'undefined') return;
+    mql = window.matchMedia('(prefers-color-scheme: dark)');
+    sync();
+    mql.addEventListener('change', sync);
+  });
+  onUnmounted(() => {
+    mql?.removeEventListener('change', sync);
+  });
+  return prefersDark;
+}
+
+/**
+ * Monaco：`dark` → vs-dark；`auto` 仅在传入 fallback 时跟系统（Provider 内 auto 已解析则走 inject 即可）。
+ */
+export function useMonacoPlaygroundTheme(
+  fallbackTheme?: () => PlaygroundColorTheme | undefined,
+): ComputedRef<'vs' | 'vs-dark'> {
+  const genuiConfig = inject(GENUI_CONFIG, null) as { value?: { theme?: PlaygroundColorTheme } } | null;
+  const systemPrefersDark = useSystemPrefersDark();
+
+  return computed(() => {
+    const raw = fallbackTheme?.() ?? genuiConfig?.value?.theme ?? 'light';
+    const isDark = raw === 'dark' || (raw === 'auto' && systemPrefersDark.value);
+    return isDark ? 'vs-dark' : 'vs';
+  });
+}

--- a/sites/playground/web/src/components/genui-template/use-monaco-playground-theme.ts
+++ b/sites/playground/web/src/components/genui-template/use-monaco-playground-theme.ts
@@ -7,8 +7,8 @@ function useSystemPrefersDark() {
   const prefersDark = ref(false);
   let mql: MediaQueryList | null = null;
   const sync = () => {
-    if (typeof window === 'undefined') return;
-    prefersDark.value = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    if (!mql) return;
+    prefersDark.value = mql.matches;
   };
   onMounted(() => {
     if (typeof window === 'undefined') return;


### PR DESCRIPTION
修改 UI 检视意见
1. 查看 JSON 面板和弹出框间增加分割线；
2. 查看 JSON 字体颜色修改，hover 时增加下划线；
3. 移动端“返回预览”字体颜色和字号修改
4. 修改模板中卡片背景未随主题变化
<img width="1211" height="740" alt="image" src="https://github.com/user-attachments/assets/75bcf5e5-ae8b-42ab-9c74-3bcba3e7e39b" />

<img width="1207" height="760" alt="image" src="https://github.com/user-attachments/assets/e1c4893a-3584-4383-85bc-732d1752c24b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Monaco editor theme now follows the playground theme and system dark-mode, and the mobile sheet and editors use that dynamic theme.

* **Style**
  * Updated component styling to use theme-aware colors, consistent borders/box-sizing, improved hover underline behavior, adjusted mobile header/back typography, and refined preview divider placement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentiny/genui-sdk/pull/152?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->