### PR TITLE
feat(playground): implement language switcher and add English translations

### DIFF
--- a/packages/frameworks/vue/src/config-provider/ConfigProvider.vue
+++ b/packages/frameworks/vue/src/config-provider/ConfigProvider.vue
@@ -62,7 +62,9 @@ provide(GENUI_CONFIG, genuiConfig);
 watch(
   () => [props.locale, props.i18n] as const,
   () => {
-    i18n.setLocale(props.locale);
+    if (props.locale && props.locale !== i18n.locale.value) {
+      i18n.setLocale(props.locale);
+    }
     props.i18n && i18n.mergeMessages(props.i18n);
   },
   { immediate: true },

--- a/sites/playground/web/src/App.vue
+++ b/sites/playground/web/src/App.vue
@@ -347,6 +347,7 @@ onUnmounted(() => {
   <TopIconsRenderer style="height: 0" />
   <div class="genui-playground">
     <PlaygroundSidebar
+      :key="locale"
       v-model:expanded="isSidebarOpen"
       v-model:theme="theme"
       @new-task="chat?.handleNewConversation()"

--- a/sites/playground/web/src/App.vue
+++ b/sites/playground/web/src/App.vue
@@ -429,11 +429,9 @@ onUnmounted(() => {
   .genui-playground {
     --ti-gen-chat-avatar-and-gap-width: 0px;
   }
-  :deep(.action-buttons__button) {
+  :deep(.action-buttons__button .action-buttons__icon) {
     padding-right: 10px;
-    svg[alt='录音'] {
-      display: none;
-    }
+    display: none;
   }
   .empty {
     font-size: 24px;

--- a/sites/playground/web/src/App.vue
+++ b/sites/playground/web/src/App.vue
@@ -2,7 +2,18 @@
 import { IconAi, IconUser } from '@opentiny/tiny-robot-svgs';
 import ThemeTool, { tinyDarkTheme, tinyOldTheme } from '@opentiny/vue-theme/theme-tool';
 import { GenuiConfigProvider, GenuiChat, GENUI_RENDERER } from '@opentiny/genui-sdk-vue';
-import { ref, watch, onMounted, reactive, computed, onUnmounted, provide, defineAsyncComponent, h, shallowRef } from 'vue';
+import {
+  ref,
+  watch,
+  onMounted,
+  reactive,
+  computed,
+  onUnmounted,
+  provide,
+  defineAsyncComponent,
+  h,
+  shallowRef,
+} from 'vue';
 import { getModelFeatures, getModelOptions } from './api';
 import { createCustomFetch } from './api/custom-fetch';
 import AssistantFooter from './components/AssistantFooter.vue';
@@ -11,8 +22,14 @@ import PlaygroundSidebar from './components/PlaygroundSidebar.vue';
 import { useInputMessage } from './hooks/use-input-message';
 import { useIsMobile } from './hooks';
 import useTemplate from './components/genui-template/useTemplate';
-import { getOverlapEliminatorHandler, getContinueGeneratingHandler, locationPartialSchemaJson, movePartialSchemaJsonToLastMessage } from './continue-writing';
+import {
+  getOverlapEliminatorHandler,
+  getContinueGeneratingHandler,
+  locationPartialSchemaJson,
+  movePartialSchemaJsonToLastMessage,
+} from './continue-writing';
 import useIcon from './use-icon';
+import { locale, t } from './i18n';
 
 const { topRenderer, addIcons } = useIcon();
 const TopIconsRenderer = topRenderer();
@@ -123,7 +140,9 @@ const syncModelFeatures = async (model) => {
 watch(() => llmConfig.model, syncModelFeatures);
 const transformTheme = (themeConfig) => {
   const newThemeConfig = structuredClone(themeConfig);
-  newThemeConfig.css = newThemeConfig.css.replaceAll(':host', `[class*="tiny-genui-playground"]`).replaceAll(':root', `[class*="tiny-genui-playground"]`);
+  newThemeConfig.css = newThemeConfig.css
+    .replaceAll(':host', `[class*="tiny-genui-playground"]`)
+    .replaceAll(':root', `[class*="tiny-genui-playground"]`);
   return newThemeConfig;
 };
 
@@ -135,10 +154,14 @@ const themeMap = {
 
 const themeTool = new ThemeTool();
 
-watch(theme, (newVal) => {
-  const themeConfig = themeMap[newVal] || themeMap.light;
-  themeTool.changeTheme(themeConfig);
-}, { immediate: true });
+watch(
+  theme,
+  (newVal) => {
+    const themeConfig = themeMap[newVal] || themeMap.light;
+    themeTool.changeTheme(themeConfig);
+  },
+  { immediate: true },
+);
 
 watch(
   [() => theme.value, () => llmConfig, () => chatConfig, () => customExamples.value],
@@ -156,11 +179,11 @@ watch(
   { deep: true },
 );
 
-const themeData = ref([
-  { text: '默认', value: 'light' },
-  { text: '暗黑', value: 'dark' },
-  { text: '清新', value: 'lite' },
-  { text: '自动', value: 'auto' },
+const themeData = computed(() => [
+  { text: t('theme.default'), value: 'light' },
+  { text: t('theme.dark'), value: 'dark' },
+  { text: t('theme.lite'), value: 'lite' },
+  { text: t('theme.auto'), value: 'auto' },
 ]);
 
 const messages = ref([]);
@@ -169,32 +192,33 @@ const url = import.meta.env.VITE_CHAT_URL;
 
 // TODO: 后续优化后，在GenUI SDK导出此API
 const insertHandlersAfterName = (handlers, insertHandlers, name) => {
-  const index = handlers.findIndex(handler => handler.name === name);
+  const index = handlers.findIndex((handler) => handler.name === name);
   if (index !== -1) {
     handlers.splice(index + 1, 0, ...insertHandlers);
   }
   return handlers;
-}
+};
 
 const chat = ref(null);
 const conversation = computed(() => chat.value?.getConversation());
 watch(chat, (instance) => {
   if (instance) {
     const defaultResponseHandlers = instance.getResponseHandlers();
-    const contentHandler = defaultResponseHandlers.find(handler => handler.name === 'content');
+    const contentHandler = defaultResponseHandlers.find((handler) => handler.name === 'content');
     const newResponseHandlers = [
       ...defaultResponseHandlers,
       getContinueGeneratingHandler(conversation.value.messageManager),
       locationPartialSchemaJson(),
     ];
-    
-    insertHandlersAfterName(newResponseHandlers, [
-      movePartialSchemaJsonToLastMessage(),
-      getOverlapEliminatorHandler(contentHandler),
-    ], 'init');
+
+    insertHandlersAfterName(
+      newResponseHandlers,
+      [movePartialSchemaJsonToLastMessage(), getOverlapEliminatorHandler(contentHandler)],
+      'init',
+    );
     instance.setResponseHandlers(newResponseHandlers);
   }
-})
+});
 
 // 提供给侧边栏及其子组件使用的共享上下文
 const playgroundContext = {
@@ -283,17 +307,19 @@ const updateCustomExamples = (list) => {
   customExamples.value = normalizeCustomExamples(list);
 };
 
-watch(() => templateSchemaList.value, (newVal) => {
-  if (!newVal) {
-    return;
-  }
-  const templateMap = new Map(newVal.map((item) => [item.id, item]));
-  // Only keep examples that still exist in templateSchemaList,
-  // and always refresh them from the latest template source.
-  customExamples.value = customExamples.value
-    .map((example) => templateMap.get(example.id))
-    .filter(Boolean);
-}, { deep: true });
+watch(
+  () => templateSchemaList.value,
+  (newVal) => {
+    if (!newVal) {
+      return;
+    }
+    const templateMap = new Map(newVal.map((item) => [item.id, item]));
+    // Only keep examples that still exist in templateSchemaList,
+    // and always refresh them from the latest template source.
+    customExamples.value = customExamples.value.map((example) => templateMap.get(example.id)).filter(Boolean);
+  },
+  { deep: true },
+);
 
 onMounted(() => {
   initInputMessage();
@@ -320,23 +346,43 @@ onUnmounted(() => {
 <template>
   <TopIconsRenderer style="height: 0" />
   <div class="genui-playground">
-    <PlaygroundSidebar v-model:expanded="isSidebarOpen" v-model:theme="theme" @new-task="chat?.handleNewConversation()"
-      @update-custom-examples="updateCustomExamples" v-slot="{ activeName }">
+    <PlaygroundSidebar
+      v-model:expanded="isSidebarOpen"
+      v-model:theme="theme"
+      @new-task="chat?.handleNewConversation()"
+      @update-custom-examples="updateCustomExamples"
+      v-slot="{ activeName }"
+    >
       <template v-if="ENABLE_TEMPLATE && isTemplateInit">
         <div v-if="activeName === 'template'" class="chat-container">
-          <component v-if="GenuiTemplate" :is="GenuiTemplate" ref="genuiTemplateRef" :llm-config="llmConfig"
-            :theme="theme" :chat-config="chatConfig" />
+          <component
+            v-if="GenuiTemplate"
+            :is="GenuiTemplate"
+            ref="genuiTemplateRef"
+            :llm-config="llmConfig"
+            :theme="theme"
+            :chat-config="chatConfig"
+          />
         </div>
       </template>
       <div v-show="!ENABLE_TEMPLATE || activeName !== 'template'" class="chat-container">
-        <GenuiConfigProvider :theme="theme" style="height: 100%">
-          <GenuiChat :url="url" ref="chat" :messages="messages" :chat-config="chatConfig" :roles="roles"
-            :model="llmConfig.model" :temperature="llmConfig.temperature" :features="modelFeatures"
-            :custom-fetch="customFetch" :custom-examples="customExamples">
+        <GenuiConfigProvider :theme="theme" :locale="locale" style="height: 100%">
+          <GenuiChat
+            :url="url"
+            ref="chat"
+            :messages="messages"
+            :chat-config="chatConfig"
+            :roles="roles"
+            :model="llmConfig.model"
+            :temperature="llmConfig.temperature"
+            :features="modelFeatures"
+            :custom-fetch="customFetch"
+            :custom-examples="customExamples"
+          >
             <template #empty>
               <div class="empty">
                 <IconAi />
-                <span>GenUI Playground</span>
+                <span>{{ t('app.emptyTitle') }}</span>
               </div>
             </template>
           </GenuiChat>
@@ -372,7 +418,7 @@ onUnmounted(() => {
   font-size: 32px;
   font-weight: 600;
 
-  &>svg {
+  & > svg {
     width: 56px;
     height: 56px;
   }
@@ -384,14 +430,14 @@ onUnmounted(() => {
   }
   :deep(.action-buttons__button) {
     padding-right: 10px;
-    svg[alt="录音"] {
+    svg[alt='录音'] {
       display: none;
     }
   }
   .empty {
     font-size: 24px;
 
-    &>svg {
+    & > svg {
       width: 48px;
       height: 48px;
     }

--- a/sites/playground/web/src/components/AssistantFooter.vue
+++ b/sites/playground/web/src/components/AssistantFooter.vue
@@ -9,6 +9,7 @@ import type { IBubbleSlotsProps } from './common.types';
 import { useGenerateMore } from '../continue-writing';
 import FinishInfo from './FinishInfo.vue';
 import { vFocusHoverSync } from './v-focus-hover-sync';
+import { t } from '../i18n';
 const props = defineProps<IBubbleSlotsProps>();
 
 const vAutoTip = AutoTip;
@@ -23,7 +24,7 @@ const CopyIcon = iconCopy();
 const ArrowRightIcon = IconArrowRight();
 const ArrowLeftIcon = IconArrowLeft();
 
-const copyTooltip = ref('复制');
+const copyTooltip = ref(t('chatFooter.copy'));
 
 const isLastBubble = computed(() => {
   const { messages } = props.messageManager;
@@ -74,7 +75,7 @@ const { markGenerateMore, revertGenerateMore } = useGenerateMore(props.messageMa
       type="text"
       :reset-time="0"
       :icon="RefreshIcon"
-      v-auto-tip="{ always: true, content: '刷新', effect: tooltipEffect }"
+      v-auto-tip="{ always: true, content: t('chatFooter.refresh'), effect: tooltipEffect }"
       v-focus-hover-sync
       @click="refresh"
     >
@@ -94,7 +95,7 @@ const { markGenerateMore, revertGenerateMore } = useGenerateMore(props.messageMa
       :reset-time="0"
       type="text"
       :icon="ArrowRightIcon"
-      v-auto-tip="{ always: true, content: '继续生成（实验特性）', effect: tooltipEffect }"
+      v-auto-tip="{ always: true, content: t('chatFooter.continueGenerate'), effect: tooltipEffect }"
       v-focus-hover-sync
       @click="markGenerateMore"
     >
@@ -104,7 +105,7 @@ const { markGenerateMore, revertGenerateMore } = useGenerateMore(props.messageMa
       :reset-time="0"
       type="text"
       :icon="ArrowLeftIcon"
-      v-auto-tip="{ always: true, content: '撤回上次继续生成（实验特性）', effect: tooltipEffect }"
+      v-auto-tip="{ always: true, content: t('chatFooter.revertContinueGenerate'), effect: tooltipEffect }"
       v-focus-hover-sync
       @click="revertGenerateMore"
     >

--- a/sites/playground/web/src/components/FinishInfo.vue
+++ b/sites/playground/web/src/components/FinishInfo.vue
@@ -4,6 +4,7 @@ import { computed } from 'vue';
 import { TinyPopover, TinyButton } from '@opentiny/vue';
 import { iconInfoCircle } from '@opentiny/vue-icon';
 import { vFocusHoverSync } from './v-focus-hover-sync';
+import { t } from '../i18n';
 
 const InfoIcon = iconInfoCircle();
 
@@ -48,11 +49,10 @@ function formatInt(n: number) {
 }
 
 const titleContent = computed(() => {
-  const base = '对话信息';
   if (props.chatMessage['originChatMessage'] !== undefined) {
-    return `${base}（含多次生成，仅统计最后一次生成）`;
+    return t('finishInfo.titleMultiGen');
   }
-  return base;
+  return t('finishInfo.title');
 });
 </script>
 
@@ -70,28 +70,28 @@ const titleContent = computed(() => {
         <div class="panel-title">{{ titleContent }}</div>
         <dl class="stat-list">
           <div v-if="finishChunk.model" class="stat-row">
-            <dt>模型</dt>
+            <dt>{{ t('finishInfo.model') }}</dt>
             <dd>{{ finishChunk.model }}</dd>
           </div>
           <div v-if="finishReason != null && finishReason !== ''" class="stat-row">
-            <dt>结束原因</dt>
+            <dt>{{ t('finishInfo.finishReason') }}</dt>
             <dd>{{ finishReason }}</dd>
           </div>
           <div v-if="finishChunk.created != null" class="stat-row">
-            <dt>时间</dt>
+            <dt>{{ t('finishInfo.time') }}</dt>
             <dd>{{ createdLabel }}</dd>
           </div>
           <template v-if="usage">
             <div v-if="usage.prompt_tokens != null" class="stat-row">
-              <dt>输入 Token</dt>
+              <dt>{{ t('finishInfo.promptTokens') }}</dt>
               <dd>{{ formatInt(usage.prompt_tokens) }}</dd>
             </div>
             <div v-if="usage.completion_tokens != null" class="stat-row">
-              <dt>输出 Token</dt>
+              <dt>{{ t('finishInfo.completionTokens') }}</dt>
               <dd>{{ formatInt(usage.completion_tokens) }}</dd>
             </div>
             <div v-if="usage.total_tokens != null" class="stat-row stat-row--emphasis">
-              <dt>总计 Token</dt>
+              <dt>{{ t('finishInfo.totalTokens') }}</dt>
               <dd>{{ formatInt(usage.total_tokens) }}</dd>
             </div>
           </template>
@@ -101,7 +101,7 @@ const titleContent = computed(() => {
     <template #reference>
       <tiny-button
         :reset-time="0"
-        aria-label="本轮对话统计信息"
+        :aria-label="t('finishInfo.ariaLabel')"
         type="text"
         :icon="InfoIcon"
         v-focus-hover-sync

--- a/sites/playground/web/src/components/LanguageSwitcher.vue
+++ b/sites/playground/web/src/components/LanguageSwitcher.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { TinyRadioGroup } from '@opentiny/vue';
+import { t, locale, setLocale } from '../i18n';
+
+const langOptions = [
+  { label: 'zh_CN', text: '简体中文' },
+  { label: 'en_US', text: 'English' },
+];
+
+const currentLang = computed({
+  get: () => locale.value,
+  set: (value: string) => setLocale(value),
+});
+</script>
+
+<template>
+  <div class="language-switcher" role="radiogroup" :aria-label="t('lang.switch')">
+    <tiny-radio-group v-model="currentLang" :options="langOptions" />
+  </div>
+</template>
+
+<style scoped>
+.language-switcher :deep(.tiny-radio-group) {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+</style>

--- a/sites/playground/web/src/components/LanguageSwitcher.vue
+++ b/sites/playground/web/src/components/LanguageSwitcher.vue
@@ -1,29 +1,46 @@
 <script setup lang="ts">
 import { computed } from 'vue';
-import { TinyRadioGroup } from '@opentiny/vue';
-import { t, locale, setLocale } from '../i18n';
+import { TinyDropdown } from '@opentiny/vue';
+import { locale, setLocale } from '../i18n';
 
 const langOptions = [
-  { label: 'zh_CN', text: '简体中文' },
-  { label: 'en_US', text: 'English' },
+  { label: '简体中文', value: 'zh_CN' },
+  { label: 'English', value: 'en_US' },
 ];
 
-const currentLang = computed({
-  get: () => locale.value,
-  set: (value: string) => setLocale(value),
-});
+const menuOptions = {
+  options: langOptions,
+  placement: 'top-start',
+};
+
+const currentLangLabel = computed(
+  () => langOptions.find((option) => option.value === locale.value)?.label ?? locale.value,
+);
+
+const itemClick = (payload: { itemData?: { value?: string } }) => {
+  const value = payload?.itemData?.value;
+  if (value) {
+    setLocale(value);
+  }
+};
 </script>
 
 <template>
-  <div class="language-switcher" role="radiogroup" :aria-label="t('lang.switch')">
-    <tiny-radio-group v-model="currentLang" :options="langOptions" />
+  <div class="language-switcher">
+    <tiny-dropdown
+      trigger="click"
+      :menu-options="menuOptions"
+      :title="currentLangLabel"
+      size="small"
+      :hide-on-click="true"
+      @item-click="itemClick"
+    />
   </div>
 </template>
 
 <style scoped>
-.language-switcher :deep(.tiny-radio-group) {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 16px;
+.language-switcher :deep(.tiny-dropdown) {
+  color: #191919;
+  stroke: #808080;
 }
 </style>

--- a/sites/playground/web/src/components/LanguageSwitcher.vue
+++ b/sites/playground/web/src/components/LanguageSwitcher.vue
@@ -2,6 +2,9 @@
 import { computed } from 'vue';
 import { TinyDropdown } from '@opentiny/vue';
 import { locale, setLocale } from '../i18n';
+import { iconLanguage } from '@opentiny/vue-icon';
+
+const IconLanguage = iconLanguage();
 
 const langOptions = [
   { label: '简体中文', value: 'zh_CN' },
@@ -29,7 +32,14 @@ const itemClick = (payload: { itemData?: { value?: string } }) => {
 
 <template>
   <div class="language-switcher">
-    <tiny-dropdown trigger="click" :menu-options="menuOptions" :title="currentLangLabel" @item-click="itemClick" />
+    <tiny-dropdown
+      trigger="click"
+      :prefix-icon="IconLanguage"
+      :show-icon="false"
+      :menu-options="menuOptions"
+      title=""
+      @item-click="itemClick"
+    />
   </div>
 </template>
 
@@ -37,5 +47,8 @@ const itemClick = (payload: { itemData?: { value?: string } }) => {
 .language-switcher :deep(.tiny-dropdown) {
   color: #191919;
   stroke: #808080;
+}
+.language-switcher :deep(.tiny-dropdown__prefix-inner svg) {
+  fill: #191919;
 }
 </style>

--- a/sites/playground/web/src/components/LanguageSwitcher.vue
+++ b/sites/playground/web/src/components/LanguageSwitcher.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
-import { computed } from 'vue';
 import { TinyDropdown } from '@opentiny/vue';
-import { locale, setLocale } from '../i18n';
+import { setLocale } from '../i18n';
 import { iconLanguage } from '@opentiny/vue-icon';
 
 const IconLanguage = iconLanguage();
@@ -16,12 +15,6 @@ const menuOptions = {
   placement: 'top-start',
 };
 
-const currentLangLabel = computed(() => {
-  const zhOption = langOptions[0];
-  const enOption = langOptions[1];
-  return locale.value === zhOption.value ? enOption.label : zhOption.label;
-});
-
 const itemClick = (payload: { itemData?: { value?: string } }) => {
   const value = payload?.itemData?.value;
   if (value) {
@@ -34,10 +27,10 @@ const itemClick = (payload: { itemData?: { value?: string } }) => {
   <div class="language-switcher">
     <tiny-dropdown
       trigger="click"
+      title=""
       :prefix-icon="IconLanguage"
       :show-icon="false"
       :menu-options="menuOptions"
-      title=""
       @item-click="itemClick"
     />
   </div>

--- a/sites/playground/web/src/components/LanguageSwitcher.vue
+++ b/sites/playground/web/src/components/LanguageSwitcher.vue
@@ -13,9 +13,11 @@ const menuOptions = {
   placement: 'top-start',
 };
 
-const currentLangLabel = computed(
-  () => langOptions.find((option) => option.value === locale.value)?.label ?? locale.value,
-);
+const currentLangLabel = computed(() => {
+  const zhOption = langOptions[0];
+  const enOption = langOptions[1];
+  return locale.value === zhOption.value ? enOption.label : zhOption.label;
+});
 
 const itemClick = (payload: { itemData?: { value?: string } }) => {
   const value = payload?.itemData?.value;
@@ -27,14 +29,7 @@ const itemClick = (payload: { itemData?: { value?: string } }) => {
 
 <template>
   <div class="language-switcher">
-    <tiny-dropdown
-      trigger="click"
-      :menu-options="menuOptions"
-      :title="currentLangLabel"
-      size="small"
-      :hide-on-click="true"
-      @item-click="itemClick"
-    />
+    <tiny-dropdown trigger="click" :menu-options="menuOptions" :title="currentLangLabel" @item-click="itemClick" />
   </div>
 </template>
 

--- a/sites/playground/web/src/components/PlaygroundSidebar.vue
+++ b/sites/playground/web/src/components/PlaygroundSidebar.vue
@@ -190,8 +190,6 @@ const updateCustomExamples = (list) => {
             :model-value="theme"
             @update:model-value="emit('update:theme', $event)"
           />
-          <div class="config-title language-switcher-title">{{ t('lang.switch') }}</div>
-          <LanguageSwitcher />
         </tiny-tab-item>
         <tiny-tab-item :title="t('sidebar.tabHistory')" name="history" class="history-tab">
           <GenuiHistory v-if="conversation" :conversation="conversation" />
@@ -200,6 +198,10 @@ const updateCustomExamples = (list) => {
           <component v-if="GenuiTemplateList" :is="GenuiTemplateList" />
         </tiny-tab-item>
       </tiny-tabs>
+
+      <footer v-show="expanded" class="playground-sidebar__footer">
+        <LanguageSwitcher />
+      </footer>
     </div>
 
     <!-- 移动端遮罩层 -->
@@ -302,10 +304,6 @@ const updateCustomExamples = (list) => {
       padding: 0 20px;
     }
 
-    .language-switcher-title {
-      margin-top: 24px;
-    }
-
     :deep(.tiny-tabs__header.is-top) {
       padding: 0 24px;
       flex-shrink: 0;
@@ -330,6 +328,12 @@ const updateCustomExamples = (list) => {
         overflow: hidden;
       }
     }
+  }
+
+  &__footer {
+    flex-shrink: 0;
+    padding: 12px 24px 24px;
+    border-top: 1px solid #f0f0f0;
   }
 
   .svg-icon {

--- a/sites/playground/web/src/components/PlaygroundSidebar.vue
+++ b/sites/playground/web/src/components/PlaygroundSidebar.vue
@@ -9,8 +9,10 @@ import MenuSvg from '../assets/images/menu.svg?raw';
 import ModelConfig from './tab-components/ModelConfig.vue';
 import McpTools from './tab-components/mcpTools.vue';
 import GenuiHistory from './tab-components/GenuiHistory.vue';
+import LanguageSwitcher from './LanguageSwitcher.vue';
 import { useIsMobile } from '../hooks';
 import useTemplate from './genui-template/useTemplate';
+import { t } from '../i18n';
 
 const props = defineProps({
   expanded: { type: Boolean, default: true },
@@ -37,7 +39,7 @@ const { isMobile } = useIsMobile();
 
 const currentConversationTitle = computed(() => {
   const current = conversation.value?.getCurrentConversation?.();
-  return current?.title || '新会话';
+  return current?.title || t('sidebar.newConversation');
 });
 
 // 侧边栏宽度（使用样式中定义的 CSS 变量，避免重复）
@@ -84,7 +86,7 @@ const updateCustomExamples = (list) => {
       <button
         type="button"
         class="playground-topbar__icon-btn"
-        aria-label="打开菜单"
+        :aria-label="t('sidebar.openMenu')"
         @click="emit('update:expanded', true)"
       >
         <span class="svg-icon" :innerHTML="MenuSvg"></span>
@@ -92,7 +94,13 @@ const updateCustomExamples = (list) => {
       <div class="playground-topbar__title">
         {{ currentConversationTitle }}
       </div>
-      <button v-if="showNewTaskButton" type="button" class="playground-topbar__icon-btn" aria-label="新建会话" @click="handleNewTask">
+      <button
+        v-if="showNewTaskButton"
+        type="button"
+        class="playground-topbar__icon-btn"
+        :aria-label="t('sidebar.newTask')"
+        @click="handleNewTask"
+      >
         <span class="svg-icon" :innerHTML="NewSvg"></span>
       </button>
     </div>
@@ -121,8 +129,8 @@ const updateCustomExamples = (list) => {
               v-if="expanded"
               type="button"
               class="playground-sidebar__icon-btn"
-              :aria-label="isMobile ? '关闭侧边栏' : '收起侧边栏'"
-              :title="isMobile ? '关闭' : '收起'"
+              :aria-label="isMobile ? t('sidebar.closeSidebar') : t('sidebar.collapseSidebar')"
+              :title="isMobile ? t('sidebar.close') : t('sidebar.collapseSidebar')"
               @click="emit('update:expanded', false)"
             >
               <span class="svg-icon" :innerHTML="CloseSvg" />
@@ -131,8 +139,8 @@ const updateCustomExamples = (list) => {
               v-else
               type="button"
               class="playground-sidebar__icon-btn"
-              aria-label="展开侧边栏"
-              title="展开"
+              :aria-label="t('sidebar.expandSidebar')"
+              :title="t('sidebar.expand')"
               @click="toggleExpanded"
             >
               <span class="svg-icon" :innerHTML="OpenSvg" />
@@ -142,8 +150,8 @@ const updateCustomExamples = (list) => {
             v-if="!expanded && !isMobile && showNewTaskButton"
             type="button"
             class="playground-sidebar__icon-btn"
-            aria-label="新建会话"
-            title="新建会话"
+            :aria-label="t('sidebar.newTask')"
+            :title="t('sidebar.newTask')"
             @click="handleNewTask"
           >
             <span class="svg-icon" :innerHTML="NewSvg" />
@@ -154,7 +162,7 @@ const updateCustomExamples = (list) => {
       <div class="playground-sidebar__new-task">
         <button v-if="expanded && showNewTaskButton" class="new-task-btn" type="button" @click="handleNewTask">
           <TinyIconPlus :size="16" />
-          <span class="new-task-btn__text">新建会话</span>
+          <span class="new-task-btn__text">{{ t('sidebar.newTask') }}</span>
           <div class="new-task-btn__shortcut">
             <span>Ctrl</span>
             <span>K</span>
@@ -168,26 +176,28 @@ const updateCustomExamples = (list) => {
         v-model="activeName"
         v-show="expanded"
       >
-        <tiny-tab-item title="模型配置" name="model">
-          <ModelConfig @createNewTemplate="handleCreateNewTemplate" @update-custom-examples="updateCustomExamples"/>
+        <tiny-tab-item :title="t('sidebar.tabModel')" name="model">
+          <ModelConfig @createNewTemplate="handleCreateNewTemplate" @update-custom-examples="updateCustomExamples" />
         </tiny-tab-item>
-        <tiny-tab-item title="工具" name="tools">
+        <tiny-tab-item :title="t('sidebar.tabTools')" name="tools">
           <McpTools />
         </tiny-tab-item>
-        <tiny-tab-item title="主题" name="theme">
-          <div class="config-title">切换主题</div>
+        <tiny-tab-item :title="t('sidebar.tabTheme')" name="theme">
+          <div class="config-title">{{ t('theme.switchTitle') }}</div>
           <tiny-button-group
             size="small"
             :data="themeData"
             :model-value="theme"
             @update:model-value="emit('update:theme', $event)"
           />
+          <div class="config-title language-switcher-title">{{ t('lang.switch') }}</div>
+          <LanguageSwitcher />
         </tiny-tab-item>
-        <tiny-tab-item title="历史会话" name="history" class="history-tab">
+        <tiny-tab-item :title="t('sidebar.tabHistory')" name="history" class="history-tab">
           <GenuiHistory v-if="conversation" :conversation="conversation" />
         </tiny-tab-item>
-        <tiny-tab-item v-if="ENABLE_TEMPLATE" title="模板（实验特性）" name="template">
-          <component v-if="GenuiTemplateList && isTemplateInit" :is="GenuiTemplateList"/>
+        <tiny-tab-item v-if="ENABLE_TEMPLATE && isTemplateInit" :title="t('sidebar.tabTemplate')" name="template">
+          <component v-if="GenuiTemplateList" :is="GenuiTemplateList" />
         </tiny-tab-item>
       </tiny-tabs>
     </div>
@@ -287,6 +297,13 @@ const updateCustomExamples = (list) => {
       color: #595959;
       margin-bottom: 12px;
       line-height: 32px;
+    }
+    :deep(.tiny-button-group .tiny-group-item li button) {
+      padding: 0 20px;
+    }
+
+    .language-switcher-title {
+      margin-top: 24px;
     }
 
     :deep(.tiny-tabs__header.is-top) {

--- a/sites/playground/web/src/components/UserFooter.vue
+++ b/sites/playground/web/src/components/UserFooter.vue
@@ -8,6 +8,7 @@ import { AutoTip } from '@opentiny/vue-directive';
 import copy from 'clipboard-copy';
 import type { IBubbleSlotsProps } from './common.types';
 import EditInputRenderer from './EditInputRenderer.vue';
+import { t } from '../i18n';
 
 const props = defineProps<IBubbleSlotsProps>();
 const generating = computed(() => GeneratingStatus.includes(props.messageManager?.messageState.status));
@@ -93,7 +94,7 @@ const handleCancelEdit = () => {
         :reset-time="0"
         type="text"
         :icon="EditIcon"
-        v-auto-tip="{ always: true, content: '编辑', effect: tooltipEffect }"
+        v-auto-tip="{ always: true, content: t('common.edit'), effect: tooltipEffect }"
         @click="handleStartEditByIndex"
       >
       </tiny-button>
@@ -102,7 +103,7 @@ const handleCancelEdit = () => {
         type="text"
         :reset-time="0"
         :icon="CopyIcon"
-        v-auto-tip="{ always: true, content: '复制', effect: tooltipEffect }"
+        v-auto-tip="{ always: true, content: t('chatFooter.copy'), effect: tooltipEffect }"
         @click="handleCopyMessageByIndex"
       >
       </tiny-button>

--- a/sites/playground/web/src/components/genui-template/GenuiTemplate.vue
+++ b/sites/playground/web/src/components/genui-template/GenuiTemplate.vue
@@ -13,6 +13,7 @@ import useTemplate from './useTemplate';
 import { useIsMobile } from '../../use-mobile';
 import { useMonacoPlaygroundTheme } from './use-monaco-playground-theme';
 import viewSchemaIcon from '../../assets/images/view-schema.svg';
+import { locale, t } from '../../i18n';
 
 const { isMobile } = useIsMobile();
 
@@ -274,7 +275,12 @@ onUnmounted(() => {
   <div :class="['genui-schema-template', { 'is-mobile': isMobile }]">
     <div class="genui-schema-template-item chat-container">
       <!-- 桌面：打开内联编辑器时隐藏聊天；移动端：底部抽屉叠在聊天上，聊天保持挂载以便背后仍可见 -->
-      <GenuiConfigProvider v-show="!schemaEditorVisible || isMobile" :theme="theme" style="width: 100%; height: 100%">
+      <GenuiConfigProvider
+        v-show="!schemaEditorVisible || isMobile"
+        :theme="theme"
+        :locale="locale"
+        style="width: 100%; height: 100%"
+      >
         <genui-template-chat class="genui-template-chat" @schema-version-toggle="toggleSchemaVersion" />
       </GenuiConfigProvider>
       <div class="schema-version-container" v-show="schemaEditorVisible && !isMobile">
@@ -284,7 +290,7 @@ onUnmounted(() => {
             type="text"
             class="genui-schema-toolbar-close-btn"
             :icon="TinyCloseIcon"
-            aria-label="关闭"
+            :aria-label="t('templateEditor.close')"
             @click="closeSchemaEditorView"
           />
         </div>
@@ -320,23 +326,30 @@ onUnmounted(() => {
           <div class="top-button-group">
             <button type="button" class="schema-toggle-text" @click="toggleSchemaEditor">
               <img class="button-svg-icon" :src="viewSchemaIcon" alt="" />
-              查看 JSON
+              {{ t('templateEditor.viewJson') }}
             </button>
             <div class="top-button-group-right">
-              <tiny-button v-if="showReturnLatestButton" type="primary" round @click="resetToLatestVersion">返回最新版本</tiny-button>
+              <tiny-button v-if="showReturnLatestButton" type="primary" round @click="resetToLatestVersion">{{
+                t('templateEditor.returnLatest')
+              }}</tiny-button>
               <tiny-button v-if="showReturnLatestButton" round @click="applyCurrentVersion">
-                应用此版本
+                {{ t('templateEditor.applyVersion') }}
               </tiny-button>
               <tiny-button
                 type="text"
                 class="genui-schema-toolbar-close-btn"
                 :icon="TinyCloseIcon"
-                aria-label="关闭预览区"
+                :aria-label="t('templateEditor.closePreview')"
                 @click="closeRendererPanel"
               />
             </div>
           </div>
-          <schema-renderer class="schema-renderer" :content="currentPreviewSchema" :generating="false" :isJsonComplete="currentPreviewSchemaComplete" />
+          <schema-renderer
+            class="schema-renderer"
+            :content="currentPreviewSchema"
+            :generating="false"
+            :isJsonComplete="currentPreviewSchemaComplete"
+          />
         </div>
       </div>
     </template>

--- a/sites/playground/web/src/components/genui-template/GenuiTemplateChat.vue
+++ b/sites/playground/web/src/components/genui-template/GenuiTemplateChat.vue
@@ -33,6 +33,7 @@ import AssistantFooter from './TemplateAssistantFooter.vue';
 import TemplateSchemaMessageRenderer from './TemplateSchemaMessageRenderer.vue';
 import { emitter } from './template-chat-event-emitter';
 import useIcon from '../../use-icon';
+import { t } from '../../i18n';
 
 const { addIcons } = useIcon();
 addIcons(IconAi, IconUser, IconArrowDown);
@@ -324,7 +325,7 @@ const showMessages = computed(() => {
       ...showMessages,
       {
         role: 'assistant',
-        content: '正在思考中...',
+        content: t('loading.thinking'),
         loading: true,
       },
     ];
@@ -454,7 +455,7 @@ onUnmounted(() => {
       <tr-sender
         v-model="inputMessage"
         :placeholder="
-          GeneratingStatus.includes(messageManager.messageState.status) ? '正在思考中...' : '请输入您的问题～'
+          GeneratingStatus.includes(messageManager.messageState.status) ? t('loading.thinking') : t('placeholder.input')
         "
         :clearable="true"
         :loading="GeneratingStatus.includes(messageManager.messageState.status)"
@@ -465,7 +466,7 @@ onUnmounted(() => {
         @cancel="messageManager.abortRequest"
       >
       </tr-sender>
-      <div class="footer-text">内容由AI生成，仅供参考</div>
+      <div class="footer-text">{{ t('footer.aiGenerated') }}</div>
     </div>
   </div>
 </template>

--- a/sites/playground/web/src/components/genui-template/GenuiTemplateList.vue
+++ b/sites/playground/web/src/components/genui-template/GenuiTemplateList.vue
@@ -8,9 +8,10 @@ import useTemplate from './useTemplate';
 import {
   HistoryTransferToolbar,
   downloadConversations,
+  getHistoryMenuItems,
   reconcileImportedConversationIds,
-  historyMenuItems,
 } from '../tab-components/history-transfer';
+import { t } from '../../i18n';
 
 const TinyIconPlus = iconPlus();
 const { isTouchDevice } = useTouchDevice();
@@ -24,6 +25,8 @@ const selectedTemplateIds = ref<string[]>([]);
 const selectionActive = ref(false);
 
 const conversations = computed(() => templateConversationState.value?.conversations ?? []);
+
+const historyMenuItems = getHistoryMenuItems();
 
 watch(selectionActive, (active) => {
   if (!active) {
@@ -62,7 +65,7 @@ const handleItemAction = (action: { id: string }, item: Conversation) => {
   }
 
   if (action.id === 'delete') {
-    TinyModal.confirm('确定删除该模板吗？')
+    TinyModal.confirm(t('template.confirmDeleteOne'))
       .then((type: 'confirm' | 'cancel') => {
         if (type === 'cancel') {
           return;
@@ -91,7 +94,7 @@ const handleBatchDelete = () => {
   if (ids.length === 0) {
     return;
   }
-  TinyModal.confirm(`确定删除选中的 ${ids.length} 个模板？`)
+  TinyModal.confirm(t('template.confirmBatchDelete', { count: ids.length }))
     .then((type: 'confirm' | 'cancel') => {
       if (type === 'cancel') {
         return;
@@ -108,7 +111,7 @@ const handleBatchDelete = () => {
   <div class="genui-template-list">
     <button class="new-template-btn" type="button" @click="handleAddItem">
       <TinyIconPlus :size="16" />
-      <span class="new-template-btn__text">新建模板</span>
+      <span class="new-template-btn__text">{{ t('template.new') }}</span>
     </button>
     <history-transfer-toolbar
       v-model:selection-active="selectionActive"

--- a/sites/playground/web/src/components/genui-template/GenuiTemplateMobileSheet.vue
+++ b/sites/playground/web/src/components/genui-template/GenuiTemplateMobileSheet.vue
@@ -4,6 +4,7 @@ import { GenuiRenderer as SchemaRenderer } from '@opentiny/genui-sdk-vue';
 import { TinyButton } from '@opentiny/vue';
 import type { CSSProperties } from 'vue';
 import { useMonacoPlaygroundTheme, type PlaygroundColorTheme } from './use-monaco-playground-theme';
+import { t } from '../../i18n';
 
 const props = defineProps<{
   visible: boolean;
@@ -44,7 +45,7 @@ const handleJsonEditorChange = (value: string) => {
         class="schema-mobile-sheet"
         role="dialog"
         aria-modal="true"
-        :aria-label="jsonEditorOpen ? 'Schema JSON 编辑器' : 'Schema JSON 预览'"
+        :aria-label="jsonEditorOpen ? t('templateEditor.jsonEditorAria') : t('templateEditor.jsonPreviewAria')"
       >
         <div class="schema-mobile-sheet__mask" @click="emit('mask-click')" />
         <div class="schema-mobile-sheet__panel" :style="props.panelStyle">
@@ -58,7 +59,7 @@ const handleJsonEditorChange = (value: string) => {
                 @click="emit('update:jsonEditorOpen', true)"
               >
                 <img class="schema-mobile-sheet__entry-icon" :src="viewSchemaIcon" alt="" />
-                查看 JSON
+                {{ t('templateEditor.viewJson') }}
               </button>
               <button
                 v-else
@@ -66,7 +67,7 @@ const handleJsonEditorChange = (value: string) => {
                 class="schema-mobile-sheet__back"
                 @click="emit('update:jsonEditorOpen', false)"
               >
-                返回预览
+                {{ t('templateEditor.backToPreview') }}
               </button>
             </div>
             <div class="schema-mobile-sheet__header-end">
@@ -74,7 +75,7 @@ const handleJsonEditorChange = (value: string) => {
                 type="text"
                 class="genui-schema-toolbar-close-btn"
                 :icon="closeIcon"
-                aria-label="关闭"
+                :aria-label="t('templateEditor.close')"
                 @click="emit('close')"
               />
             </div>
@@ -108,7 +109,7 @@ const handleJsonEditorChange = (value: string) => {
           </div>
           <div v-if="showReturnLatestButton" class="schema-mobile-sheet__footer">
             <tiny-button round class="schema-mobile-sheet__latest-btn" @click="emit('apply-current-version')">
-              应用此版本
+              {{ t('templateEditor.applyVersion') }}
             </tiny-button>
             <tiny-button
               type="primary"
@@ -116,7 +117,7 @@ const handleJsonEditorChange = (value: string) => {
               class="schema-mobile-sheet__latest-btn"
               @click="emit('reset-to-latest-version')"
             >
-              返回最新版本
+              {{ t('templateEditor.returnLatest') }}
             </tiny-button>
           </div>
         </div>

--- a/sites/playground/web/src/components/genui-template/JsonPatchDev.vue
+++ b/sites/playground/web/src/components/genui-template/JsonPatchDev.vue
@@ -7,6 +7,7 @@ import * as jsonDiffPatch from 'jsondiffpatch';
 import * as jsonPatchFormatter from 'jsondiffpatch/formatters/jsonpatch';
 import type { JsonPatchOp } from 'jsondiffpatch/formatters/jsonpatch-apply';
 import { textToJson } from './template-chat-utils';
+import { t } from '../../i18n';
 
 const props = defineProps<{
   currentSchema: string;
@@ -90,7 +91,7 @@ watch(
 </script>
 
 <template>
-  <tiny-dialog-box v-model:visible="visible" title="调试器" width="80%" height="600px">
+  <tiny-dialog-box v-model:visible="visible" :title="t('templateEditor.debugger')" width="80%" height="600px">
     <!-- footer 居中 -->
     <template #footer>
       <div class="json-patch-dev-footer">

--- a/sites/playground/web/src/components/genui-template/SchemaVersionCard.vue
+++ b/sites/playground/web/src/components/genui-template/SchemaVersionCard.vue
@@ -7,6 +7,7 @@ import useTemplate from './useTemplate';
 import { useIsMobile } from '../../use-mobile';
 import docCardIcon from '../../assets/images/card.svg';
 import docEditIcon from '../../assets/images/card-edit.svg';
+import { t } from '../../i18n';
 
 const TinyIconRichTextCodeView = iconRichTextCodeView();
 
@@ -67,18 +68,18 @@ const handleDev = () => {
           {{ props.input.substring(0, 20) }}{{ props.input.length > 20 ? '...' : '' }}
         </div>
         <div class="schema-version-card-content-time">
-          <template v-if="generating">生成中...</template>
-          <template v-else>创建时间：{{ generatedTime }}</template>
+          <template v-if="generating">{{ t('templateEditor.generating') }}</template>
+          <template v-else>{{ t('templateEditor.createdAt', { time: generatedTime }) }}</template>
         </div>
       </div>
     </div>
     <div class="schema-version-card-footer">
       <div v-if="isDev && props.type === 'json-patch' && !generating && !isMobile" class="icons-wrap">
-        <div class="icon-item" title="调试 jsonPatch" @click.stop="handleDev">
+        <div class="icon-item" :title="t('templateEditor.debugJsonPatch')" @click.stop="handleDev">
           <TinyIconRichTextCodeView />
         </div>
       </div>
-      <div v-if="errorMessage" class="error-message">解析失败</div>
+      <div v-if="errorMessage" class="error-message">{{ t('templateEditor.parseFailed') }}</div>
     </div>
   </div>
   <JsonPatchDev

--- a/sites/playground/web/src/components/genui-template/TemplateAssistantFooter.vue
+++ b/sites/playground/web/src/components/genui-template/TemplateAssistantFooter.vue
@@ -4,6 +4,7 @@ import { TinyButton } from '@opentiny/vue';
 import { AutoTip } from '@opentiny/vue-directive';
 import { iconRefresh, iconCopy } from '@opentiny/vue-icon';
 import type { IBubbleSlotsProps } from '@opentiny/genui-sdk-vue';
+import { t } from '../../i18n';
 
 const emit = defineEmits(['refresh', 'copy']);
 
@@ -13,7 +14,7 @@ const RefreshIcon = iconRefresh();
 const CopyIcon = iconCopy();
 
 const vAutoTip = AutoTip;
-const copyTooltip = ref('复制');
+const copyTooltip = ref(t('chatFooter.copy'));
 
 const isLastBubble = computed(() => {
   const { messages } = props.messageManager;
@@ -34,7 +35,7 @@ const refresh = () => {
     <tiny-button
       type="text"
       :icon="RefreshIcon"
-      v-auto-tip="{ always: true, content: '刷新', effect: 'light' }"
+      v-auto-tip="{ always: true, content: t('chatFooter.refresh'), effect: 'light' }"
       @click="refresh"
     >
     </tiny-button>

--- a/sites/playground/web/src/components/genui-template/useTemplate.ts
+++ b/sites/playground/web/src/components/genui-template/useTemplate.ts
@@ -3,6 +3,7 @@ import { useConversation, IndexedDBStrategy } from '@opentiny/genui-sdk-vue';
 import { AIClient, type ChatMessage } from '@opentiny/tiny-robot-kit';
 import { CustomModelProvider } from './template-provider';
 import type { LLMConfig, IMessageItem, IJsonPatchMessageItem, ISchemaCardMessageItem } from './chat.types';
+import { t } from '../../i18n';
 
 const conversation = shallowRef<ReturnType<typeof useConversation> | null>(null);
 let templateProvider: CustomModelProvider | null = null;
@@ -15,7 +16,6 @@ const currentPreviewSchema = shallowRef<any>(null);
 const currentPreviewSchemaComplete = ref(true);
 // 当前卡片 id，用于记录卡片 id，避免重复执行 patch 操作
 const currentCardId = ref<string>('');
-const DEFAULT_TEMPLATE_TITLE = '新模板';
 
 export interface UseTemplateOptions {
   url: string;
@@ -52,7 +52,7 @@ export default function useTemplate(options?: UseTemplateOptions) {
         onLoaded(conversations) {
           // 如果历史会话为空，则创建一个默认会话
           if (!conversations.length) {
-            conversation.value!.createConversation(DEFAULT_TEMPLATE_TITLE);
+            conversation.value!.createConversation(t('template.defaultTitle'));
             conversation.value!.saveConversations();
           }
         },
@@ -113,7 +113,7 @@ export default function useTemplate(options?: UseTemplateOptions) {
     }
 
     const { createConversation, saveConversations } = conversation.value;
-    createConversation(DEFAULT_TEMPLATE_TITLE);
+    createConversation(t('template.defaultTitle'));
     saveConversations();
     setCurrentSchema(null);
     setCurrentPreviewSchema(null);

--- a/sites/playground/web/src/components/tab-components/GenuiHistory.vue
+++ b/sites/playground/web/src/components/tab-components/GenuiHistory.vue
@@ -37,11 +37,14 @@
 <script setup lang="ts">
 import { TrHistory, useTouchDevice } from '@opentiny/tiny-robot';
 import { type Conversation, type UseConversationReturn } from '@opentiny/tiny-robot-kit';
-import { HistoryTransferToolbar, downloadConversations, historyMenuItems, groupByTimeBuckets } from './history-transfer';
+import { HistoryTransferToolbar, downloadConversations, getHistoryMenuItems, groupByTimeBuckets } from './history-transfer';
 import { TinyCheckbox, TinyCheckboxGroup, TinyModal } from '@opentiny/vue';
+import { t } from '../../i18n';
 import { computed, ref, watch } from 'vue';
 
 const { isTouchDevice } = useTouchDevice();
+
+const historyMenuItems = getHistoryMenuItems();
 
 const selectedConversations = ref<string[]>([]);
 const selectionActive = ref(false);
@@ -112,7 +115,7 @@ const handleBatchDelete = () => {
   if (ids.length === 0) {
     return;
   }
-  TinyModal.confirm(`确定删除选中的 ${ids.length} 条会话？`)
+  TinyModal.confirm(t('conversation.confirmBatchDelete', { count: ids.length }))
     .then((type: 'confirm' | 'cancel') => {
       if (type === 'cancel') {
         return;

--- a/sites/playground/web/src/components/tab-components/ModelConfig.vue
+++ b/sites/playground/web/src/components/tab-components/ModelConfig.vue
@@ -11,6 +11,7 @@ import {
 } from '@opentiny/vue';
 import { iconPlus, iconEllipsis, iconEdit, iconDel } from '@opentiny/vue-icon';
 import SelectTemplateDialog from './SelectTemplateDialog.vue';
+import { t } from '../../i18n';
 
 const emit = defineEmits(['update:llmConfig', 'createNewTemplate', 'update-custom-examples']);
 const playgroundContext = inject('playgroundContext');
@@ -97,10 +98,10 @@ const createNewTemplate = () => {
 };
 </script>
 <template>
-  <div class="config-title">模型选择</div>
+  <div class="config-title">{{ t('model.select') }}</div>
   <tiny-base-select :model-value="llmConfig.model" @update:model-value="updateModel" :options="modelData"
     :tooltip-config="{ always: false }" class="config-content"></tiny-base-select>
-  <div class="config-title">模型温度</div>
+  <div class="config-title">{{ t('model.temperature') }}</div>
   <tiny-slider
     :model-value="llmConfig.temperature"
     @update:model-value="updateTemperature"
@@ -115,7 +116,7 @@ const createNewTemplate = () => {
     </template>
   </tiny-slider>
   <div class="config-title prompt-title">
-    <span>提示词</span>
+    <span>{{ t('model.prompt') }}</span>
     <span>
       <tiny-button type="text" :icon="IconPlus" @click="showAddPromptBox = true"> </tiny-button>
     </span>
@@ -141,11 +142,11 @@ const createNewTemplate = () => {
           <div class="prompt-item-actions">
             <div @click="editPrompt(index)">
               <IconEdit />
-              <span>编辑</span>
+              <span>{{ t('model.edit') }}</span>
             </div>
             <div @click="delPrompt(index)">
               <IconDel />
-              <span>删除</span>
+              <span>{{ t('model.delete') }}</span>
             </div>
           </div>
         </template>
@@ -157,7 +158,7 @@ const createNewTemplate = () => {
   </div>
   <tiny-dialog-box
     v-model:visible="showAddPromptBox"
-    :title="isEditPrompt ? '编辑提示词' : '添加提示词'"
+    :title="isEditPrompt ? t('model.editPrompt') : t('model.addPrompt')"
     width="30%"
     :append-to-body="true"
   >
@@ -170,10 +171,10 @@ const createNewTemplate = () => {
       autofocus
     ></tiny-input>
     <template #footer>
-      <tiny-button @click="resetState" round>取 消</tiny-button>
+      <tiny-button @click="resetState" round>{{ t('model.cancel') }}</tiny-button>
       <tiny-button type="primary"
         @click="isEditPrompt ? updatePrompt(appendPrompt, activeIndex) : addPrompt(activeIndex)" round>
-        确 定
+        {{ t('model.confirm') }}
       </tiny-button>
     </template>
   </tiny-dialog-box>
@@ -181,7 +182,7 @@ const createNewTemplate = () => {
   <!-- 选择示例模板 -->
   <template v-if="ENABLE_TEMPLATE">
     <div class="config-title prompt-title">
-      <span>示例模板</span>
+      <span>{{ t('model.exampleTemplates') }}</span>
       <span>
         <tiny-button type="text" :icon="IconPlus" @click="showSelectExampleBox = true"> </tiny-button>
       </span>
@@ -197,11 +198,11 @@ const createNewTemplate = () => {
           <div class="prompt-item-actions">
             <div @click="editCustomExample(item.id)">
               <IconEdit />
-              <span>编辑</span>
+              <span>{{ t('model.edit') }}</span>
             </div>
             <div @click="delCustomExample(index)">
               <IconDel />
-              <span>删除</span>
+              <span>{{ t('model.delete') }}</span>
             </div>
           </div>
         </template>

--- a/sites/playground/web/src/components/tab-components/SelectTemplateDialog.vue
+++ b/sites/playground/web/src/components/tab-components/SelectTemplateDialog.vue
@@ -2,6 +2,7 @@
 import { computed, ref, watch } from 'vue';
 import useTemplate from '../genui-template/useTemplate';
 import { TinyDialogBox, TinyButton, TinyCheckboxGroup, TinyCheckbox } from '@opentiny/vue';
+import { t } from '../../i18n';
 
 const props = defineProps({
   visible: {
@@ -77,12 +78,12 @@ watch(
 </script>
 
 <template>
-  <tiny-dialog-box v-model:visible="visibleModel" @close="cancel" title="选择示例模板" width="40%"
+  <tiny-dialog-box v-model:visible="visibleModel" @close="cancel" :title="t('template.selectTitle')" width="40%"
     :append-to-body="true">
     <template #footer>
-      <tiny-button @click="cancel">取 消</tiny-button>
-      <tiny-button type="primary" @click="createNewTemplate">创建新模板</tiny-button>
-      <tiny-button type="primary" @click="confirmSelectExample">确 定</tiny-button>
+      <tiny-button @click="cancel">{{ t('template.cancel') }}</tiny-button>
+      <tiny-button type="primary" @click="createNewTemplate">{{ t('template.createNew') }}</tiny-button>
+      <tiny-button type="primary" @click="confirmSelectExample">{{ t('template.confirm') }}</tiny-button>
     </template>
     <template #default>
       <tiny-checkbox-group v-model="selectedExamples" class="template-checkbox-group">

--- a/sites/playground/web/src/components/tab-components/ToolCallConfig.vue
+++ b/sites/playground/web/src/components/tab-components/ToolCallConfig.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { inject } from 'vue';
 import { TinyCheckbox } from '@opentiny/vue';
+import { t } from '../../i18n';
 
 const playgroundContext = inject('playgroundContext');
 const { chatConfig } = playgroundContext;
@@ -17,12 +18,12 @@ const updateShowThinkingResult = (value) => {
 <template>
   <div class="tool-call-config">
     <tiny-checkbox :model-value="chatConfig.addToolCallContext" @update:model-value="updateAddToolCallContext">
-      调用结果添加到上下文
+      {{ t('tool.addContext') }}
     </tiny-checkbox>
   </div>
   <div class="tool-call-config">
     <tiny-checkbox :model-value="chatConfig.showThinkingResult" @update:model-value="updateShowThinkingResult">
-      调用结果展示在界面中
+      {{ t('tool.showInUI') }}
     </tiny-checkbox>
   </div>
 </template>

--- a/sites/playground/web/src/components/tab-components/history-transfer/HistoryTransferToolbar.vue
+++ b/sites/playground/web/src/components/tab-components/history-transfer/HistoryTransferToolbar.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="history-transfer-toolbar">
     <span class="history-transfer-toolbar__selection-toggle" :class="{ 'active': selectionActive }" @click="toggleSelectionMode">
-      {{ selectionActive ? '取消' : '多选' }}
+      {{ selectionActive ? t('history.cancel') : t('history.selectMode') }}
     </span>
     <tiny-button
       round
@@ -9,13 +9,13 @@
       :disabled="!selectionActive || selectedIds.length === 0"
       @click="emit('batch-delete')"
     >
-      删除
+      {{ t('history.delete') }}
     </tiny-button>
-    <tiny-button round size="small" @click="triggerImport">导入</tiny-button>
+    <tiny-button round size="small" @click="triggerImport">{{ t('history.import') }}</tiny-button>
     <tiny-dropdown
       border
       trigger="click"
-      title="导出"
+      :title="t('history.export')"
       size="small"
       round
       :hide-on-click="true"
@@ -26,12 +26,12 @@
       <template #dropdown>
         <tiny-dropdown-menu>
           <tiny-dropdown-item
-            label="导出全部记录"
+            :label="t('history.exportAll')"
             :disabled="conversations.length === 0"
             :item-data="exportItemAll"
           />
           <tiny-dropdown-item
-            label="导出已选记录"
+            :label="t('history.exportSelected')"
             :disabled="!selectionActive || selectedIds.length === 0"
             :item-data="exportItemSelected"
           />
@@ -58,6 +58,7 @@ import {
   TinyDropdownItem,
 } from '@opentiny/vue';
 import type { Conversation } from '@opentiny/tiny-robot-kit';
+import { t } from '../../../i18n';
 import { downloadConversations, parseConversationFile, reconcileImportedConversationIds } from './history-transfer';
 
 const selectionActive = defineModel<boolean>('selectionActive', { default: false });
@@ -101,7 +102,7 @@ const triggerImport = () => {
 
 const exportAll = () => {
   if (props.conversations.length === 0) {
-    notify('warning', '当前没有可导出的会话');
+    notify('warning', t('history.noExportable'));
     return;
   }
 
@@ -133,15 +134,15 @@ const handleImportFile = async (event: Event) => {
   try {
     const importedConversations = await parseConversationFile(file);
     if (importedConversations.length === 0) {
-      notify('warning', '未找到可导入的会话');
+      notify('warning', t('history.noImportable'));
       return;
     }
 
     const reconciledImported = reconcileImportedConversationIds(props.conversations, importedConversations);
     emit('import-conversations', reconciledImported);
-    notify('success', `已导入 ${reconciledImported.length} 条会话`);
+    notify('success', t('history.importSuccess', { count: reconciledImported.length }));
   } catch (error) {
-    const message = error instanceof Error ? error.message : '导入失败';
+    const message = error instanceof Error ? error.message : t('history.importFailed');
     notify('error', message);
   } finally {
     input.value = '';

--- a/sites/playground/web/src/components/tab-components/history-transfer/history-menu.ts
+++ b/sites/playground/web/src/components/tab-components/history-transfer/history-menu.ts
@@ -1,8 +1,9 @@
 import { IconDelete, IconEditPen } from '@opentiny/tiny-robot-svgs';
 import { IconDownload } from '@opentiny/vue-icon';
+import { t } from '../../../i18n';
 
-export const historyMenuItems = [
-  { id: 'export', text: '导出', icon: IconDownload() },
-  { id: 'rename', text: '重命名', icon: IconEditPen },
-  { id: 'delete', text: '删除', icon: IconDelete },
+export const getHistoryMenuItems = () => [
+  { id: 'export', text: t('history.menu.export'), icon: IconDownload() },
+  { id: 'rename', text: t('history.menu.rename'), icon: IconEditPen },
+  { id: 'delete', text: t('history.menu.delete'), icon: IconDelete },
 ];

--- a/sites/playground/web/src/components/tab-components/history-transfer/history-transfer.ts
+++ b/sites/playground/web/src/components/tab-components/history-transfer/history-transfer.ts
@@ -1,4 +1,5 @@
 import type { Conversation } from '@opentiny/tiny-robot-kit';
+import { t } from '../../../i18n';
 import { formatDate, generateId } from '../../../utils';
 
 const generateUniqueId = (existingIds: Set<string>) => {
@@ -26,7 +27,7 @@ const normalizeConversation = (value: unknown): Conversation | null => {
 
   return {
     id,
-    title: typeof value.title === 'string' && value.title.trim() ? value.title : '新会话',
+    title: typeof value.title === 'string' && value.title.trim() ? value.title : t('conversation.newConversation'),
     createdAt: typeof value.createdAt === 'number' ? value.createdAt : Date.now(),
     updatedAt: typeof value.updatedAt === 'number' ? value.updatedAt : Date.now(),
     messages: value.messages as Conversation['messages'],
@@ -50,11 +51,11 @@ export const parseConversationFile = async (file: File) => {
   try {
     rawData = JSON.parse(await file.text());
   } catch (error) {
-    throw new Error('导入文件不是有效的 JSON');
+    throw new Error(t('history.invalidJson'));
   }
 
   if (!Array.isArray(rawData)) {
-    throw new Error('导入文件必须是会话数组');
+    throw new Error(t('history.mustBeArray'));
   }
 
   return rawData.map(normalizeConversation).filter(Boolean) as Conversation[];

--- a/sites/playground/web/src/components/tab-components/history-transfer/index.ts
+++ b/sites/playground/web/src/components/tab-components/history-transfer/index.ts
@@ -1,5 +1,5 @@
 import HistoryTransferToolbar from './HistoryTransferToolbar.vue';
 export { downloadConversations, parseConversationFile, reconcileImportedConversationIds } from './history-transfer';
-export { historyMenuItems } from './history-menu';
+export { getHistoryMenuItems } from './history-menu';
 export { HistoryTransferToolbar };
 export * from './time-buckets';

--- a/sites/playground/web/src/components/tab-components/history-transfer/time-buckets.ts
+++ b/sites/playground/web/src/components/tab-components/history-transfer/time-buckets.ts
@@ -1,3 +1,5 @@
+import { t } from '../../../i18n';
+
 export enum TimeBucketKey {
   Today = 'today',
   Yesterday = 'yesterday',
@@ -16,13 +18,8 @@ export const TIME_BUCKET_LABELS = [
   TimeBucketKey.AMonthAgo,
 ] as const satisfies readonly TimeBucketLabel[];
 
-export const TIME_BUCKET_DISPLAY_LABELS: Record<TimeBucketLabel, string> = {
-  [TimeBucketKey.Today]: '今天',
-  [TimeBucketKey.Yesterday]: '昨天',
-  [TimeBucketKey.TwoDaysAgo]: '两天前',
-  [TimeBucketKey.AWeekAgo]: '一周前',
-  [TimeBucketKey.AMonthAgo]: '一个月前',
-};
+export const getTimeBucketDisplayLabel = (label: TimeBucketLabel): string =>
+  t(`history.timeBucket.${label}`);
 
 const MS_PER_DAY = 86400000;
 
@@ -83,7 +80,7 @@ export const groupByTimeBuckets = <T extends WithCreatedAt>(
   }
 
   return TIME_BUCKET_LABELS.filter((label) => buckets[label].length > 0).map((label) => ({
-    group: TIME_BUCKET_DISPLAY_LABELS[label],
+    group: getTimeBucketDisplayLabel(label),
     items: [...buckets[label]],
   }));
 };

--- a/sites/playground/web/src/components/tab-components/skill/SkillFormDialog.vue
+++ b/sites/playground/web/src/components/tab-components/skill/SkillFormDialog.vue
@@ -3,6 +3,7 @@ import { computed, nextTick, ref, watch } from 'vue';
 import { TinyButton, TinyDialogBox, TinyForm, TinyFormItem, TinyInput } from '@opentiny/vue';
 import SkillModulesExplorer from './SkillModulesExplorer.vue';
 import { buildSingleModules, parseFrontMatterNameDesc } from './index';
+import { t } from '../../../i18n';
 
 const props = defineProps({
   allSkills: {
@@ -24,7 +25,7 @@ const rules = computed(() => ({
       validator: (rule, value, callback) => {
         const skillName = (value || '').trim();
         if (!skillName) {
-          callback(new Error('请填写 Skill 名称'));
+          callback(new Error(t('skill.nameRequired')));
           return;
         }
         const index = skillData.value.index ?? -1;
@@ -32,7 +33,7 @@ const rules = computed(() => ({
           (s, i) => i !== index && (s.name || '').trim() === skillName,
         );
         if (dup) {
-          callback(new Error(`已存在名为「${skillName}」的 Skill，名称不可重复`));
+          callback(new Error(t('skill.duplicateName', { name: skillName })));
         } else {
           callback();
         }
@@ -46,7 +47,7 @@ const rules = computed(() => ({
         const hasModules = value && typeof value === 'object' && Object.keys(value).length > 0;
         const hasContent = (skillData.value.content || '').trim();
         if (!hasModules && !hasContent) {
-          callback(new Error('请导入文件夹或填写单文档内容'));
+          callback(new Error(t('skill.contentRequired')));
         } else {
           callback();
         }
@@ -117,7 +118,7 @@ const submit = () => {
 <template>
   <tiny-dialog-box
     v-model:visible="visible"
-    :title="skillData.index > -1 ? '编辑 Skill' : '添加 Skill'"
+    :title="skillData.index > -1 ? t('skill.edit') : t('skill.add')"
     width="1000px"
     :append-to-body="true"
     @close="handleDialogClose"
@@ -129,26 +130,25 @@ const submit = () => {
       label-width="120px"
       label-position="left"
     >
-      <tiny-form-item label="名称" prop="name" required>
-        <tiny-input v-model="skillData.name" placeholder="列表展示名称，可与 SKILL.md 中 name 一致"></tiny-input>
+      <tiny-form-item :label="t('common.name')" prop="name" required>
+        <tiny-input v-model="skillData.name" :placeholder="t('skill.namePlaceholder')"></tiny-input>
       </tiny-form-item>
-      <tiny-form-item label="描述" prop="description" required>
+      <tiny-form-item :label="t('common.description')" prop="description" required>
         <tiny-input
           type="textarea"
           v-model="skillData.description"
-          placeholder="列表摘要；导入文件夹时可从主 SKILL.md 自动带出"
+          :placeholder="t('skill.descPlaceholder')"
         ></tiny-input>
       </tiny-form-item>
-      <tiny-form-item label="技能包" prop="modules">
+      <tiny-form-item :label="t('skill.pack')" prop="modules">
         <div class="skill-pack-row">
-          <label for="playground-skill-folder-import" class="skill-folder-pick-btn">选择文件夹</label>
+          <label for="playground-skill-folder-import" class="skill-folder-pick-btn">{{ t('skill.pickFolder') }}</label>
           <tiny-button v-if="skillData.modules && Object.keys(skillData.modules).length" type="text" @click="clearImportedFolder">
-            清除文件夹，改用手写单文档
+            {{ t('skill.clearFolder') }}
           </tiny-button>
         </div>
         <div v-if="skillData.modules && Object.keys(skillData.modules).length" class="skill-pack-summary">
-          已加载 {{ Object.keys(skillData.modules).length }} 个文件；对话时仅注入技能摘要，完整文档由模型通过 get_skill_content
-          按需拉取（渐进式披露）。
+          {{ t('skill.packSummary', { count: Object.keys(skillData.modules).length }) }}
         </div>
         <SkillModulesExplorer
           v-if="skillData.modules && Object.keys(skillData.modules).length"
@@ -156,19 +156,19 @@ const submit = () => {
           @modules-edit="onModulesEdit"
         />
       </tiny-form-item>
-      <tiny-form-item v-if="!skillData.modules || !Object.keys(skillData.modules).length" label="单文档内容" prop="content">
+      <tiny-form-item v-if="!skillData.modules || !Object.keys(skillData.modules).length" :label="t('skill.singleDoc')" prop="content">
         <tiny-input
           type="textarea"
           v-model="skillData.content"
           :autosize="{ minRows: 12, maxRows: 20 }"
-          placeholder="未导入文件夹时，可在此粘贴整份 SKILL.md；粘贴后会自动解析出名称与描述"
+          :placeholder="t('skill.singleDocPlaceholder')"
           @paste="onContentPaste"
           @update:model-value="onContentInput"
         ></tiny-input>
       </tiny-form-item>
     </tiny-form>
     <template #footer>
-      <tiny-button type="primary" @click="submit">确认</tiny-button>
+      <tiny-button type="primary" @click="submit">{{ t('common.confirm') }}</tiny-button>
     </template>
   </tiny-dialog-box>
 </template>

--- a/sites/playground/web/src/components/tab-components/skill/SkillModuleFileEditor.vue
+++ b/sites/playground/web/src/components/tab-components/skill/SkillModuleFileEditor.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { TinyInput } from '@opentiny/vue';
+import { t } from '../../../i18n';
 
 const props = defineProps({
   filePath: {
@@ -22,14 +23,14 @@ const onInput = (val) => {
 <template>
   <div class="skill-module-file-editor">
     <div v-if="filePath" class="skill-module-file-editor-path">{{ filePath }}</div>
-    <div v-else class="skill-module-file-editor-empty">在左侧树中选择一个文件以编辑内容</div>
+    <div v-else class="skill-module-file-editor-empty">{{ t('skill.selectFileHint') }}</div>
     <tiny-input
       v-if="filePath"
       class="skill-module-file-editor-input"
       type="textarea"
       :model-value="modelValue"
       :autosize="{ minRows: 14, maxRows: 22 }"
-      placeholder="文件内容"
+      :placeholder="t('skill.fileContent')"
       @update:model-value="onInput"
     />
   </div>

--- a/sites/playground/web/src/components/tab-components/skill/SkillPanel.vue
+++ b/sites/playground/web/src/components/tab-components/skill/SkillPanel.vue
@@ -4,6 +4,7 @@ import { TinyButton, TinySwitch, TinyPopover, TinyCollapseItem, TinyNotify } fro
 import SkillFormDialog from './SkillFormDialog.vue';
 import { iconDel, iconEdit, iconPlus, iconEllipsis } from '@opentiny/vue-icon';
 import { fileListToSkillModules, pickMainSkillOverview, remapModulesByName } from './index';
+import { t } from '../../../i18n';
 
 const playgroundContext = inject('playgroundContext');
 const { llmConfig = {} } = playgroundContext || {};
@@ -75,7 +76,7 @@ const onFolderInputChange = async (e) => {
     if (!files?.length) {
       TinyNotify({
         type: 'info',
-        message: '未选择任何文件，或所选文件夹为空',
+        message: t('skill.noFiles'),
         position: 'top-right',
       });
       return;
@@ -89,7 +90,7 @@ const onFolderInputChange = async (e) => {
     if (!Object.keys(modules).length) {
       TinyNotify({
         type: 'warning',
-        message: `共选中 ${files.length} 个文件，没有可导入的文本类文件（需为 .md、.txt、.json、.yaml 等常见文本扩展名）。`,
+        message: t('skill.noTextFiles', { total: files.length }),
         position: 'top-right',
       });
       return;
@@ -112,11 +113,11 @@ const onFolderInputChange = async (e) => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     const n = Object.keys(remapModules).length;
-    let doneMsg = `已导入 ${n} 个文本文件`;
+    let doneMsg = t('skill.importFilesSuccess', { count: n });
     if (skippedFileNum > 0) {
-      doneMsg += `（已跳过 ${skippedFileNum} 个扩展名不匹配的文件）`;
+      doneMsg += t('skill.importSkipped', { count: skippedFileNum });
     }
-    doneMsg += '。表单已打开，请核对名称与描述后点击「确认」保存到列表。';
+    doneMsg += t('skill.importFormHint');
     TinyNotify({
       type: 'success',
       message: doneMsg,
@@ -126,8 +127,7 @@ const onFolderInputChange = async (e) => {
     if (!overview) {
       TinyNotify({
         type: 'warning',
-        message:
-          '未检测到形如 ./目录名/SKILL.md 的主入口，对话摘要可能不完整；可调整目录结构或仍通过 get_skill_content 按路径读取子文档。',
+        message: t('skill.noMainEntry'),
         position: 'top-right',
       });
     }
@@ -135,7 +135,7 @@ const onFolderInputChange = async (e) => {
     const msg = err && typeof err === 'object' && 'message' in err ? err.message : String(err);
     TinyNotify({
       type: 'error',
-      message: `读取文件夹失败：${msg}`,
+      message: t('skill.readFolderFailed', { message: msg }),
       position: 'top-right',
     });
   } finally {
@@ -178,7 +178,7 @@ const confirmSkill = () => {
   <tiny-collapse-item name="skills" title="Skills">
     <template #title-right>
       <span class="skill-panel-title-actions" @click.stop>
-        <label for="playground-skill-folder-import" class="skill-folder-text-btn">导入文件夹</label>
+        <label for="playground-skill-folder-import" class="skill-folder-text-btn">{{ t('skill.importFolder') }}</label>
         <tiny-button type="text" :icon="IconPlus" @click="addSkill"> </tiny-button>
       </span>
     </template>
@@ -202,11 +202,11 @@ const confirmSkill = () => {
                 <div class="skills-item-actions">
                   <div @click="editSkill(skill, index)">
                     <component :is="IconEdit" />
-                    <span>编辑</span>
+                    <span>{{ t('common.edit') }}</span>
                   </div>
                   <div @click="deleteSkill(index)">
                     <component :is="IconDel" />
-                    <span>移除</span>
+                    <span>{{ t('common.remove') }}</span>
                   </div>
                 </div>
               </template>
@@ -222,11 +222,11 @@ const confirmSkill = () => {
       <div class="skills-item-empty">
         <div class="skills-item-empty-icon">
           <label for="playground-skill-folder-import" class="skill-folder-text-btn skill-folder-btn-inline" @click.stop
-            >导入技能文件夹</label
+            >{{ t('skill.importSkillFolder') }}</label
           >
-          或右上角
+          {{ t('common.or') }}
           <component :is="IconPlus" class="skills-item-empty-plus-icon" />
-          添加单条
+          {{ t('skill.addSingle') }}
         </div>
       </div>
     </div>

--- a/sites/playground/web/src/components/tab-components/tool-panels/AgentDialog.vue
+++ b/sites/playground/web/src/components/tab-components/tool-panels/AgentDialog.vue
@@ -7,6 +7,7 @@ import {
   TinyFormItem,
   TinyInput,
 } from '@opentiny/vue';
+import { t } from '../../../i18n';
 
 const props = defineProps<{
   visible: boolean;
@@ -68,7 +69,7 @@ function normalizeCapabilityEntry(item: unknown, fallbackTitle?: string): AgentC
     const title =
       pickString(o, ['name', 'id', 'title', 'skillId', 'capabilityId', 'type']) ??
       fallbackTitle ??
-      (description ? '未命名能力' : JSON.stringify(item));
+      (description ? t('agent.unnamedCapability') : JSON.stringify(item));
     return { title, description };
   }
   return { title: String(item) };
@@ -101,7 +102,7 @@ const agentCapabilityItems = computed((): AgentCapabilityViewItem[] => {
 <template>
   <tiny-dialog-box
     :visible="visible"
-    :title="agentData.index > -1 ? '编辑 Agent' : '添加 Agent'"
+    :title="agentData.index > -1 ? t('agent.edit') : t('agent.add')"
     width="540px"
     :append-to-body="true"
     @update:visible="emit('update:visible', $event)"
@@ -116,22 +117,22 @@ const agentCapabilityItems = computed((): AgentCapabilityViewItem[] => {
             @update:model-value="updateField('agentCardUrl', $event)"
           />
           <tiny-button type="primary" :loading="agentQueryLoading" @click="emit('queryAgentCard')">
-            {{ agentCardStatus === 'error' ? '重试' : '查询' }}
+            {{ agentCardStatus === 'error' ? t('agent.retry') : t('agent.query') }}
           </tiny-button>
         </div>
       </tiny-form-item>
-      <tiny-form-item label="名称" prop="name" required>
+      <tiny-form-item :label="t('common.name')" prop="name" required>
         <tiny-input
           :model-value="agentData.name"
-          placeholder="Agent 名称（用于在界面展示）"
+          :placeholder="t('agent.namePlaceholder')"
           @update:model-value="updateField('name', $event)"
         />
       </tiny-form-item>
-      <tiny-form-item label="描述" prop="description">
+      <tiny-form-item :label="t('common.description')" prop="description">
         <tiny-input
           type="textarea"
           :model-value="agentData.description"
-          placeholder="可选：用于在列表展示"
+          :placeholder="t('agent.descPlaceholder')"
           @update:model-value="updateField('description', $event)"
         />
       </tiny-form-item>
@@ -143,24 +144,24 @@ const agentCapabilityItems = computed((): AgentCapabilityViewItem[] => {
         @click="emit('confirmAgent')"
         v-if="agentCardStatus === 'success'"
       >
-        确认
+        {{ t('common.confirm') }}
       </tiny-button>
     </template>
     <div v-if="agentCardStatus === 'loading'" class="agent-card-hint agent-card-hint--info">
-      正在查询 Agent Card...
+      {{ t('agent.querying') }}
     </div>
     <div v-if="agentCardStatus === 'error'" class="agent-card-hint agent-card-hint--error">
       {{ agentCardError }}
     </div>
     <div v-if="agentCardStatus === 'success' && agentCard" class="agent-card-detail">
-      <div class="agent-card-detail__badge">AgentCard 已解析</div>
+      <div class="agent-card-detail__badge">{{ t('agent.parsed') }}</div>
       <div class="agent-card-detail__main">
-        <h4 class="agent-card-detail__title">{{ agentCard.name || '未命名 Agent' }}</h4>
+        <h4 class="agent-card-detail__title">{{ agentCard.name || t('agent.unnamed') }}</h4>
         <p v-if="agentCard.description" class="agent-card-detail__desc">{{ agentCard.description }}</p>
         <div class="agent-card-detail__block">
           <span class="agent-card-detail__block-label">API URL</span>
           <div class="agent-card-detail__url" :class="{ 'is-missing': !agentCard.api?.url }">
-            {{ agentCard.api?.url || '缺少 api.url，服务端无法作为工具调用' }}
+            {{ agentCard.api?.url || t('agent.missingApiUrlHint') }}
           </div>
         </div>
         <div class="agent-card-detail__block agent-card-detail__capabilities">
@@ -171,15 +172,15 @@ const agentCapabilityItems = computed((): AgentCapabilityViewItem[] => {
               <div v-if="item.description" class="agent-card-detail__cap-desc">{{ item.description }}</div>
             </li>
           </ul>
-          <div v-else class="agent-card-detail__cap-empty">未声明或为空</div>
+          <div v-else class="agent-card-detail__cap-empty">{{ t('agent.capabilitiesEmpty') }}</div>
         </div>
         <div
           v-if="agentCard.auth?.type && String(agentCard.auth.type).toLowerCase() !== 'none'"
           class="agent-card-detail__auth"
         >
-          <span class="agent-card-detail__block-label">认证</span>
+          <span class="agent-card-detail__block-label">{{ t('agent.auth') }}</span>
           <span class="agent-card-detail__auth-text">
-            {{ agentCard.auth.type }} · 工具调用时请在 metadata 中传入 token 或 apiKey
+            {{ agentCard.auth.type }} · {{ t('agent.authHint') }}
           </span>
         </div>
       </div>

--- a/sites/playground/web/src/components/tab-components/tool-panels/AgentPanel.vue
+++ b/sites/playground/web/src/components/tab-components/tool-panels/AgentPanel.vue
@@ -3,6 +3,7 @@ import { ref, inject } from 'vue';
 import { TinyButton, TinySwitch, TinyPopover, TinyCollapseItem, TinyNotify } from '@opentiny/vue';
 import { iconDel, iconEdit, iconPlus, iconEllipsis } from '@opentiny/vue-icon';
 import AgentDialog from './AgentDialog.vue';
+import { t } from '../../../i18n';
 
 const playgroundContext = inject('playgroundContext');
 const { llmConfig = {} } = playgroundContext || {};
@@ -115,7 +116,7 @@ const queryAgentCard = async () => {
   if (!requestedUrl) {
     TinyNotify({
       type: 'warning',
-      message: '请填写 Agent Card URL',
+      message: t('agent.cardUrlRequired'),
       position: 'top-right',
     });
     return;
@@ -152,7 +153,9 @@ const queryAgentCard = async () => {
     lastQueriedAgentCardUrl.value = requestedUrl;
   } catch (error) {
     agentCardStatus.value = 'error';
-    agentCardError.value = error?.message ? `获取 Agent Card 失败：${error.message}` : '获取 Agent Card 失败';
+    agentCardError.value = error?.message
+      ? t('agent.fetchFailed', { message: error.message })
+      : t('agent.fetchFailedGeneric');
   } finally {
     agentQueryLoading.value = false;
   }
@@ -166,7 +169,7 @@ const confirmAgent = () => {
   if (!nameTrimmed || !urlTrimmed) {
     TinyNotify({
       type: 'warning',
-      message: '请填写名称和 Agent Card URL',
+      message: t('agent.nameAndUrlRequired'),
       position: 'top-right',
     });
     return;
@@ -179,7 +182,7 @@ const confirmAgent = () => {
   ) {
     TinyNotify({
       type: 'warning',
-      message: '请先查询并确认 Agent Card 信息',
+      message: t('agent.queryFirst'),
       position: 'top-right',
     });
     return;
@@ -190,7 +193,7 @@ const confirmAgent = () => {
   if (!apiUrl) {
     TinyNotify({
       type: 'warning',
-      message: 'Agent Card 中缺少 api.url，服务端无法调用该 Agent',
+      message: t('agent.missingApiUrl'),
       position: 'top-right',
     });
     return;
@@ -201,7 +204,7 @@ const confirmAgent = () => {
   if (nameCollision) {
     TinyNotify({
       type: 'warning',
-      message: `已存在名为「${nameTrimmed}」的 Agent，名称不可重复`,
+      message: t('agent.duplicateName', { name: nameTrimmed }),
       position: 'top-right',
     });
     return;
@@ -233,7 +236,7 @@ const updateAgentEnabled = (agent, enabled) => {
 </script>
 
 <template>
-  <tiny-collapse-item name="agent" title="Agent（A2A 协议）">
+  <tiny-collapse-item name="agent" :title="t('agent.title')">
     <template #title-right>
       <tiny-button type="text" :icon="IconPlus" @click.stop="addAgent"> </tiny-button>
     </template>
@@ -250,11 +253,11 @@ const updateAgentEnabled = (agent, enabled) => {
                 <div class="mcp-server-item-actions">
                   <div @click="editAgent(agent, index)">
                     <component :is="IconEdit" />
-                    <span>编辑</span>
+                    <span>{{ t('common.edit') }}</span>
                   </div>
                   <div @click="deleteAgent(agent)">
                     <component :is="IconDel" />
-                    <span>移除</span>
+                    <span>{{ t('common.remove') }}</span>
                   </div>
                 </div>
               </template>
@@ -270,9 +273,9 @@ const updateAgentEnabled = (agent, enabled) => {
     <div v-else class="mcp-server-list-empty">
       <div class="mcp-server-item-empty">
         <div class="mcp-server-item-empty-icon">
-          点击右上角
+          {{ t('common.emptyHintPrefix') }}
           <component :is="IconPlus" class="mcp-server-item-empty-plus-icon" />
-          添加 Agent
+          {{ t('agent.add') }}
         </div>
       </div>
     </div>

--- a/sites/playground/web/src/components/tab-components/tool-panels/McpServerPanel.vue
+++ b/sites/playground/web/src/components/tab-components/tool-panels/McpServerPanel.vue
@@ -12,6 +12,7 @@ import {
   TinyNotify,
 } from '@opentiny/vue';
 import { iconDel, iconEdit, iconPlus, iconEllipsis } from '@opentiny/vue-icon';
+import { t } from '../../../i18n';
 
 const playgroundContext = inject('playgroundContext');
 const { llmConfig } = playgroundContext;
@@ -152,7 +153,7 @@ const confirmMCPServer = async () => {
 </script>
 
 <template>
-  <tiny-collapse-item name="mcp" title="MCP 服务">
+  <tiny-collapse-item name="mcp" :title="t('mcp.title')">
     <template #title-right>
       <tiny-button type="text" :icon="IconPlus" @click.stop="addMCPServer"></tiny-button>
     </template>
@@ -169,11 +170,11 @@ const confirmMCPServer = async () => {
                 <div class="mcp-server-item-actions">
                   <div @click="editMCPServer(server, index)">
                     <component :is="IconEdit" />
-                    <span>编辑</span>
+                    <span>{{ t('common.edit') }}</span>
                   </div>
                   <div @click="deleteMCPServer(server)">
                     <component :is="IconDel" />
-                    <span>移除</span>
+                    <span>{{ t('common.remove') }}</span>
                   </div>
                 </div>
               </template>
@@ -189,38 +190,38 @@ const confirmMCPServer = async () => {
     <div v-if="!llmConfig.mcpServers || llmConfig.mcpServers.length === 0" class="mcp-server-list-empty">
       <div class="mcp-server-item-empty">
         <div class="mcp-server-item-empty-icon">
-          点击右上角
+          {{ t('common.emptyHintPrefix') }}
           <component :is="IconPlus" class="mcp-server-item-empty-plus-icon" />
-          添加 MCP 服务
+          {{ t('mcp.emptyAction') }}
         </div>
       </div>
     </div>
     <tiny-dialog-box
       v-model:visible="showToolFormDialog"
-      :title="mcpServerData.index > -1 ? '编辑 MCP 服务' : '添加 MCP 服务'"
+      :title="mcpServerData.index > -1 ? t('mcp.edit') : t('mcp.add')"
       width="500px"
       @close="closeToolFormDialog"
       :append-to-body="true"
     >
       <tiny-form ref="mcpServerFormRef" :model="mcpServerData" label-width="120px" label-position="left">
-        <tiny-form-item label="名称" prop="name" required>
-          <tiny-input v-model="mcpServerData.name" placeholder="MCP 服务"></tiny-input>
+        <tiny-form-item :label="t('common.name')" prop="name" required>
+          <tiny-input v-model="mcpServerData.name" :placeholder="t('mcp.namePlaceholder')"></tiny-input>
         </tiny-form-item>
         <tiny-form-item label="URL" prop="url" required>
           <tiny-input v-model="mcpServerData.url" placeholder="http://localhost:3000/mcp"></tiny-input>
         </tiny-form-item>
-        <tiny-form-item label="请求头" prop="headers">
+        <tiny-form-item :label="t('mcp.headers')" prop="headers">
           <tiny-input v-model="mcpServerData.headers" :placeholder="headersPlaceholder" type="textarea"></tiny-input>
         </tiny-form-item>
-        <tiny-form-item label="超时（毫秒）" prop="timeout">
+        <tiny-form-item :label="t('mcp.timeout')" prop="timeout">
           <tiny-input v-model="mcpServerData.timeout" :placeholder="String(DEFAULT_TIMEOUT_SECONDS)" type="number"></tiny-input>
         </tiny-form-item>
-        <tiny-form-item label="描述" prop="description">
-          <tiny-input type="textarea" v-model="mcpServerData.description" placeholder="描述"></tiny-input>
+        <tiny-form-item :label="t('common.description')" prop="description">
+          <tiny-input type="textarea" v-model="mcpServerData.description" :placeholder="t('mcp.descPlaceholder')"></tiny-input>
         </tiny-form-item>
       </tiny-form>
       <template #footer>
-        <tiny-button type="primary" :loading="addToolLoading" @click="confirmMCPServer">确认</tiny-button>
+        <tiny-button type="primary" :loading="addToolLoading" @click="confirmMCPServer">{{ t('common.confirm') }}</tiny-button>
       </template>
     </tiny-dialog-box>
   </tiny-collapse-item>

--- a/sites/playground/web/src/i18n/en.json
+++ b/sites/playground/web/src/i18n/en.json
@@ -1,0 +1,186 @@
+{
+  "lang": {
+    "switch": "Language"
+  },
+  "app": {
+    "emptyTitle": "GenUI Playground"
+  },
+  "theme": {
+    "default": "Default",
+    "dark": "Dark",
+    "lite": "Lite",
+    "auto": "Auto",
+    "switchTitle": "Switch theme"
+  },
+  "sidebar": {
+    "openMenu": "Open menu",
+    "newConversation": "New conversation",
+    "closeSidebar": "Close sidebar",
+    "collapseSidebar": "Collapse sidebar",
+    "close": "Close",
+    "expandSidebar": "Expand sidebar",
+    "expand": "Expand",
+    "newTask": "New conversation",
+    "tabModel": "Model",
+    "tabTools": "Tools",
+    "tabTheme": "Theme",
+    "tabHistory": "History",
+    "tabTemplate": "Templates (experimental)"
+  },
+  "model": {
+    "select": "Model",
+    "temperature": "Temperature",
+    "prompt": "Prompts",
+    "edit": "Edit",
+    "delete": "Delete",
+    "editPrompt": "Edit prompt",
+    "addPrompt": "Add prompt",
+    "cancel": "Cancel",
+    "confirm": "OK",
+    "exampleTemplates": "Example templates"
+  },
+  "tool": {
+    "addContext": "Add tool results to context",
+    "showInUI": "Show tool results in UI"
+  },
+  "history": {
+    "selectMode": "Select",
+    "cancel": "Cancel",
+    "delete": "Delete",
+    "import": "Import",
+    "export": "Export",
+    "exportAll": "Export all",
+    "exportSelected": "Export selected",
+    "noExportable": "No conversations to export",
+    "noImportable": "No conversations found in file",
+    "importSuccess": "Imported {count} conversation(s)",
+    "importFailed": "Import failed",
+    "invalidJson": "Invalid JSON file",
+    "mustBeArray": "File must be a conversation array",
+    "menu": {
+      "export": "Export",
+      "rename": "Rename",
+      "delete": "Delete"
+    },
+    "timeBucket": {
+      "today": "Today",
+      "yesterday": "Yesterday",
+      "twoDaysAgo": "2 days ago",
+      "aWeekAgo": "Past week",
+      "aMonthAgo": "Past month"
+    }
+  },
+  "template": {
+    "selectTitle": "Select example templates",
+    "cancel": "Cancel",
+    "createNew": "Create template",
+    "confirm": "OK",
+    "new": "New template",
+    "defaultTitle": "New template",
+    "confirmDeleteOne": "Delete this template?",
+    "confirmBatchDelete": "Delete {count} selected template(s)?"
+  },
+  "common": {
+    "edit": "Edit",
+    "remove": "Remove",
+    "confirm": "Confirm",
+    "name": "Name",
+    "description": "Description",
+    "emptyHintPrefix": "Click the",
+    "or": "or use the"
+  },
+  "mcp": {
+    "title": "MCP Servers",
+    "add": "Add MCP Server",
+    "edit": "Edit MCP Server",
+    "namePlaceholder": "MCP server",
+    "descPlaceholder": "Description",
+    "timeout": "Timeout (ms)",
+    "headers": "Headers",
+    "emptyAction": "add an MCP server"
+  },
+  "agent": {
+    "title": "Agent (A2A)",
+    "add": "Add Agent",
+    "edit": "Edit Agent",
+    "cardUrlRequired": "Please enter Agent Card URL",
+    "fetchFailed": "Failed to fetch Agent Card: {message}",
+    "fetchFailedGeneric": "Failed to fetch Agent Card",
+    "nameAndUrlRequired": "Please enter name and Agent Card URL",
+    "queryFirst": "Query and confirm Agent Card first",
+    "missingApiUrl": "Agent Card is missing api.url; the server cannot call this agent",
+    "duplicateName": "An agent named 「{name}」 already exists",
+    "namePlaceholder": "Agent name (shown in UI)",
+    "descPlaceholder": "Optional description for the list",
+    "retry": "Retry",
+    "query": "Query",
+    "querying": "Querying Agent Card...",
+    "parsed": "AgentCard parsed",
+    "unnamed": "Unnamed Agent",
+    "missingApiUrlHint": "Missing api.url; cannot invoke as a tool on the server",
+    "capabilitiesEmpty": "Not declared or empty",
+    "auth": "Authentication",
+    "authHint": "Pass token or apiKey in metadata when invoking tools",
+    "unnamedCapability": "Unnamed capability"
+  },
+  "skill": {
+    "importFolder": "Import folder",
+    "importSkillFolder": "Import skill folder",
+    "addSingle": "add one manually",
+    "edit": "Edit Skill",
+    "add": "Add Skill",
+    "nameRequired": "Please enter Skill name",
+    "duplicateName": "A Skill named 「{name}」 already exists",
+    "contentRequired": "Import a folder or enter single-document content",
+    "namePlaceholder": "Display name; can match name in SKILL.md",
+    "descPlaceholder": "List summary; auto-filled from main SKILL.md when importing a folder",
+    "pack": "Skill pack",
+    "pickFolder": "Choose folder",
+    "clearFolder": "Clear folder and use single document",
+    "packSummary": "Loaded {count} file(s). Only the summary is injected in chat; full docs are fetched via get_skill_content on demand.",
+    "singleDoc": "Single document",
+    "singleDocPlaceholder": "Paste full SKILL.md here if no folder was imported; name and description will be parsed",
+    "selectFileHint": "Select a file in the tree on the left to edit",
+    "fileContent": "File content",
+    "noFiles": "No files selected, or the folder is empty",
+    "noTextFiles": "Selected {total} file(s), but none are importable text files (.md, .txt, .json, .yaml, etc.).",
+    "importFilesSuccess": "Imported {count} text file(s)",
+    "importSkipped": " ({count} skipped due to unsupported extension)",
+    "importFormHint": ". Review name and description, then click Confirm to save.",
+    "noMainEntry": "No ./dir/SKILL.md main entry detected; chat summary may be incomplete. Adjust structure or use get_skill_content by path.",
+    "readFolderFailed": "Failed to read folder: {message}",
+    "defaultPackDesc": "Skill pack (please complete name / description in SKILL.md)"
+  },
+  "chatFooter": {
+    "refresh": "Refresh",
+    "copy": "Copy",
+    "continueGenerate": "Continue generating (experimental)",
+    "revertContinueGenerate": "Revert last continue-generate (experimental)"
+  },
+  "templateEditor": {
+    "generating": "Generating...",
+    "createdAt": "Created: {time}",
+    "debugJsonPatch": "Debug jsonPatch",
+    "parseFailed": "Parse failed",
+    "debugger": "Debugger",
+    "jsonEditorAria": "Schema JSON editor",
+    "jsonPreviewAria": "Schema JSON preview",
+    "viewJson": "View JSON",
+    "backToPreview": "Back to preview",
+    "close": "Close",
+    "closePreview": "Close preview",
+    "applyVersion": "Apply this version",
+    "returnLatest": "Back to latest"
+  },
+  "finishInfo": {
+    "title": "Conversation info",
+    "titleMultiGen": "Conversation info (multiple generations; last generation only)",
+    "ariaLabel": "Statistics for this turn",
+    "model": "Model",
+    "finishReason": "Finish reason",
+    "time": "Time",
+    "promptTokens": "Prompt tokens",
+    "completionTokens": "Completion tokens",
+    "totalTokens": "Total tokens"
+  }
+}

--- a/sites/playground/web/src/i18n/index.ts
+++ b/sites/playground/web/src/i18n/index.ts
@@ -1,0 +1,14 @@
+import zhCN from './zh.json';
+import enUS from './en.json';
+import { useI18n } from '@opentiny/genui-sdk-vue';
+
+const globalI18n = useI18n();
+
+globalI18n.mergeMessages({
+  zh_CN: zhCN,
+  en_US: enUS,
+});
+
+export const { t, locale, setLocale, mergeMessages, messages } = globalI18n;
+
+export { useI18n };

--- a/sites/playground/web/src/i18n/zh.json
+++ b/sites/playground/web/src/i18n/zh.json
@@ -1,0 +1,186 @@
+{
+  "lang": {
+    "switch": "语言"
+  },
+  "app": {
+    "emptyTitle": "GenUI Playground"
+  },
+  "theme": {
+    "default": "默认",
+    "dark": "暗黑",
+    "lite": "清新",
+    "auto": "自动",
+    "switchTitle": "切换主题"
+  },
+  "sidebar": {
+    "openMenu": "打开菜单",
+    "newConversation": "新会话",
+    "closeSidebar": "关闭侧边栏",
+    "collapseSidebar": "收起侧边栏",
+    "close": "关闭",
+    "expandSidebar": "展开侧边栏",
+    "expand": "展开",
+    "newTask": "新建会话",
+    "tabModel": "模型配置",
+    "tabTools": "工具",
+    "tabTheme": "主题",
+    "tabHistory": "历史会话",
+    "tabTemplate": "模板（实验特性）"
+  },
+  "model": {
+    "select": "模型选择",
+    "temperature": "模型温度",
+    "prompt": "提示词",
+    "edit": "编辑",
+    "delete": "删除",
+    "editPrompt": "编辑提示词",
+    "addPrompt": "添加提示词",
+    "cancel": "取消",
+    "confirm": "确定",
+    "exampleTemplates": "示例模板"
+  },
+  "tool": {
+    "addContext": "调用结果添加到上下文",
+    "showInUI": "调用结果展示在界面中"
+  },
+  "history": {
+    "selectMode": "多选",
+    "cancel": "取消",
+    "delete": "删除",
+    "import": "导入",
+    "export": "导出",
+    "exportAll": "导出全部记录",
+    "exportSelected": "导出已选记录",
+    "noExportable": "当前没有可导出的会话",
+    "noImportable": "未找到可导入的会话",
+    "importSuccess": "已导入 {count} 条会话",
+    "importFailed": "导入失败",
+    "invalidJson": "导入文件不是有效的 JSON",
+    "mustBeArray": "导入文件必须是会话数组",
+    "menu": {
+      "export": "导出",
+      "rename": "重命名",
+      "delete": "删除"
+    },
+    "timeBucket": {
+      "today": "今天",
+      "yesterday": "昨天",
+      "twoDaysAgo": "两天前",
+      "aWeekAgo": "一周前",
+      "aMonthAgo": "一个月前"
+    }
+  },
+  "template": {
+    "selectTitle": "选择示例模板",
+    "cancel": "取消",
+    "createNew": "创建新模板",
+    "confirm": "确定",
+    "new": "新建模板",
+    "defaultTitle": "新模板",
+    "confirmDeleteOne": "确定删除该模板吗？",
+    "confirmBatchDelete": "确定删除选中的 {count} 个模板？"
+  },
+  "common": {
+    "edit": "编辑",
+    "remove": "移除",
+    "confirm": "确认",
+    "name": "名称",
+    "description": "描述",
+    "emptyHintPrefix": "点击右上角",
+    "or": "或右上角"
+  },
+  "mcp": {
+    "title": "MCP 服务",
+    "add": "添加 MCP 服务",
+    "edit": "编辑 MCP 服务",
+    "namePlaceholder": "MCP 服务",
+    "descPlaceholder": "描述",
+    "timeout": "超时（毫秒）",
+    "headers": "请求头",
+    "emptyAction": "添加 MCP 服务"
+  },
+  "agent": {
+    "title": "Agent（A2A 协议）",
+    "add": "添加 Agent",
+    "edit": "编辑 Agent",
+    "cardUrlRequired": "请填写 Agent Card URL",
+    "fetchFailed": "获取 Agent Card 失败：{message}",
+    "fetchFailedGeneric": "获取 Agent Card 失败",
+    "nameAndUrlRequired": "请填写名称和 Agent Card URL",
+    "queryFirst": "请先查询并确认 Agent Card 信息",
+    "missingApiUrl": "Agent Card 中缺少 api.url，服务端无法调用该 Agent",
+    "duplicateName": "已存在名为「{name}」的 Agent，名称不可重复",
+    "namePlaceholder": "Agent 名称（用于在界面展示）",
+    "descPlaceholder": "可选：用于在列表展示",
+    "retry": "重试",
+    "query": "查询",
+    "querying": "正在查询 Agent Card...",
+    "parsed": "AgentCard 已解析",
+    "unnamed": "未命名 Agent",
+    "missingApiUrlHint": "缺少 api.url，服务端无法作为工具调用",
+    "capabilitiesEmpty": "未声明或为空",
+    "auth": "认证",
+    "authHint": "工具调用时请在 metadata 中传入 token 或 apiKey",
+    "unnamedCapability": "未命名能力"
+  },
+  "skill": {
+    "importFolder": "导入文件夹",
+    "importSkillFolder": "导入技能文件夹",
+    "addSingle": "添加单条",
+    "edit": "编辑 Skill",
+    "add": "添加 Skill",
+    "nameRequired": "请填写 Skill 名称",
+    "duplicateName": "已存在名为「{name}」的 Skill，名称不可重复",
+    "contentRequired": "请导入文件夹或填写单文档内容",
+    "namePlaceholder": "列表展示名称，可与 SKILL.md 中 name 一致",
+    "descPlaceholder": "列表摘要；导入文件夹时可从主 SKILL.md 自动带出",
+    "pack": "技能包",
+    "pickFolder": "选择文件夹",
+    "clearFolder": "清除文件夹，改用手写单文档",
+    "packSummary": "已加载 {count} 个文件；对话时仅注入技能摘要，完整文档由模型通过 get_skill_content 按需拉取（渐进式披露）。",
+    "singleDoc": "单文档内容",
+    "singleDocPlaceholder": "未导入文件夹时，可在此粘贴整份 SKILL.md；粘贴后会自动解析出名称与描述",
+    "selectFileHint": "在左侧树中选择一个文件以编辑内容",
+    "fileContent": "文件内容",
+    "noFiles": "未选择任何文件，或所选文件夹为空",
+    "noTextFiles": "共选中 {total} 个文件，没有可导入的文本类文件（需为 .md、.txt、.json、.yaml 等常见文本扩展名）。",
+    "importFilesSuccess": "已导入 {count} 个文本文件",
+    "importSkipped": "（已跳过 {count} 个扩展名不匹配的文件）",
+    "importFormHint": "。表单已打开，请核对名称与描述后点击「确认」保存到列表。",
+    "noMainEntry": "未检测到形如 ./目录名/SKILL.md 的主入口，对话摘要可能不完整；可调整目录结构或仍通过 get_skill_content 按路径读取子文档。",
+    "readFolderFailed": "读取文件夹失败：{message}",
+    "defaultPackDesc": "技能包（请补全 SKILL.md 的 name / description）"
+  },
+  "chatFooter": {
+    "refresh": "刷新",
+    "copy": "复制",
+    "continueGenerate": "继续生成（实验特性）",
+    "revertContinueGenerate": "撤回上次继续生成（实验特性）"
+  },
+  "templateEditor": {
+    "generating": "生成中...",
+    "createdAt": "创建时间：{time}",
+    "debugJsonPatch": "调试 jsonPatch",
+    "parseFailed": "解析失败",
+    "debugger": "调试器",
+    "jsonEditorAria": "Schema JSON 编辑器",
+    "jsonPreviewAria": "Schema JSON 预览",
+    "viewJson": "查看 JSON",
+    "backToPreview": "返回预览",
+    "close": "关闭",
+    "closePreview": "关闭预览区",
+    "applyVersion": "应用此版本",
+    "returnLatest": "返回最新版本"
+  },
+  "finishInfo": {
+    "title": "对话信息",
+    "titleMultiGen": "对话信息（含多次生成，仅统计最后一次生成）",
+    "ariaLabel": "本轮对话统计信息",
+    "model": "模型",
+    "finishReason": "结束原因",
+    "time": "时间",
+    "promptTokens": "输入 Token",
+    "completionTokens": "输出 Token",
+    "totalTokens": "总计 Token"
+  }
+}

--- a/sites/playground/web/src/main.ts
+++ b/sites/playground/web/src/main.ts
@@ -1,4 +1,5 @@
 import { createApp } from 'vue';
+import './i18n';
 import './style.css';
 import App from './App.vue';
 import 'gridstack/dist/gridstack.min.css';


### PR DESCRIPTION
playground添加国际化
<img width="1351" height="1031" alt="image" src="https://github.com/user-attachments/assets/eb5f5fee-0a90-40ab-900a-c9b21edf21d6" />

<img width="326" height="707" alt="image" src="https://github.com/user-attachments/assets/29398c7f-600e-452f-bf95-6c455c7620f0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full English translation bundle and a Language Switcher for Chinese/English toggling

* **Enhancements**
  * Extensive i18n applied across UI: tooltips, dialogs, notifications, templates, history, chat, tool/agent/skill panels and more
  * Locale wired into providers and theme/empty-state texts for consistent rendering

* **Bug Fixes**
  * Locale switching refined to avoid unnecessary resets
<!-- end of auto-generated comment: release notes by coderabbit.ai -->