### PR TITLE
feat: defer lifeCycles until schema streaming is complete

### DIFF
--- a/packages/frameworks/vue/src/renderer/SchemaCardRenderer.vue
+++ b/packages/frameworks/vue/src/renderer/SchemaCardRenderer.vue
@@ -95,13 +95,17 @@ watch(
     } else {
       isCompleted = isJsonComplete ?? true;
     }
+    if (!isCompleted && json && 'lifeCycles' in json) {
+      const { lifeCycles, ...rest } = json;
+      json = rest;
+    }
     deltaPatcher.patchWithDelta(schema.value, json, isCompleted); // TODO： 速率限制
     if (!updateActionTimer) {
       updateActionTimer = nextTick(() => {
         if (!rendererInstance.value) return;
         updateContextAndState();
         updateActionTimer = null;
-      })
+      });
     }
   },
   {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -694,6 +694,9 @@ importers:
       '@opentiny/vue-numeric':
         specifier: ^3.28.0
         version: 3.28.0
+      '@opentiny/vue-pager':
+        specifier: ^3.28.0
+        version: 3.28.0
       '@opentiny/vue-radio':
         specifier: ^3.28.0
         version: 3.28.0

--- a/sites/playground/web/src/components/genui-template/GenuiTemplateChat.vue
+++ b/sites/playground/web/src/components/genui-template/GenuiTemplateChat.vue
@@ -27,7 +27,7 @@ import {
   formatJsonPatch,
   generateIdForComponents,
 } from './template-chat-utils';
-import { formatDate, generateId } from '../../utils';
+import { formatDate, generateId, stripSchemaFieldsWhileStreaming } from '../../utils';
 import useTemplate from './useTemplate';
 import AssistantFooter from './TemplateAssistantFooter.vue';
 import TemplateSchemaMessageRenderer from './TemplateSchemaMessageRenderer.vue';
@@ -152,7 +152,7 @@ const schemaCardRenderer = async (props: any) => {
       if (!value) {
         return;
       }
-      json = value;
+      json = stripSchemaFieldsWhileStreaming(value as Record<string, unknown>, isCompleted);
     }
     deltaPatcher.patchWithDelta(target, json, isCompleted);
     // 给每个组件添加 id
@@ -227,7 +227,8 @@ const jsonPatchRenderer = async (props: any) => {
 
     // 增量 patch 需要基于“当前预览态”持续叠加，避免每个 chunk 都从已应用态重建导致丢操作。
     const patchBaseline = lastPreviewSchema.value ?? currentSchema.value;
-    const targetSchema = JSON.parse(JSON.stringify(patchBaseline));
+    let targetSchema = JSON.parse(JSON.stringify(patchBaseline)) as Record<string, unknown>;
+    targetSchema = stripSchemaFieldsWhileStreaming(targetSchema, isComplete);
     jsonPatchFormatter.patch(targetSchema, standardOperations);
     setCurrentPreviewSchema(generateIdForComponents(targetSchema), isComplete || lastOperationComplete);
   } catch (error) {

--- a/sites/playground/web/src/components/genui-template/GenuiTemplateChat.vue
+++ b/sites/playground/web/src/components/genui-template/GenuiTemplateChat.vue
@@ -230,6 +230,8 @@ const jsonPatchRenderer = async (props: any) => {
     let targetSchema = JSON.parse(JSON.stringify(patchBaseline)) as Record<string, unknown>;
     targetSchema = stripSchemaFieldsWhileStreaming(targetSchema, isComplete);
     jsonPatchFormatter.patch(targetSchema, standardOperations);
+    // 避免流式未完成时 patch 操作把 lifeCycles 写回 schema
+    targetSchema = stripSchemaFieldsWhileStreaming(targetSchema, isComplete);
     setCurrentPreviewSchema(generateIdForComponents(targetSchema), isComplete || lastOperationComplete);
   } catch (error) {
     errorMessagesMap.value.set(props.cardId, error.message);

--- a/sites/playground/web/src/utils/index.ts
+++ b/sites/playground/web/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './date-format';
 export * from './generate-id';
+export * from './strip-schema-fields';

--- a/sites/playground/web/src/utils/strip-schema-fields.ts
+++ b/sites/playground/web/src/utils/strip-schema-fields.ts
@@ -1,0 +1,27 @@
+/** 流式未完成时默认从 schema 中剥离的顶层字段 */
+export const STREAMING_DEFERRED_SCHEMA_FIELDS = ['lifeCycles'] as const;
+
+export type StreamingDeferredSchemaField = (typeof STREAMING_DEFERRED_SCHEMA_FIELDS)[number];
+
+/**
+ * 流式未完成时从 schema 快照中移除指定顶层字段，避免未写完的配置被提前渲染/执行。
+ */
+export function stripSchemaFieldsWhileStreaming<T extends Record<string, unknown>>(
+  schema: T,
+  streamComplete: boolean,
+  fields: readonly string[] = STREAMING_DEFERRED_SCHEMA_FIELDS,
+): T {
+  if (streamComplete || !schema || typeof schema !== 'object' || fields.length === 0) {
+    return schema;
+  }
+
+  const next = { ...schema };
+  let changed = false;
+  for (const field of fields) {
+    if (field in next) {
+      delete next[field];
+      changed = true;
+    }
+  }
+  return changed ? (next as T) : schema;
+}


### PR DESCRIPTION
解决流式处理过程中 lifeCycles 被重复执行的问题 
回放流：
[replay.txt](https://github.com/user-attachments/files/28336947/replay.txt)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented incomplete lifecycle fields from appearing during incremental schema streaming, avoiding premature or incorrect preview updates.
  * Ensured streamed patching no longer writes deferred fields back into live previews.

* **New Features**
  * Streaming-aware schema handling strips deferred fields while content is incomplete, delivering smoother, more consistent live previews.

* **Chores**
  * Added and re-exported a utility to support streaming-aware schema handling; updated a renderer subproject reference.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentiny/genui-sdk/pull/182?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->