### PR TITLE
docs: update playground link in readme doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Whether you are building an AI chat application from scratch or adding generativ
 
 ### Try It Now
 
-You can visit the [Playground](https://playground.opentiny.design/genui-sdk) to experience Generative UI capabilities in action.  
+You can visit the [Playground](https://opentiny.github.io/genui-sdk/playground/) to experience Generative UI capabilities in action.  
 The playground itself is built using GenUI SDK.
 
 ### Getting Started

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,7 +10,7 @@ GenUI SDK 是 OpenTiny 面向生成式 UI（Generative UI）场景的全栈开�
 
 ## 立即体验
 
-你可以前往[演练场](https://playground.opentiny.design/genui-sdk)立即体验生成式 UI 能力。演练场正是基于 GenUI SDK 开发的应用。
+你可以前往[演练场](https://opentiny.github.io/genui-sdk/playground/)立即体验生成式 UI 能力。演练场正是基于 GenUI SDK 开发的应用。
 
 ## 快速开始
 


### PR DESCRIPTION
更新readme中的演练场链接

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the "Try It Now" section links in English and Chinese README files to point to the new playground URL.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentiny/genui-sdk/pull/166?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->