### PR TITLE
build(genui-sdk-angular): fix build dts bundle genui-sdk-core and its dependencies's dts

### DIFF
--- a/packages/frameworks/angular/build-from-dist/vite.config.lib.ts
+++ b/packages/frameworks/angular/build-from-dist/vite.config.lib.ts
@@ -33,7 +33,7 @@ export default defineConfig(({ mode }) => {
             '../dist/renderer': ['../../dist/renderer/index.d.ts'] // hack for fix relative path for 'output/dist'
           },
         },
-        bundledPackages: ['@opentiny/tiny-schema-renderer-ng'],
+        bundledPackages: ['@opentiny/tiny-schema-renderer-ng', '@opentiny/genui-sdk-core', 'jsondiffpatch', '@dmsnell/diff-match-patch'],
       }),
       viteStaticCopy({
         targets: [


### PR DESCRIPTION
genui-sdk-core没发包，genui-sdk-angular的dts文件需要把core包相关dts打入
before:
<img width="1020" height="380" alt="image" src="https://github.com/user-attachments/assets/9987c12e-12f1-4659-8721-74165b2fa722" />

after:
<img width="898" height="394" alt="image" src="https://github.com/user-attachments/assets/3eeafd16-1402-4168-a303-6ee4a3a5618c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated library build configuration to properly bundle additional core dependencies, improving compatibility and distribution handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentiny/genui-sdk/pull/167?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->