### PR TITLE
feat(schema-stream-normalizer): add schema normalization for streaming lifeCycles

### DIFF
--- a/packages/core/src/delta-patcher/delta-patcher.ts
+++ b/packages/core/src/delta-patcher/delta-patcher.ts
@@ -3,6 +3,7 @@ import * as jsonDiffPatch from 'jsondiffpatch';
 import { flatten } from 'flat';
 import { get } from 'radash';
 import { jsonSelectorMatcher } from '../delta-json-path-selector/json-selector-matcher';
+import { normalizeStreamingSchema } from '../schema-stream-normalizer';
 // import DiffMatchPatch from 'diff-match-patch';
 
 type ISchema = any;
@@ -240,7 +241,11 @@ export class DeltaPatcher {
     if (!newValue) {
       return oldValue;
     }
-    const diff = this.diffPatcher.diff(oldValue, newValue);
+    const normalizedNewValue = normalizeStreamingSchema(
+      newValue as Record<string, unknown>,
+      isCompleted,
+    );
+    const diff = this.diffPatcher.diff(oldValue, normalizedNewValue);
     if (!diff) {
       return oldValue;
     }
@@ -249,7 +254,7 @@ export class DeltaPatcher {
       return this.diffPatcher.patch(oldValue, diff);
     }
 
-    const delta = this.getPatchDelta(newValue, diff);
+    const delta = this.getPatchDelta(normalizedNewValue, diff);
     if (!delta) {
       return oldValue;
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,3 +4,4 @@ export * from './prompt-generator';
 export * from './delta-json-path-selector';
 export * from './stream-pattern-extractor';
 export * from './repair-json';
+export * from './schema-stream-normalizer';

--- a/packages/core/src/schema-stream-normalizer/__tests__/normalize-streaming-schema.spec.ts
+++ b/packages/core/src/schema-stream-normalizer/__tests__/normalize-streaming-schema.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeStreamingSchema } from '../normalize-streaming-schema';
+
+describe('normalizeStreamingSchema', () => {
+  it('keeps lifeCycles unchanged when schema-json is complete', () => {
+    const schema = {
+      componentName: 'Page',
+      lifeCycles: {
+        onMounted: { type: 'JSFunction', value: 'function() {}' },
+      },
+    };
+
+    expect(normalizeStreamingSchema(schema, true)).toBe(schema);
+    expect(normalizeStreamingSchema(schema, true).lifeCycles).toEqual(schema.lifeCycles);
+  });
+
+  it('replaces lifeCycles with {} while streaming', () => {
+    const schema = {
+      componentName: 'Page',
+      lifeCycles: {
+        onMounted: { type: 'JSFunction', value: 'function() {' },
+      },
+    };
+
+    expect(normalizeStreamingSchema(schema, false)).toEqual({
+      componentName: 'Page',
+      lifeCycles: {},
+    });
+    expect(schema.lifeCycles).not.toEqual({});
+  });
+
+  it('does not mutate schema without lifeCycles', () => {
+    const schema = { componentName: 'Page' };
+    expect(normalizeStreamingSchema(schema, false)).toBe(schema);
+  });
+
+  it('keeps explicit empty lifeCycles as {} while streaming', () => {
+    const schema = { componentName: 'Page', lifeCycles: {} };
+
+    expect(normalizeStreamingSchema(schema, false)).toEqual({
+      componentName: 'Page',
+      lifeCycles: {},
+    });
+    expect(normalizeStreamingSchema(schema, false)).not.toBe(schema);
+  });
+
+  it('normalizes when lifeCycles key exists but value is undefined', () => {
+    const schema = { componentName: 'Page', lifeCycles: undefined };
+
+    expect(normalizeStreamingSchema(schema, false)).toEqual({
+      componentName: 'Page',
+      lifeCycles: {},
+    });
+  });
+
+  it('returns non-object inputs unchanged', () => {
+    expect(normalizeStreamingSchema(null as unknown as Record<string, unknown>, false)).toBe(null);
+    expect(normalizeStreamingSchema('text' as unknown as Record<string, unknown>, false)).toBe('text');
+  });
+});

--- a/packages/core/src/schema-stream-normalizer/index.ts
+++ b/packages/core/src/schema-stream-normalizer/index.ts
@@ -1,0 +1,1 @@
+export * from './normalize-streaming-schema';

--- a/packages/core/src/schema-stream-normalizer/normalize-streaming-schema.ts
+++ b/packages/core/src/schema-stream-normalizer/normalize-streaming-schema.ts
@@ -1,0 +1,21 @@
+/**
+ * 流式输出期间将 schema 中的 lifeCycles 归一化为空对象，
+ * 避免未闭合的 lifecycle 配置触发渲染；schema-json 完整解析后再应用真实值。
+ */
+export function normalizeStreamingSchema<T extends Record<string, unknown>>(
+  schema: T,
+  isCompleted: boolean,
+): T {
+  if (isCompleted || !schema || typeof schema !== 'object') {
+    return schema;
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(schema, 'lifeCycles')) {
+    return schema;
+  }
+
+  return {
+    ...schema,
+    lifeCycles: {},
+  };
+}

--- a/packages/frameworks/angular/projects/renderer/src/lib/config.ts
+++ b/packages/frameworks/angular/projects/renderer/src/lib/config.ts
@@ -1,4 +1,5 @@
 export const requiredCompleteFieldSelectors = [ // TODO: move to core & material package
+  'lifeCycles',
   'componentName',
   'style',
   '[type=JSFunction]',

--- a/packages/frameworks/vue/src/renderer/config.ts
+++ b/packages/frameworks/vue/src/renderer/config.ts
@@ -1,4 +1,5 @@
 export const requiredCompleteFieldSelectors = [
+  'lifeCycles',
   '[componentName=Img] > props > src',
   'componentName',
   'style',


### PR DESCRIPTION
处理流式输出过程中生命周期函数重复触发的问题
回放流：
[replay.txt](https://github.com/user-attachments/files/28299877/replay.txt)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schema streaming behavior to consistently handle lifecycle data during incomplete streaming states.
  * Fixed normalization of lifecycle definitions across Angular and Vue renderers.

* **New Features**
  * Added schema normalization utility for streaming operations.

* **Tests**
  * Added comprehensive test coverage for schema streaming normalization behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentiny/genui-sdk/pull/179?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->