### PR TITLE
fix(playground): pin tool call options to tools tab bottom with independent scroll

### DIFF
--- a/sites/playground/web/src/components/PlaygroundSidebar.vue
+++ b/sites/playground/web/src/components/PlaygroundSidebar.vue
@@ -162,12 +162,19 @@ const updateCustomExamples = (list) => {
         </button>
       </div>
 
-      <tiny-tabs class="playground-sidebar__tabs" v-model="activeName" v-show="expanded">
+      <tiny-tabs
+        class="playground-sidebar__tabs"
+        :class="{ 'playground-sidebar__tabs--tools': activeName === 'tools' }"
+        v-model="activeName"
+        v-show="expanded"
+      >
         <tiny-tab-item title="模型配置" name="model">
           <ModelConfig @createNewTemplate="handleCreateNewTemplate" @update-custom-examples="updateCustomExamples"/>
         </tiny-tab-item>
         <tiny-tab-item title="工具" name="tools">
-          <McpTools />
+          <div class="tools-tab-panel">
+            <McpTools />
+          </div>
         </tiny-tab-item>
         <tiny-tab-item title="主题" name="theme">
           <div class="config-title">切换主题</div>
@@ -274,6 +281,8 @@ const updateCustomExamples = (list) => {
     flex: 1;
     min-height: 0;
     overflow: hidden;
+    display: flex;
+    flex-direction: column;
 
     .config-title {
       font-size: 14px;
@@ -282,14 +291,47 @@ const updateCustomExamples = (list) => {
       line-height: 32px;
     }
 
+    :deep(.tiny-tabs) {
+      display: flex;
+      flex-direction: column;
+      flex: 1;
+      min-height: 0;
+    }
+
     :deep(.tiny-tabs__header.is-top) {
       padding: 0 24px;
+      flex-shrink: 0;
     }
 
     :deep(.tiny-tabs__content) {
-      height: 100%;
+      flex: 1;
+      min-height: 0;
+      height: auto;
       overflow: auto;
       padding: 0 24px 90px;
+    }
+
+    &--tools {
+      :deep(.tiny-tabs__content) {
+        overflow: hidden;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+      }
+
+      :deep(.tiny-tabs__content > .tiny-tab-pane) {
+        flex: 1;
+        min-height: 0;
+        overflow: hidden;
+      }
+
+      :deep(.tools-tab-panel) {
+        height: 100%;
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+      }
     }
   }
 

--- a/sites/playground/web/src/components/PlaygroundSidebar.vue
+++ b/sites/playground/web/src/components/PlaygroundSidebar.vue
@@ -172,9 +172,7 @@ const updateCustomExamples = (list) => {
           <ModelConfig @createNewTemplate="handleCreateNewTemplate" @update-custom-examples="updateCustomExamples"/>
         </tiny-tab-item>
         <tiny-tab-item title="工具" name="tools">
-          <div class="tools-tab-panel">
-            <McpTools />
-          </div>
+          <McpTools />
         </tiny-tab-item>
         <tiny-tab-item title="主题" name="theme">
           <div class="config-title">切换主题</div>
@@ -291,13 +289,6 @@ const updateCustomExamples = (list) => {
       line-height: 32px;
     }
 
-    :deep(.tiny-tabs) {
-      display: flex;
-      flex-direction: column;
-      flex: 1;
-      min-height: 0;
-    }
-
     :deep(.tiny-tabs__header.is-top) {
       padding: 0 24px;
       flex-shrink: 0;
@@ -306,30 +297,19 @@ const updateCustomExamples = (list) => {
     :deep(.tiny-tabs__content) {
       flex: 1;
       min-height: 0;
-      height: auto;
       overflow: auto;
       padding: 0 24px 90px;
     }
 
-    &--tools {
-      :deep(.tiny-tabs__content) {
-        overflow: hidden;
-        padding: 0;
-        display: flex;
-        flex-direction: column;
-      }
+    &--tools :deep(.tiny-tabs__content) {
+      overflow: hidden;
+      padding: 0;
+      display: flex;
+      flex-direction: column;
 
-      :deep(.tiny-tabs__content > .tiny-tab-pane) {
+      > .tiny-tab-pane {
         flex: 1;
         min-height: 0;
-        overflow: hidden;
-      }
-
-      :deep(.tools-tab-panel) {
-        height: 100%;
-        min-height: 0;
-        display: flex;
-        flex-direction: column;
         overflow: hidden;
       }
     }

--- a/sites/playground/web/src/components/tab-components/ToolCallConfig.vue
+++ b/sites/playground/web/src/components/tab-components/ToolCallConfig.vue
@@ -1,0 +1,41 @@
+<script setup>
+import { inject } from 'vue';
+import { TinyCheckbox } from '@opentiny/vue';
+
+const playgroundContext = inject('playgroundContext');
+const { chatConfig } = playgroundContext;
+
+const updateAddToolCallContext = (value) => {
+  chatConfig.addToolCallContext = value;
+};
+
+const updateShowThinkingResult = (value) => {
+  chatConfig.showThinkingResult = value;
+};
+</script>
+
+<template>
+  <div class="tool-call-config">
+    <tiny-checkbox :model-value="chatConfig.addToolCallContext" @update:model-value="updateAddToolCallContext">
+      调用结果添加到上下文
+    </tiny-checkbox>
+  </div>
+  <div class="tool-call-config">
+    <tiny-checkbox :model-value="chatConfig.showThinkingResult" @update:model-value="updateShowThinkingResult">
+      调用结果展示在界面中
+    </tiny-checkbox>
+  </div>
+</template>
+
+<style scoped lang="less">
+.tool-call-config {
+  display: flex;
+  align-items: center;
+  font-size: 14px;
+  color: #595959;
+
+  & + & {
+    margin-top: 12px;
+  }
+}
+</style>

--- a/sites/playground/web/src/components/tab-components/mcpTools.vue
+++ b/sites/playground/web/src/components/tab-components/mcpTools.vue
@@ -1,20 +1,10 @@
 <script setup>
-import { ref, inject } from 'vue';
-import { TinyCollapse, TinyCheckbox } from '@opentiny/vue';
+import { ref } from 'vue';
+import { TinyCollapse } from '@opentiny/vue';
 import { AgentPanel, McpServerPanel, SkillPanel } from './tool-panels';
-
-const playgroundContext = inject('playgroundContext');
-const { chatConfig } = playgroundContext;
+import ToolCallConfig from './ToolCallConfig.vue';
 
 const activePanels = ref(['mcp', 'agent', 'skills']);
-
-const updateAddToolCallContext = (value) => {
-  chatConfig.addToolCallContext = value;
-};
-
-const updateShowThinkingResult = (value) => {
-  chatConfig.showThinkingResult = value;
-};
 </script>
 
 <template>
@@ -29,16 +19,7 @@ const updateShowThinkingResult = (value) => {
       </div>
     </div>
     <div class="mcp-tools__footer">
-      <div class="tool-call-options">
-        <tiny-checkbox :model-value="chatConfig.addToolCallContext" @update:model-value="updateAddToolCallContext">
-          调用结果添加到上下文
-        </tiny-checkbox>
-      </div>
-      <div class="tool-call-options">
-        <tiny-checkbox :model-value="chatConfig.showThinkingResult" @update:model-value="updateShowThinkingResult">
-          调用结果展示在界面中
-        </tiny-checkbox>
-      </div>
+      <ToolCallConfig />
     </div>
   </div>
 </template>
@@ -66,17 +47,6 @@ const updateShowThinkingResult = (value) => {
   flex-shrink: 0;
   padding: 12px 24px 16px;
   background: var(--ti-base-color-bg, #fff);
-}
-
-.tool-call-options {
-  display: flex;
-  align-items: center;
-  font-size: 14px;
-  color: #595959;
-
-  & + & {
-    margin-top: 12px;
-  }
 }
 
 :deep(.tiny-collapse) {

--- a/sites/playground/web/src/components/tab-components/mcpTools.vue
+++ b/sites/playground/web/src/components/tab-components/mcpTools.vue
@@ -1,9 +1,20 @@
 <script setup>
-import { ref } from 'vue';
-import { TinyCollapse } from '@opentiny/vue';
+import { ref, inject } from 'vue';
+import { TinyCollapse, TinyCheckbox } from '@opentiny/vue';
 import { AgentPanel, McpServerPanel, SkillPanel } from './tool-panels';
 
+const playgroundContext = inject('playgroundContext');
+const { chatConfig } = playgroundContext;
+
 const activePanels = ref(['mcp', 'agent', 'skills']);
+
+const updateAddToolCallContext = (value) => {
+  chatConfig.addToolCallContext = value;
+};
+
+const updateShowThinkingResult = (value) => {
+  chatConfig.showThinkingResult = value;
+};
 </script>
 
 <template>
@@ -13,10 +24,32 @@ const activePanels = ref(['mcp', 'agent', 'skills']);
       <AgentPanel />
       <SkillPanel />
     </tiny-collapse>
+    <div class="tool-call-options">
+      <tiny-checkbox :model-value="chatConfig.addToolCallContext" @update:model-value="updateAddToolCallContext">
+        调用结果添加到上下文
+      </tiny-checkbox>
+    </div>
+    <div class="tool-call-options">
+      <tiny-checkbox :model-value="chatConfig.showThinkingResult" @update:model-value="updateShowThinkingResult">
+        调用结果展示在界面中
+      </tiny-checkbox>
+    </div>
   </div>
 </template>
 
 <style scoped lang="less">
+.tool-call-options {
+  margin-top: 12px;
+  display: flex;
+  align-items: center;
+  font-size: 14px;
+  color: #595959;
+
+  &:last-child {
+    margin-bottom: 16px;
+  }
+}
+
 :deep(.tiny-collapse) {
   border-bottom: none;
 

--- a/sites/playground/web/src/components/tab-components/mcpTools.vue
+++ b/sites/playground/web/src/components/tab-components/mcpTools.vue
@@ -18,35 +18,64 @@ const updateShowThinkingResult = (value) => {
 </script>
 
 <template>
-  <div>
-    <tiny-collapse class="playground-tools" v-model="activePanels">
-      <McpServerPanel />
-      <AgentPanel />
-      <SkillPanel />
-    </tiny-collapse>
-    <div class="tool-call-options">
-      <tiny-checkbox :model-value="chatConfig.addToolCallContext" @update:model-value="updateAddToolCallContext">
-        调用结果添加到上下文
-      </tiny-checkbox>
+  <div class="mcp-tools">
+    <div class="mcp-tools__scroll">
+      <div class="mcp-tools__scroll-inner">
+        <tiny-collapse class="playground-tools" v-model="activePanels">
+          <McpServerPanel />
+          <AgentPanel />
+          <SkillPanel />
+        </tiny-collapse>
+      </div>
     </div>
-    <div class="tool-call-options">
-      <tiny-checkbox :model-value="chatConfig.showThinkingResult" @update:model-value="updateShowThinkingResult">
-        调用结果展示在界面中
-      </tiny-checkbox>
+    <div class="mcp-tools__footer">
+      <div class="tool-call-options">
+        <tiny-checkbox :model-value="chatConfig.addToolCallContext" @update:model-value="updateAddToolCallContext">
+          调用结果添加到上下文
+        </tiny-checkbox>
+      </div>
+      <div class="tool-call-options">
+        <tiny-checkbox :model-value="chatConfig.showThinkingResult" @update:model-value="updateShowThinkingResult">
+          调用结果展示在界面中
+        </tiny-checkbox>
+      </div>
     </div>
   </div>
 </template>
 
 <style scoped lang="less">
+.mcp-tools {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+
+.mcp-tools__scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.mcp-tools__scroll-inner {
+  padding: 0 24px;
+}
+
+.mcp-tools__footer {
+  flex-shrink: 0;
+  padding: 12px 24px 16px;
+  background: var(--ti-base-color-bg, #fff);
+}
+
 .tool-call-options {
-  margin-top: 12px;
   display: flex;
   align-items: center;
   font-size: 14px;
   color: #595959;
 
-  &:last-child {
-    margin-bottom: 16px;
+  & + & {
+    margin-top: 12px;
   }
 }
 
@@ -67,6 +96,9 @@ const updateShowThinkingResult = (value) => {
     .tiny-collapse-item__header {
       padding: 0;
       border-bottom: none;
+      position: sticky;
+      top: 0;
+      z-index: 2;
     }
 
     .tiny-collapse-item__content {

--- a/sites/playground/web/src/components/tab-components/tool-panels/McpServerPanel.vue
+++ b/sites/playground/web/src/components/tab-components/tool-panels/McpServerPanel.vue
@@ -4,7 +4,6 @@ import {
   TinyButton,
   TinySwitch,
   TinyPopover,
-  TinyCheckbox,
   TinyCollapseItem,
   TinyDialogBox,
   TinyForm,
@@ -15,7 +14,7 @@ import {
 import { iconDel, iconEdit, iconPlus, iconEllipsis } from '@opentiny/vue-icon';
 
 const playgroundContext = inject('playgroundContext');
-const { llmConfig, chatConfig } = playgroundContext;
+const { llmConfig } = playgroundContext;
 
 const IconPlus = iconPlus();
 const IconDel = iconDel();
@@ -89,14 +88,6 @@ const deleteMCPServer = (server) => {
 const updateServerEnabled = (server, enabled) => {
   const mcpServers = llmConfig.mcpServers || [];
   llmConfig.mcpServers = mcpServers.map((s) => (s.name === server.name ? { ...s, enabled } : s));
-};
-
-const updateAddToolCallContext = (value) => {
-  chatConfig.addToolCallContext = value;
-};
-
-const updateShowThinkingResult = (value) => {
-  chatConfig.showThinkingResult = value;
 };
 
 const confirmMCPServer = async () => {
@@ -204,16 +195,6 @@ const confirmMCPServer = async () => {
         </div>
       </div>
     </div>
-    <div class="mcp-server-tool-call-context">
-      <tiny-checkbox :model-value="chatConfig.addToolCallContext" @update:model-value="updateAddToolCallContext">
-        调用结果添加到上下文
-      </tiny-checkbox>
-    </div>
-    <div class="mcp-server-tool-call-context" style="margin-top: 12px">
-      <tiny-checkbox :model-value="chatConfig.showThinkingResult" @update:model-value="updateShowThinkingResult">
-        调用结果展示在界面中
-      </tiny-checkbox>
-    </div>
     <tiny-dialog-box
       v-model:visible="showToolFormDialog"
       :title="mcpServerData.index > -1 ? '编辑 MCP 服务' : '添加 MCP 服务'"
@@ -315,19 +296,6 @@ const confirmMCPServer = async () => {
   width: 12px;
   height: 12px;
   color: #595959;
-}
-
-.mcp-server-tool-call-context {
-  margin-top: 12px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  font-size: 14px;
-  color: #595959;
-
-  &:last-child {
-    margin-bottom: 16px;
-  }
 }
 
 :deep(.mcp-server-item-actions-popover) {


### PR DESCRIPTION
1、工具调用配置固定到底部
2、添加多项mcp、skill后支持滚动，collsapse header支持吸顶布局

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Tool Call configuration panel with two toggles for including tool-call context and showing tool results.

* **Style**
  * Redesigned the tools panel for improved scrolling, sticky headers, and clearer footer placement.
  * Adjusted sidebar tab sizing to use flexible layout and better clipping/overflow behavior.

* **Refactor**
  * Removed tool-call settings from the MCP server panel and consolidated them into the new footer configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentiny/genui-sdk/pull/168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->