### PR TITLE
fix(genui-sdk-vue): optimize notification event payload and toolcall result

### DIFF
--- a/packages/frameworks/vue/src/chat/renderer/ToolRenderer.vue
+++ b/packages/frameworks/vue/src/chat/renderer/ToolRenderer.vue
@@ -7,23 +7,58 @@
   const MAX_HIGHLIGHT_JSON_FIELD_COUNT = 100;
 
   /**
-   * 递归统计 JSON 对象中的字段总数（含嵌套 object 的 key 与 array 内 object 的 key）。
-   * 非 object（含 null、原始类型）返回 0。
+   * 判断 JSON 对象的字段总数是否超过指定阈值（含嵌套 object 的 key 与 array 内 object 的 key）。
+   * 超过阈值时提前终止递归，避免对大 payload 做全量遍历。
    *
    * @param value - 待统计的值
-   * @returns 字段总数
+   * @param limit - 字段数上限
+   * @returns 字段总数是否超过 limit
    */
-  const countObjectFields = (value: unknown): number => {
-    if (!value || typeof value !== 'object') {
-      return 0
+  const exceedsFieldCountLimit = (value: unknown, limit: number): boolean => {
+    let count = 0
+
+    const traverse = (val: unknown): boolean => {
+      if (!val || typeof val !== 'object') {
+        return false
+      }
+
+      if (Array.isArray(val)) {
+        for (const item of val) {
+          if (traverse(item)) {
+            return true
+          }
+        }
+        return false
+      }
+
+      for (const item of Object.values(val)) {
+        count += 1
+        if (count > limit) {
+          return true
+        }
+        if (traverse(item)) {
+          return true
+        }
+      }
+      return false
     }
 
-    if (Array.isArray(value)) {
-      return value.reduce((sum, item) => sum + countObjectFields(item), 0)
-    }
-
-    return Object.values(value).reduce((sum, item) => sum + 1 + countObjectFields(item), 0)
+    return traverse(value)
   }
+
+  /**
+   * 转义 HTML 特殊字符，防止 v-html 注入 XSS。
+   *
+   * @param text - 待转义的文本
+   * @returns 转义后的安全 HTML 文本
+   */
+  const escapeHtml = (text: string): string =>
+    text
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;')
   
   const props = defineProps<{
     name: string
@@ -69,11 +104,13 @@
       console.warn(error)
     }
 
-    const shouldSkipHighlight =
-      countObjectFields(parsedValue) > MAX_HIGHLIGHT_JSON_FIELD_COUNT
+    const shouldSkipHighlight = exceedsFieldCountLimit(
+      parsedValue,
+      MAX_HIGHLIGHT_JSON_FIELD_COUNT,
+    )
 
     if (shouldSkipHighlight) {
-      return prettyJson
+      return escapeHtml(prettyJson)
     }
   
     prettyJson = prettyJson.replace(
@@ -87,7 +124,7 @@
         } else if (/null/.test(match)) {
           className = 'null'
         }
-        return `<span class="${classes[className]}">${match}</span>`
+        return `<span class="${classes[className]}">${escapeHtml(match)}</span>`
       },
     )
   

--- a/packages/frameworks/vue/src/chat/renderer/ToolRenderer.vue
+++ b/packages/frameworks/vue/src/chat/renderer/ToolRenderer.vue
@@ -2,6 +2,28 @@
   import { IconArrowDown, IconCancelled, IconError, IconLoading, IconPlugin } from '@opentiny/tiny-robot-svgs'
   import { computed, ref, useCssModule, type Component } from 'vue'
   import { useI18n } from '../i18n';
+
+
+  const MAX_HIGHLIGHT_JSON_FIELD_COUNT = 100;
+
+  /**
+   * 递归统计 JSON 对象中的字段总数（含嵌套 object 的 key 与 array 内 object 的 key）。
+   * 非 object（含 null、原始类型）返回 0。
+   *
+   * @param value - 待统计的值
+   * @returns 字段总数
+   */
+  const countObjectFields = (value: unknown): number => {
+    if (!value || typeof value !== 'object') {
+      return 0
+    }
+
+    if (Array.isArray(value)) {
+      return value.reduce((sum, item) => sum + countObjectFields(item), 0)
+    }
+
+    return Object.values(value).reduce((sum, item) => sum + 1 + countObjectFields(item), 0)
+  }
   
   const props = defineProps<{
     name: string
@@ -32,16 +54,26 @@
     }
   
     let prettyJson = ''
+    let parsedValue: unknown = json
     const space = props.formatPretty ? 2 : 0
   
     try {
       if (typeof json === 'string') {
-        prettyJson = JSON.stringify(JSON.parse(json), null, space)
+        parsedValue = JSON.parse(json)
+        prettyJson = JSON.stringify(parsedValue, null, space)
       } else {
+        parsedValue = json
         prettyJson = JSON.stringify(json, null, space)
       }
     } catch (error) {
       console.warn(error)
+    }
+
+    const shouldSkipHighlight =
+      countObjectFields(parsedValue) > MAX_HIGHLIGHT_JSON_FIELD_COUNT
+
+    if (shouldSkipHighlight) {
+      return prettyJson
     }
   
     prettyJson = prettyJson.replace(
@@ -159,6 +191,8 @@
       white-space: pre-wrap;
       word-break: break-word;
       font-family: monospace;
+      max-height: 300px;
+      overflow-y: auto;
     }
   }
   </style>

--- a/packages/frameworks/vue/src/chat/renderer/ToolRenderer.vue
+++ b/packages/frameworks/vue/src/chat/renderer/ToolRenderer.vue
@@ -1,258 +1,253 @@
 <script setup lang="ts">
-  import { IconArrowDown, IconCancelled, IconError, IconLoading, IconPlugin } from '@opentiny/tiny-robot-svgs'
-  import { computed, ref, useCssModule, type Component } from 'vue'
-  import { useI18n } from '../i18n';
+import { IconArrowDown, IconCancelled, IconError, IconLoading, IconPlugin } from '@opentiny/tiny-robot-svgs';
+import { computed, ref, useCssModule, type Component } from 'vue';
+import { useI18n } from '../i18n';
 
+const MAX_HIGHLIGHT_JSON_FIELD_COUNT = 100;
 
-  const MAX_HIGHLIGHT_JSON_FIELD_COUNT = 100;
+/**
+ * 判断 JSON 对象的字段总数是否超过指定阈值（含嵌套 object 的 key 与 array 内 object 的 key）。
+ * 超过阈值时提前终止递归，避免对大 payload 做全量遍历。
+ *
+ * @param value - 待统计的值
+ * @param limit - 字段数上限
+ * @returns 字段总数是否超过 limit
+ */
+const exceedsFieldCountLimit = (value: unknown, limit: number): boolean => {
+  let count = 0;
 
-  /**
-   * 判断 JSON 对象的字段总数是否超过指定阈值（含嵌套 object 的 key 与 array 内 object 的 key）。
-   * 超过阈值时提前终止递归，避免对大 payload 做全量遍历。
-   *
-   * @param value - 待统计的值
-   * @param limit - 字段数上限
-   * @returns 字段总数是否超过 limit
-   */
-  const exceedsFieldCountLimit = (value: unknown, limit: number): boolean => {
-    let count = 0
+  const traverse = (val: unknown): boolean => {
+    if (!val || typeof val !== 'object') {
+      return false;
+    }
 
-    const traverse = (val: unknown): boolean => {
-      if (!val || typeof val !== 'object') {
-        return false
-      }
-
-      if (Array.isArray(val)) {
-        for (const item of val) {
-          if (traverse(item)) {
-            return true
-          }
-        }
-        return false
-      }
-
-      for (const item of Object.values(val)) {
-        count += 1
-        if (count > limit) {
-          return true
-        }
+    if (Array.isArray(val)) {
+      for (const item of val) {
         if (traverse(item)) {
-          return true
+          return true;
         }
       }
-      return false
+      return false;
     }
 
-    return traverse(value)
-  }
-
-  /**
-   * 转义 HTML 特殊字符，防止 v-html 注入 XSS。
-   *
-   * @param text - 待转义的文本
-   * @returns 转义后的安全 HTML 文本
-   */
-  const escapeHtml = (text: string): string =>
-    text
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;')
-      .replace(/'/g, '&#39;')
-  
-  const props = defineProps<{
-    name: string
-    status: 'running' | 'success' | 'failed' | 'cancelled'
-    content?: string | { params?: object; result?: object; [x: string]: unknown }
-    formatPretty?: boolean
-    defaultOpen?: boolean
-  }>()
-  const { t } = useI18n();
-  const opened = ref(props.defaultOpen ?? false)
-  
-  const textAndIconMap = new Map<string, { text: string; icon: Component }>([
-    ['running', { text: t('toolStatus.running'), icon: IconLoading }],
-    ['success', { text: t('toolStatus.success'), icon: IconPlugin }],
-    ['failed', { text: t('toolStatus.failed'), icon: IconError }],
-    ['cancelled', { text: t('toolStatus.cancelled'), icon: IconCancelled }],
-  ])
-  
-  const textAndIcon = computed(() => {
-    return textAndIconMap.get(props.status) || { text: '', icon: IconPlugin }
-  })
-  
-  const classes = useCssModule()
-  
-  const highlightJSON = <T extends string | object>(json?: T): string => {
-    if (!json) {
-      return ''
-    }
-  
-    let prettyJson = ''
-    let parsedValue: unknown = json
-    const space = props.formatPretty ? 2 : 0
-  
-    try {
-      if (typeof json === 'string') {
-        parsedValue = JSON.parse(json)
-        prettyJson = JSON.stringify(parsedValue, null, space)
-      } else {
-        parsedValue = json
-        prettyJson = JSON.stringify(json, null, space)
+    for (const item of Object.values(val)) {
+      count += 1;
+      if (count > limit) {
+        return true;
       }
-    } catch (error) {
-      console.warn(error)
+      if (traverse(item)) {
+        return true;
+      }
     }
+    return false;
+  };
 
-    const shouldSkipHighlight = exceedsFieldCountLimit(
-      parsedValue,
-      MAX_HIGHLIGHT_JSON_FIELD_COUNT,
-    )
+  return traverse(value);
+};
 
-    if (shouldSkipHighlight) {
-      return escapeHtml(prettyJson)
-    }
-  
-    prettyJson = prettyJson.replace(
-      /("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)/g,
-      (match) => {
-        let className = 'number'
-        if (/^"/.test(match)) {
-          className = /:$/.test(match) ? 'key' : 'string'
-        } else if (/true|false/.test(match)) {
-          className = 'boolean'
-        } else if (/null/.test(match)) {
-          className = 'null'
-        }
-        return `<span class="${classes[className]}">${escapeHtml(match)}</span>`
-      },
-    )
-  
-    return prettyJson
+/**
+ * 转义 HTML 特殊字符，防止 v-html 注入 XSS。
+ *
+ * @param text - 待转义的文本
+ * @returns 转义后的安全 HTML 文本
+ */
+const escapeHtml = (text: string): string =>
+  text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
+const props = defineProps<{
+  name: string;
+  status: 'running' | 'success' | 'failed' | 'cancelled';
+  content?: string | { params?: object; result?: object; [x: string]: unknown };
+  formatPretty?: boolean;
+  defaultOpen?: boolean;
+}>();
+const { t } = useI18n();
+const opened = ref(props.defaultOpen ?? false);
+
+const textAndIconMap = new Map<string, { text: string; icon: Component }>([
+  ['running', { text: t('toolStatus.running'), icon: IconLoading }],
+  ['success', { text: t('toolStatus.success'), icon: IconPlugin }],
+  ['failed', { text: t('toolStatus.failed'), icon: IconError }],
+  ['cancelled', { text: t('toolStatus.cancelled'), icon: IconCancelled }],
+]);
+
+const textAndIcon = computed(() => {
+  return textAndIconMap.get(props.status) || { text: '', icon: IconPlugin };
+});
+
+const classes = useCssModule();
+
+const highlightJSON = <T extends string | object>(json?: T): string => {
+  if (!json) {
+    return '';
   }
-  </script>
-  
-  <template>
-    <div class="tr-bubble__step-tool">
-      <div class="tr-bubble__step-tool-header">
-        <div class="tr-bubble__step-tool-left">
-          <component :is="textAndIcon.icon" class="tr-bubble__step-tool-icon" :class="`icon-${props.status}`" />
-          <span class="tr-bubble__step-tool-title">
-            {{ textAndIcon.text }}
-            <span class="tr-bubble__step-tool-name">{{ props.name }}</span>
-          </span>
-        </div>
-        <div class="tr-bubble__step-tool-expand">
-          <IconArrowDown class="expand-icon" :class="{ '-rotate-90': !opened }" @click="opened = !opened" />
-        </div>
+
+  let prettyJson = '';
+  let parsedValue: unknown = json;
+  const space = props.formatPretty ? 2 : 0;
+
+  try {
+    if (typeof json === 'string') {
+      parsedValue = JSON.parse(json);
+      prettyJson = JSON.stringify(parsedValue, null, space);
+    } else {
+      parsedValue = json;
+      prettyJson = JSON.stringify(json, null, space);
+    }
+  } catch (error) {
+    console.warn(error);
+  }
+
+  const shouldSkipHighlight = exceedsFieldCountLimit(parsedValue, MAX_HIGHLIGHT_JSON_FIELD_COUNT);
+
+  if (shouldSkipHighlight) {
+    return escapeHtml(prettyJson);
+  }
+
+  prettyJson = prettyJson.replace(
+    /("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)/g,
+    (match) => {
+      let className = 'number';
+      if (/^"/.test(match)) {
+        className = /:$/.test(match) ? 'key' : 'string';
+      } else if (/true|false/.test(match)) {
+        className = 'boolean';
+      } else if (/null/.test(match)) {
+        className = 'null';
+      }
+      return `<span class="${classes[className]}">${escapeHtml(match)}</span>`;
+    },
+  );
+
+  return prettyJson;
+};
+</script>
+
+<template>
+  <div class="tr-bubble__step-tool">
+    <div class="tr-bubble__step-tool-header">
+      <div class="tr-bubble__step-tool-left">
+        <component :is="textAndIcon.icon" class="tr-bubble__step-tool-icon" :class="`icon-${props.status}`" />
+        <span class="tr-bubble__step-tool-title">
+          {{ textAndIcon.text }}
+          <span class="tr-bubble__step-tool-name">{{ props.name }}</span>
+        </span>
       </div>
-      <div class="tr-bubble__step-tool-params" v-if="opened">
-        <hr class="tr-bubble__step-tool-hr" />
-        <div class="tr-bubble__step-tool-params-content" v-html="highlightJSON(props.content)"></div>
+      <div class="tr-bubble__step-tool-expand">
+        <IconArrowDown class="expand-icon" :class="{ '-rotate-90': !opened }" @click="opened = !opened" />
       </div>
     </div>
-  </template>
-  
-  <style lang="less" scoped>
-  .tr-bubble__step-tool {
-    font-size: 14px;
-    line-height: 24px;
-    padding: 12px;
-    color: var(--tr-text-secondary);
-    background-color: var(--tr-container-bg-default-2);
-    border-radius: 12px;
-  
-    .tr-bubble__step-tool-header {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 8px;
-    }
-  
-    .tr-bubble__step-tool-left {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-  
-      .tr-bubble__step-tool-icon {
-        font-size: 20px;
-        flex-shrink: 0;
-  
-        &.icon-running {
-          color: #898989;
-          animation: spin 1s linear infinite;
-        }
-  
-        &.icon-success {
-          color: #898989;
-        }
-  
-        &.icon-failed,
-        &.icon-cancelled {
-          color: var(--tr-color-error);
-        }
-      }
-  
-      .tr-bubble__step-tool-title {
-        word-break: break-word;
-      }
-  
-      .tr-bubble__step-tool-name {
-        color: var(--tr-text-primary);
-        font-weight: 600;
-      }
-    }
-  
-    .tr-bubble__step-tool-expand {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      cursor: pointer;
+    <div class="tr-bubble__step-tool-params" v-if="opened">
+      <hr class="tr-bubble__step-tool-hr" />
+      <div class="tr-bubble__step-tool-params-content" v-html="highlightJSON(props.content)"></div>
+    </div>
+  </div>
+</template>
+
+<style lang="less" scoped>
+.tr-bubble__step-tool {
+  font-size: 14px;
+  line-height: 24px;
+  padding: 12px;
+  color: var(--tr-text-secondary);
+  background-color: var(--tr-container-bg-default-2);
+  border-radius: 12px;
+
+  .tr-bubble__step-tool-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+  }
+
+  .tr-bubble__step-tool-left {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+
+    .tr-bubble__step-tool-icon {
+      font-size: 20px;
       flex-shrink: 0;
-  
-      .expand-icon {
-        font-size: 16px;
-  
-        &.-rotate-90 {
-          transform: rotate(-90deg);
-        }
+
+      &.icon-running {
+        color: #898989;
+        animation: spin 1s linear infinite;
+      }
+
+      &.icon-success {
+        color: #898989;
+      }
+
+      &.icon-failed,
+      &.icon-cancelled {
+        color: var(--tr-color-error);
       }
     }
-  
-    .tr-bubble__step-tool-hr {
-      margin: 12px 0;
-      color: rgb(219, 219, 219);
-    }
-  
-    .tr-bubble__step-tool-params-content {
-      white-space: pre-wrap;
+
+    .tr-bubble__step-tool-title {
       word-break: break-word;
-      font-family: monospace;
-      max-height: 300px;
-      overflow-y: auto;
+    }
+
+    .tr-bubble__step-tool-name {
+      color: var(--tr-text-primary);
+      font-weight: 600;
     }
   }
-  </style>
-  
-  <style module>
-  .key {
-    color: var(--tr-bubble-tool-key-color);
+
+  .tr-bubble__step-tool-expand {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    flex-shrink: 0;
+
+    .expand-icon {
+      font-size: 16px;
+
+      &.-rotate-90 {
+        transform: rotate(-90deg);
+      }
+    }
   }
-  
-  .number {
-    color: var(--tr-bubble-tool-number-color);
+
+  .tr-bubble__step-tool-hr {
+    margin: 12px 0;
+    color: rgb(219, 219, 219);
   }
-  
-  .string {
-    color: var(--tr-bubble-tool-string-color);
+
+  .tr-bubble__step-tool-params-content {
+    white-space: pre-wrap;
+    word-break: break-word;
+    font-family: monospace;
+    max-height: 300px;
+    overflow-y: auto;
   }
-  
-  .boolean {
-    color: var(--tr-bubble-tool-boolean-color);
-  }
-  
-  .null {
-    color: var(--tr-bubble-tool-null-color);
-  }
-  </style>
-  
+}
+</style>
+
+<style module>
+.key {
+  color: var(--tr-bubble-tool-key-color);
+}
+
+.number {
+  color: var(--tr-bubble-tool-number-color);
+}
+
+.string {
+  color: var(--tr-bubble-tool-string-color);
+}
+
+.boolean {
+  color: var(--tr-bubble-tool-boolean-color);
+}
+
+.null {
+  color: var(--tr-bubble-tool-null-color);
+}
+</style>

--- a/packages/frameworks/vue/src/chat/response-handler.ts
+++ b/packages/frameworks/vue/src/chat/response-handler.ts
@@ -79,7 +79,7 @@ function onToolCall(toolCalls: any[], delta: IStreamDelta, toolCallIdMap: Record
     emitter.emit('notification', {
       type: 'tool',
       delta,
-      toolCallData: toolCallItem,
+      toolCallData: readonly(toolCallItem),
       chatMessage: readonly(chatMessage),
     });
 

--- a/packages/frameworks/vue/src/chat/response-handler.ts
+++ b/packages/frameworks/vue/src/chat/response-handler.ts
@@ -1,6 +1,6 @@
-import { IChatMessage, IMessageItem, IStreamDelta, IStreamData, PatternExtractor } from "@opentiny/genui-sdk-core";
+import { IChatMessage, IMessageItem, IStreamDelta, IStreamData, PatternExtractor } from '@opentiny/genui-sdk-core';
 import { ThinkTagWrapPattern } from './think-tag-wrap-pattern';
-import { reactive, readonly, watch } from "vue";
+import { reactive, readonly, watch } from 'vue';
 import { v4 as uuidv4 } from 'uuid';
 import { emitter } from './event-emitter';
 import { useI18n } from './i18n';
@@ -10,7 +10,10 @@ export interface IResponseHandler<T> {
   match: (data: T, context: any) => boolean;
   handler: (data: T, context: any) => boolean;
   notMatchHandler?: (data: T, context: any) => boolean;
-  start?: (context: any, handlers: { onData: (data: IChatMessage) => void, onDone: () => void, onError: (error: Error) => void }) => void;
+  start?: (
+    context: any,
+    handlers: { onData: (data: IChatMessage) => void; onDone: () => void; onError: (error: Error) => void },
+  ) => void;
   end?: (context: any) => void;
 }
 
@@ -18,7 +21,13 @@ const getStreamDelta = (data: IStreamData): IStreamDelta => {
   return data.choices?.[0]?.delta ?? {};
 };
 
-function onToolResult(toolCallsResult: any[], delta: IStreamDelta, toolCallIdMap: Record<string, IMessageItem & { type: 'tool' }>, chatMessage: IChatMessage, addToolCallContext: boolean) {
+function onToolResult(
+  toolCallsResult: any[],
+  delta: IStreamDelta,
+  toolCallIdMap: Record<string, IMessageItem & { type: 'tool' }>,
+  chatMessage: IChatMessage,
+  addToolCallContext: boolean,
+) {
   const {
     id,
     function: { arguments: args, result },
@@ -45,9 +54,15 @@ function onToolResult(toolCallsResult: any[], delta: IStreamDelta, toolCallIdMap
         }) + '\n\n';
     }
   }
-};
+}
 
-function onToolCall(toolCalls: any[], delta: IStreamDelta, toolCallIdMap: Record<string, IMessageItem & { type: 'tool' }>, chatMessage: IChatMessage, toolCallStatus: { inProcessToolCallId: string | null }) {
+function onToolCall(
+  toolCalls: any[],
+  delta: IStreamDelta,
+  toolCallIdMap: Record<string, IMessageItem & { type: 'tool' }>,
+  chatMessage: IChatMessage,
+  toolCallStatus: { inProcessToolCallId: string | null },
+) {
   toolCalls.forEach((toolCall) => {
     const {
       id,
@@ -82,14 +97,12 @@ function onToolCall(toolCalls: any[], delta: IStreamDelta, toolCallIdMap: Record
       toolCallData: readonly(toolCallItem),
       chatMessage: readonly(chatMessage),
     });
-
   });
-
-};
+}
 
 function onReasoningContent(reasoningContent: string, delta: IStreamDelta, chatMessage: IChatMessage) {
   const lastMessage = chatMessage.messages[chatMessage.messages.length - 1];
-  let reasoningMessage = lastMessage
+  let reasoningMessage = lastMessage;
   if (reasoningMessage?.type === 'reasoning') {
     reasoningMessage.content += reasoningContent;
   } else {
@@ -102,11 +115,11 @@ function onReasoningContent(reasoningContent: string, delta: IStreamDelta, chatM
   }
   emitNotification(delta, chatMessage);
   return reasoningMessage;
-};
+}
 
 function onReasoningEnd(reasoningMessage: IMessageItem) {
   if (reasoningMessage?.type === 'reasoning') reasoningMessage.thinking = false;
-};
+}
 
 function emitNotification(delta: IStreamDelta, chatMessage: IChatMessage) {
   const lastMessage = chatMessage.messages[chatMessage.messages.length - 1];
@@ -117,7 +130,7 @@ function emitNotification(delta: IStreamDelta, chatMessage: IChatMessage) {
       chatMessage: readonly(chatMessage),
     });
   }
-};
+}
 
 function onMarkdown(content: string, delta: IStreamDelta, chatMessage: IChatMessage) {
   if (chatMessage.messages.length > 0 && chatMessage.messages[chatMessage.messages.length - 1].type === 'markdown') {
@@ -125,11 +138,11 @@ function onMarkdown(content: string, delta: IStreamDelta, chatMessage: IChatMess
   } else {
     chatMessage.messages.push({
       type: 'markdown',
-      content: content
+      content: content,
     });
   }
   emitNotification(delta, chatMessage);
-};
+}
 
 function onSchemaJSON(content: string, delta: IStreamDelta, chatMessage: IChatMessage) {
   if (chatMessage.messages.length > 0 && chatMessage.messages[chatMessage.messages.length - 1].type === 'schema-card') {
@@ -144,14 +157,18 @@ function onSchemaJSON(content: string, delta: IStreamDelta, chatMessage: IChatMe
   emitNotification(delta, chatMessage);
 }
 
-function watchReasoningEnd (context: any) {
-  context.unWatchReasoning = watch(() => [...context.chatMessage.messages], (newVal) => {
-    if (context.handleReasoning && newVal[newVal.length - 1]?.type !== 'reasoning') {
-      context.handleReasoning = false;
-      onReasoningEnd(context.reasoningMessage);
-      context.unWatchReasoning?.();
-    }
-  }, { flush: 'sync' });
+function watchReasoningEnd(context: any) {
+  context.unWatchReasoning = watch(
+    () => [...context.chatMessage.messages],
+    (newVal) => {
+      if (context.handleReasoning && newVal[newVal.length - 1]?.type !== 'reasoning') {
+        context.handleReasoning = false;
+        onReasoningEnd(context.reasoningMessage);
+        context.unWatchReasoning?.();
+      }
+    },
+    { flush: 'sync' },
+  );
 }
 
 export const defaultResponseHandlers: IResponseHandler<IStreamData>[] = [
@@ -159,7 +176,10 @@ export const defaultResponseHandlers: IResponseHandler<IStreamData>[] = [
     name: 'init',
     match: (data: IStreamData, context: any) => false,
     handler: (data: IStreamData, context: any) => false,
-    start: (context: any, handlers: { onData: (data: IChatMessage) => void, onDone: () => void, onError: (error: Error) => void }) => {
+    start: (
+      context: any,
+      handlers: { onData: (data: IChatMessage) => void; onDone: () => void; onError: (error: Error) => void },
+    ) => {
       const chatMessage = reactive<IChatMessage>({
         role: 'assistant',
         content: '',
@@ -205,7 +225,10 @@ export const defaultResponseHandlers: IResponseHandler<IStreamData>[] = [
       }
       return true;
     },
-    start: (context: any, handlers: { onData: (data: IChatMessage) => void, onDone: () => void, onError: (error: Error) => void }) => {
+    start: (
+      context: any,
+      handlers: { onData: (data: IChatMessage) => void; onDone: () => void; onError: (error: Error) => void },
+    ) => {
       context.handleReasoning = false;
     },
     end: (context: any) => {
@@ -214,7 +237,7 @@ export const defaultResponseHandlers: IResponseHandler<IStreamData>[] = [
         context.handleReasoning = false;
         onReasoningEnd(context.reasoningMessage);
       }
-    }
+    },
   },
   {
     name: 'toolCall',
@@ -227,7 +250,10 @@ export const defaultResponseHandlers: IResponseHandler<IStreamData>[] = [
       onToolCall(delta.tool_calls, delta, context.toolCallIdMap, context.chatMessage, context.toolCallStatus);
       return true;
     },
-    start: (context: any, handlers: { onData: (data: IChatMessage) => void, onDone: () => void, onError: (error: Error) => void }) => {
+    start: (
+      context: any,
+      handlers: { onData: (data: IChatMessage) => void; onDone: () => void; onError: (error: Error) => void },
+    ) => {
       context.toolCallIdMap = {};
       context.toolCallStatus = { inProcessToolCallId: null };
     },
@@ -240,7 +266,13 @@ export const defaultResponseHandlers: IResponseHandler<IStreamData>[] = [
     },
     handler: (data: IStreamData, context: any) => {
       const delta = getStreamDelta(data);
-      onToolResult(delta.tool_calls_result, delta, context.toolCallIdMap, context.chatMessage, context.chatConfig.addToolCallContext);
+      onToolResult(
+        delta.tool_calls_result,
+        delta,
+        context.toolCallIdMap,
+        context.chatMessage,
+        context.chatConfig.addToolCallContext,
+      );
       return true;
     },
   },
@@ -253,15 +285,18 @@ export const defaultResponseHandlers: IResponseHandler<IStreamData>[] = [
     handler: (data: IStreamData, context: any) => {
       const delta = getStreamDelta(data);
       context.delta = delta;
-      context.patternExtractor.handleContent(delta.content)
+      context.patternExtractor.handleContent(delta.content);
       context.chatMessage.content += delta.content;
       return true;
     },
-    start: (context: any, handlers: { onData: (data: IChatMessage) => void, onDone: () => void, onError: (error: Error) => void }) => {
+    start: (
+      context: any,
+      handlers: { onData: (data: IChatMessage) => void; onDone: () => void; onError: (error: Error) => void },
+    ) => {
       const thinkPatternExtractor = new PatternExtractor({
         onNormalWrite: (value) => onMarkdown(value, context.delta, context.chatMessage),
-        onHandledWrite: (value) => { 
-          context.reasoningMessage = onReasoningContent(value, context.delta, context.chatMessage)
+        onHandledWrite: (value) => {
+          context.reasoningMessage = onReasoningContent(value, context.delta, context.chatMessage);
           if (!context.handleReasoning) {
             watchReasoningEnd(context);
             context.handleReasoning = true;
@@ -274,5 +309,5 @@ export const defaultResponseHandlers: IResponseHandler<IStreamData>[] = [
         onHandledWrite: (value) => onSchemaJSON(value, context.delta, context.chatMessage),
       });
     },
-  }
+  },
 ];

--- a/packages/frameworks/vue/src/chat/response-handler.ts
+++ b/packages/frameworks/vue/src/chat/response-handler.ts
@@ -1,6 +1,6 @@
 import { IChatMessage, IMessageItem, IStreamDelta, IStreamData, PatternExtractor } from "@opentiny/genui-sdk-core";
 import { ThinkTagWrapPattern } from './think-tag-wrap-pattern';
-import { reactive, toRaw, watch } from "vue";
+import { reactive, readonly, watch } from "vue";
 import { v4 as uuidv4 } from 'uuid';
 import { emitter } from './event-emitter';
 import { useI18n } from './i18n';
@@ -31,8 +31,8 @@ function onToolResult(toolCallsResult: any[], delta: IStreamDelta, toolCallIdMap
     emitter.emit('notification', {
       type: 'tool',
       delta,
-      toolCallData: structuredClone(toRaw(toolCallItem)),
-      chatMessage: structuredClone(toRaw(chatMessage)),
+      toolCallData: readonly(toolCallItem),
+      chatMessage: readonly(chatMessage),
     });
 
     if (addToolCallContext) {
@@ -80,7 +80,7 @@ function onToolCall(toolCalls: any[], delta: IStreamDelta, toolCallIdMap: Record
       type: 'tool',
       delta,
       toolCallData: toolCallItem,
-      chatMessage: structuredClone(toRaw(chatMessage)),
+      chatMessage: readonly(chatMessage),
     });
 
   });
@@ -114,7 +114,7 @@ function emitNotification(delta: IStreamDelta, chatMessage: IChatMessage) {
     emitter.emit('notification', {
       type: lastMessage.type as 'markdown' | 'schema-card',
       delta,
-      chatMessage: structuredClone(toRaw(chatMessage)),
+      chatMessage: readonly(chatMessage),
     });
   }
 };
@@ -175,7 +175,7 @@ export const defaultResponseHandlers: IResponseHandler<IStreamData>[] = [
       emitter.emit('notification', {
         type: 'done',
         delta: {},
-        chatMessage: structuredClone(toRaw(context.chatMessage)),
+        chatMessage: readonly(context.chatMessage),
       });
     },
   },


### PR DESCRIPTION
1、修改notification事件的传参，从structClone改为readonly
2、计算工具调用结果字段数量，当超过一定阈值则不显示Highlight

如图尝试修改readonly内容后，vue会告警：
<img width="1006" height="216" alt="PixPin_2026-06-10_10-25-26" src="https://github.com/user-attachments/assets/7bbdff4f-d5f9-436f-8d07-7660da1952cb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved chat notification handling for more efficient, stable message emissions without changing visible behaviour.
* **Bug Fix / UI Improvement**
  * Improved JSON display for tool outputs: prevents excessive nested highlighting, escapes inserted HTML, and confines params output with a max-height and vertical scrolling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->