### PR TITLE
fix(core): fix structuredClone error when use ref json and isJsonComplete is false

### DIFF
--- a/packages/core/src/delta-patcher/delta-patcher.ts
+++ b/packages/core/src/delta-patcher/delta-patcher.ts
@@ -12,6 +12,19 @@ export interface IPatchOptions {
   requiredCompleteFieldSelectors?: string[];
 }
 
+const deepClone = (obj: any) => {
+ if (!obj || typeof obj !== 'object') {
+  return obj;
+ }
+ let cloneData
+  try {
+    cloneData = structuredClone(obj);
+  } catch (error) {
+    cloneData = JSON.parse(JSON.stringify(obj));
+  }
+  return cloneData;
+}
+
 export class DeltaPatcher {
   protected diffPatcher: jsonDiffPatch.DiffPatcher;
   protected options: IPatchOptions;
@@ -94,7 +107,7 @@ export class DeltaPatcher {
     };
 
     if (isMatch) {
-      const cloneDelta = structuredClone(delta);
+      const cloneDelta = deepClone(delta);
       const deltaPath = this.getActualMatchPath(lastKey, matchPath, deltaIndex ?? -1);
       const { parent, selfKey } = deltaPath.match(/((?<parent>.*)\.)?(?<selfKey>.*?)$/)?.groups || {};
 

--- a/packages/core/src/delta-patcher/delta-patcher.ts
+++ b/packages/core/src/delta-patcher/delta-patcher.ts
@@ -12,7 +12,7 @@ export interface IPatchOptions {
   requiredCompleteFieldSelectors?: string[];
 }
 
-const deepClone = (obj: any) => {
+function deepClone(obj: any): any {
  if (!obj || typeof obj !== 'object') {
   return obj;
  }


### PR DESCRIPTION
修复当isJsonComplete为false时且传入的Json是ref时，structuredClone会报错

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Delta processing is now more reliable: object cloning has been improved to handle additional edge cases and unsupported values, reducing failures when computing or applying deltas and improving stability of change propagation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentiny/genui-sdk/pull/164?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->