### PR TITLE
feat(playground): add extraBody and model split to thinking/no-thinking mode

### DIFF
--- a/sites/playground/server/.env.example
+++ b/sites/playground/server/.env.example
@@ -2,6 +2,10 @@ PORT=3008
 DEEPSEEK_API_KEY=<your-api-key-here>
 DEEPSEEK_BASE_URL=https://api.modelarts-maas.com/v1/
 # 动态模型地址：配置后从该 URL 拉取模型列表
-DYNAMIC_MODELS_URL=https://chat.opentiny.design/api/v1/llm/models
+DYNAMIC_MODELS_URL=
+# 动态模型基础URL
+DYNAMIC_BASE_URL=
+# 动态模型API密钥
+DYNAMIC_API_KEY=
 # 本地模型文件路径：配置后会合并到动态模型列表后面
 providerModelsPath=maas-models.json

--- a/sites/playground/server/maas-models.json
+++ b/sites/playground/server/maas-models.json
@@ -11,6 +11,50 @@
         "specificPrompt": "schemaJson必须使用```schemaJson```包裹。"
       },
       {
+        "name": "DeepSeek-V4-Flash",
+        "id": "deepseek-v4-flash",
+        "supportJsonFormat": false,
+        "specificPrompt": "",
+        "extraBody": {
+          "thinking": {
+            "type": "disabled"
+          }
+        }
+      },
+      {
+        "name": "DeepSeek-V4-Flash-thinking",
+        "id": "deepseek-v4-flash",
+        "supportJsonFormat": false,
+        "specificPrompt": "",
+        "extraBody": {
+          "thinking": {
+            "type": "enabled"
+          }
+        }
+      },
+      {
+        "name": "DeepSeek-V4-Pro",
+        "id": "deepseek-v4-pro",
+        "supportJsonFormat": false,
+        "specificPrompt": "",
+        "extraBody": {
+          "thinking": {
+            "type": "disabled"
+          }
+        }
+      },
+      {
+        "name": "DeepSeek-V4-Pro-thinking",
+        "id": "deepseek-v4-pro",
+        "supportJsonFormat": false,
+        "specificPrompt": "",
+        "extraBody": {
+          "thinking": {
+            "type": "enabled"
+          }
+        }
+      },
+      {
         "name": "DeepSeek-V3.1",
         "id": "deepseek-v3.1-terminus",
         "supportJsonFormat": false,

--- a/sites/playground/server/src/chat-genui.ts
+++ b/sites/playground/server/src/chat-genui.ts
@@ -178,12 +178,19 @@ export async function generateLlmConfig(llmConfigParams: LLMConfigParams | undef
   const modelInfo = providerModelMapper.getModelInfo(model || '');
   const aiSDKModel = modelInfo ? providerModelMapper.getAiSDKModel(modelInfo) : undefined;
 
+  const rawExtraBody = modelInfo?.model?.extraBody;
+  const extraBody =
+    rawExtraBody && typeof rawExtraBody === 'object'
+      ? rawExtraBody
+      : undefined;
+
   return {
     ...llmConfigParams,
     ...modelInfo,
     model: aiSDKModel,
     supportJsonFormat: modelInfo?.model.supportJsonFormat || false,
     specificPrompt: modelInfo?.model.specificPrompt || '',
+    extraBody
   };
 }
 
@@ -258,7 +265,7 @@ export function createChatGenui() {
     };
 
     const llmConfig = await generateLlmConfig(llmConfigParams);
-    const { model, temperature, specificPrompt } = llmConfig;
+    const { model, temperature, specificPrompt, provider, extraBody } = llmConfig;
     const { tools: mcpTools, clientsMap } = await generateAiSdkTools(
       mcpServers.filter((s) => s.enabled),
       abort.signal,
@@ -283,6 +290,12 @@ export function createChatGenui() {
     const renderConfigForFramework = framework === 'Angular' ? ngRendererConfig : rendererConfig;
     const maxSteps = 30;
     let hasError = false; // 标记是否已经处理了错误
+
+    const providerOptions =
+      provider?.name && extraBody && Object.keys(extraBody).length > 0
+        ? { [provider.name]: extraBody } as StreamTextOptions['providerOptions']
+        : undefined;
+
     const options: StreamTextOptions = {
       model,
       temperature,
@@ -299,6 +312,7 @@ export function createChatGenui() {
       tools,
       toolChoice: 'auto',
       stopWhen: stepCountIs(maxSteps),
+      ...(providerOptions ? { providerOptions } : {}),
       onError: (error: any) => {
         if (hasError) {
           return;

--- a/sites/playground/server/src/opentiny-models.ts
+++ b/sites/playground/server/src/opentiny-models.ts
@@ -25,29 +25,31 @@ interface OpenTinyModelsResponse {
 export function convertOpenTinyToProviderModelsData(resp: OpenTinyModelsResponse): Record<string, any> {
   const models = Array.isArray(resp?.models) ? resp.models : [];
 
-  const convertedModels = models.map((m) => {
+  const convertedModels = models.map((model) => {
+    const { display_name, id, type, capabilities, provider } = model;
     const supportImage =
-      m.type === 'vision' || m.capabilities?.vision === true || m.capabilities?.fileUpload?.supportDirectImage === true;
+      type === 'vision' || capabilities?.vision === true || capabilities?.fileUpload?.supportDirectImage === true;
 
-    const model: any = {
-      name: m.display_name || m.id,
-      id: m.id,
+    const modelName = display_name && provider ? `${provider}_${display_name}` : id;
+    const modelData: any = {
+      name: modelName,
+      id,
     };
 
     if (supportImage) {
-      model.features = { supportImage: true };
+      modelData.features = { supportImage: true };
     }
 
-    return model;
+    return modelData;
   });
 
   // 为了与现有 opentiny-models.json 保持一致，统一放在 deepseek 提供商下
   return {
     dynamic: {
       name: 'deepseek',
-      apiKeyEnvName: 'API_KEY',
-      baseUrlEnvName: 'BASE_URL',
-      models: convertedModels,
+      apiKeyEnvName: 'DYNAMIC_API_KEY',
+      baseUrlEnvName: 'DYNAMIC_BASE_URL',
+      models: convertedModels,  
     },
   };
 }

--- a/sites/playground/server/src/opentiny-models.ts
+++ b/sites/playground/server/src/opentiny-models.ts
@@ -5,12 +5,27 @@ interface OpenTinyModel {
   display_name: string;
   capabilities?: {
     vision?: boolean;
+    reasoning?: {
+      enable_thinking?: boolean;
+      [key: string]: any;
+    };
     fileUpload?: {
       supportDirectImage?: boolean;
       [key: string]: any;
     };
     [key: string]: any;
   };
+}
+
+const EXTRA_BODY_THINKING_DISABLED = { thinking: { type: 'disabled' as const } };
+const EXTRA_BODY_THINKING_ENABLED = { thinking: { type: 'enabled' as const } };
+
+function shouldSplitThinkingModel(capabilities?: OpenTinyModel['capabilities']): boolean {
+  const reasoning = capabilities?.reasoning;
+  if (reasoning == null || typeof reasoning !== 'object' || Array.isArray(reasoning)) {
+    return false;
+  }
+  return reasoning.enable_thinking === true;
 }
 
 interface OpenTinyModelsResponse {
@@ -25,22 +40,25 @@ interface OpenTinyModelsResponse {
 export function convertOpenTinyToProviderModelsData(resp: OpenTinyModelsResponse): Record<string, any> {
   const models = Array.isArray(resp?.models) ? resp.models : [];
 
-  const convertedModels = models.map((model) => {
+  const convertedModels = models.flatMap((model) => {
     const { display_name, id, type, capabilities, provider } = model;
     const supportImage =
       type === 'vision' || capabilities?.vision === true || capabilities?.fileUpload?.supportDirectImage === true;
 
     const modelName = display_name && provider ? `${provider}_${display_name}` : id;
-    const modelData: any = {
-      name: modelName,
-      id,
-    };
-
+    const base: any = { id };
     if (supportImage) {
-      modelData.features = { supportImage: true };
+      base.features = { supportImage: true };
     }
 
-    return modelData;
+    if (!shouldSplitThinkingModel(capabilities)) {
+      return [{ name: modelName, ...base }];
+    }
+
+    return [
+      { name: modelName, ...base, extraBody: EXTRA_BODY_THINKING_DISABLED },
+      { name: `${modelName}-thinking`, ...base, extraBody: EXTRA_BODY_THINKING_ENABLED },
+    ];
   });
 
   // 为了与现有 opentiny-models.json 保持一致，统一放在 deepseek 提供商下
@@ -49,7 +67,7 @@ export function convertOpenTinyToProviderModelsData(resp: OpenTinyModelsResponse
       name: 'deepseek',
       apiKeyEnvName: 'DYNAMIC_API_KEY',
       baseUrlEnvName: 'DYNAMIC_BASE_URL',
-      models: convertedModels,  
+      models: convertedModels,
     },
   };
 }

--- a/sites/playground/server/src/types/llm-config.ts
+++ b/sites/playground/server/src/types/llm-config.ts
@@ -1,5 +1,7 @@
+import type { LanguageModel } from 'ai';
 import type { McpServersConfig } from './mcp-server.js';
 import type { PlaygroundSkillConfig } from '../skills/index.js';
+import type { ProviderConfig } from '../ai-sdk-providers.js';
 
 export type LLMConfigParams = {
   model?: string;
@@ -9,7 +11,10 @@ export type LLMConfigParams = {
   skills?: PlaygroundSkillConfig[];
 };
 
-export type LLMConfig = LLMConfigParams & {
+export type LLMConfig = Omit<LLMConfigParams, 'model'> & {
+  model?: LanguageModel;
+  provider?: ProviderConfig;
   supportJsonFormat?: boolean;
   specificPrompt?: string;
+  extraBody?: Record<string, unknown>;
 };


### PR DESCRIPTION
1、动态模型的env配置键名增加DYNAMIC_前缀
2、动态模型显示名称新增provider前缀
3、将思考模型拆分为thinking和非thinking两种模型
4、新增extraBody 支出传递额外自定义参数
<img width="363" height="536" alt="PixPin_2026-05-14_10-46-52" src="https://github.com/user-attachments/assets/84264e4b-f5f6-437d-81ca-63a0318c4fe6" />

<img width="646" height="485" alt="PixPin_2026-05-14_10-48-24" src="https://github.com/user-attachments/assets/09067f2d-09e9-484b-8e42-46897fb7f13c" />

