### PR TITLE
feat(ng-renderer): add page onMounted/onUnmounted lifecycle support

### DIFF
--- a/packages/frameworks/angular/projects/renderer/src/lib/genui-renderer.ts
+++ b/packages/frameworks/angular/projects/renderer/src/lib/genui-renderer.ts
@@ -122,6 +122,10 @@ export class GenuiRenderer implements OnInit {
     } else {
       isCompleted = this.isJsonComplete ?? true;
     }
+    if (!isCompleted && json && 'lifeCycles' in json) {
+      const { lifeCycles, ...rest } = json;
+      json = rest;
+    }
     if (this.deltaPatcher) {
       this.deltaPatcher.patchWithDelta(this.schema, json, isCompleted);
     } else {

--- a/packages/frameworks/angular/projects/renderer/src/lib/genui-renderer.ts
+++ b/packages/frameworks/angular/projects/renderer/src/lib/genui-renderer.ts
@@ -123,7 +123,7 @@ export class GenuiRenderer implements OnInit {
       isCompleted = this.isJsonComplete ?? true;
     }
     if (!isCompleted && json && 'lifeCycles' in json) {
-      const { lifeCycles, ...rest } = json;
+      const { lifeCycles: _lifeCycles, ...rest } = json;
       json = rest;
     }
     if (this.deltaPatcher) {

--- a/projects/tiny-schema-renderer-ng/projects/renderer/src/life-cycles.ts
+++ b/projects/tiny-schema-renderer-ng/projects/renderer/src/life-cycles.ts
@@ -1,8 +1,14 @@
 import { parseData } from './parser/schema-parser';
 
+export interface JSFunctionDescriptor {
+  type: 'JSFunction';
+  value: string;
+  params?: string[];
+}
+
 export interface LifeCycles {
-  onMounted?: unknown;
-  onUnmounted?: unknown;
+  onMounted?: JSFunctionDescriptor;
+  onUnmounted?: JSFunctionDescriptor;
 }
 
 /**
@@ -20,25 +26,29 @@ const normalizeLifeCycles = (lifeCycles: unknown): LifeCycles => {
 
 /**
  * 将生命周期配置解析为可执行的函数。
+ * 在回调执行时重新解析，确保使用最新的渲染上下文。
  *
  * @param source - 生命周期函数描述（通常为 JSFunction）
  * @param getContext - 获取当前渲染上下文的函数
  * @returns 解析成功时返回可执行函数，否则返回 null
  */
 const parseLifeCycleFn = (
-  source: unknown,
+  source: JSFunctionDescriptor | undefined,
   getContext: () => Record<string, unknown>,
 ): (() => void | Promise<void>) | null => {
   if (source == null) {
     return null;
   }
-  try {
-    const parsed = parseData(source, {}, getContext());
-    return typeof parsed === 'function' ? parsed : null;
-  } catch (error) {
-    console.error('LifeCycle parse error:', error);
-    return null;
-  }
+  return () => {
+    try {
+      const parsed = parseData(source, {}, getContext());
+      if (typeof parsed === 'function') {
+        return parsed();
+      }
+    } catch (error) {
+      console.error('LifeCycle parse error:', error);
+    }
+  };
 };
 
 /**

--- a/projects/tiny-schema-renderer-ng/projects/renderer/src/life-cycles.ts
+++ b/projects/tiny-schema-renderer-ng/projects/renderer/src/life-cycles.ts
@@ -1,0 +1,60 @@
+import { parseData } from './parser/schema-parser';
+
+export interface LifeCycles {
+  onMounted?: unknown;
+  onUnmounted?: unknown;
+}
+
+/**
+ * 将 schema 中的 lifeCycles 字段规范化为生命周期对象。
+ *
+ * @param lifeCycles - schema 中的 lifeCycles 配置
+ * @returns 规范化后的生命周期对象，无效输入时返回空对象
+ */
+const normalizeLifeCycles = (lifeCycles: unknown): LifeCycles => {
+  if (lifeCycles == null || typeof lifeCycles !== 'object' || Array.isArray(lifeCycles)) {
+    return {};
+  }
+  return lifeCycles as LifeCycles;
+};
+
+/**
+ * 将生命周期配置解析为可执行的函数。
+ *
+ * @param source - 生命周期函数描述（通常为 JSFunction）
+ * @param getContext - 获取当前渲染上下文的函数
+ * @returns 解析成功时返回可执行函数，否则返回 null
+ */
+const parseLifeCycleFn = (
+  source: unknown,
+  getContext: () => Record<string, unknown>,
+): (() => void | Promise<void>) | null => {
+  if (source == null) {
+    return null;
+  }
+  try {
+    const parsed = parseData(source, {}, getContext());
+    return typeof parsed === 'function' ? parsed : null;
+  } catch (error) {
+    console.error('LifeCycle parse error:', error);
+    return null;
+  }
+};
+
+/**
+ * 从 schema 的 lifeCycles 配置中解析页面级 onMounted / onUnmounted 回调。
+ *
+ * @param lifeCycles - schema 中的 lifeCycles 配置
+ * @param getContext - 获取当前渲染上下文的函数
+ * @returns 包含 onMounted 与 onUnmounted 回调的对象
+ */
+export const getPageLifeCycleFns = (
+  lifeCycles: LifeCycles | null | undefined,
+  getContext: () => Record<string, unknown>,
+) => {
+  const cycles = normalizeLifeCycles(lifeCycles);
+  return {
+    onMounted: parseLifeCycleFn(cycles.onMounted, getContext),
+    onUnmounted: parseLifeCycleFn(cycles.onUnmounted, getContext),
+  };
+};

--- a/projects/tiny-schema-renderer-ng/projects/renderer/src/renderer-main.ts
+++ b/projects/tiny-schema-renderer-ng/projects/renderer/src/renderer-main.ts
@@ -81,13 +81,9 @@ export class RendererMain implements OnDestroy {
   }
 
   ngOnDestroy() {
-    // Angular 不会等待 Promise 完成，异步 onUnmounted 回调可能无法在销毁前执行完毕
     void this.invokePageOnUnmounted();
   }
 
-  /**
-   * 执行并清理当前页面 onUnmounted 生命周期回调。
-   */
   private async invokePageOnUnmounted() {
     const fn = this.pageOnUnmounted;
     this.pageOnUnmounted = null;

--- a/projects/tiny-schema-renderer-ng/projects/renderer/src/renderer-main.ts
+++ b/projects/tiny-schema-renderer-ng/projects/renderer/src/renderer-main.ts
@@ -56,7 +56,6 @@ export class RendererMain implements OnDestroy {
   state: any = {};
   cssScopeId: string = '';
   private pageOnUnmounted: (() => void | Promise<void>) | null = null;
-  private schemaVersion = 0;
   constructor(
     private contextService: RendererContextService,
     private el: ElementRef,
@@ -141,21 +140,10 @@ export class RendererMain implements OnDestroy {
     });
   }
 
-  /**
-   * 判断当前 setSchema 调用是否仍为最新版本，用于忽略过期的并发调用。
-   *
-   * @param version - 本次 setSchema 的版本号
-   * @returns 若已被更新的 schema 取代则返回 true
-   */
-  private isStaleSchemaVersion(version: number): boolean {
-    return version !== this.schemaVersion;
-  }
-
   private async setSchema(data: any) {
     if (!data || !Object.keys(data).length) {
       return;
     }
-    const version = ++this.schemaVersion;
     const newSchema = JSON.parse(JSON.stringify(data));
     const context = {
       state: this.state,
@@ -166,9 +154,6 @@ export class RendererMain implements OnDestroy {
     this._setState(newSchema.state || {}, true);
 
     await this.invokePageOnUnmounted();
-    if (this.isStaleSchemaVersion(version)) {
-      return;
-    }
 
     const { onMounted: onMountedFn, onUnmounted: onUnmountedFn } = getPageLifeCycleFns(
       newSchema.lifeCycles,
@@ -176,24 +161,15 @@ export class RendererMain implements OnDestroy {
     );
 
     await new Promise((resolve) => setTimeout(resolve, 0));
-    if (this.isStaleSchemaVersion(version)) {
-      return;
-    }
 
     setPageCss(newSchema.css || '', this.cssScopeId);
     delete newSchema.lifeCycles;
     Object.assign(this.pageSchema, newSchema);
 
     await new Promise((resolve) => setTimeout(resolve, 0));
-    if (this.isStaleSchemaVersion(version)) {
-      return;
-    }
 
     try {
       await onMountedFn?.();
-      if (this.isStaleSchemaVersion(version)) {
-        return;
-      }
       this.pageOnUnmounted = onUnmountedFn;
       this.ngZone.run(() => this.cdr.detectChanges());
     } catch (error) {

--- a/projects/tiny-schema-renderer-ng/projects/renderer/src/renderer-main.ts
+++ b/projects/tiny-schema-renderer-ng/projects/renderer/src/renderer-main.ts
@@ -1,7 +1,16 @@
-import { Component, ElementRef, Input, NgZone, SimpleChanges } from '@angular/core';
+import {
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  Input,
+  NgZone,
+  OnDestroy,
+  SimpleChanges,
+} from '@angular/core';
 // import { Renderer } from './renderer';
 import { RendererContextService } from './context.service';
 import { parseData } from './parser/schema-parser';
+import { getPageLifeCycleFns } from './life-cycles';
 import { setPageCss } from './css/page-css';
 import { CommonModule } from '@angular/common';
 import { LoadingComponent } from './loading.component';
@@ -40,16 +49,19 @@ function reset(obj: any) {
     </ng-container>
   `,
 })
-export class RendererMain {
+export class RendererMain implements OnDestroy {
   @Input() schema: any = {};
   pageSchema: any = {};
   methods: any = {};
   state: any = {};
   cssScopeId: string = '';
+  private pageOnUnmounted: (() => void | Promise<void>) | null = null;
+  private schemaVersion = 0;
   constructor(
     private contextService: RendererContextService,
     private el: ElementRef,
     private ngZone: NgZone,
+    private cdr: ChangeDetectorRef,
   ) {
     this.cssScopeId = `data-schema-${Math.random().toString(36).slice(2, 8)}`;
   }
@@ -65,6 +77,26 @@ export class RendererMain {
   ngOnChanges(changes: SimpleChanges) {
     if (changes['schema']) {
       this.setSchema(changes['schema'].currentValue);
+    }
+  }
+
+  ngOnDestroy() {
+    this.invokePageOnUnmounted();
+  }
+
+  /**
+   * 执行并清理当前页面 onUnmounted 生命周期回调。
+   */
+  private async invokePageOnUnmounted() {
+    const fn = this.pageOnUnmounted;
+    this.pageOnUnmounted = null;
+    if (typeof fn !== 'function') {
+      return;
+    }
+    try {
+      await fn();
+    } catch (error) {
+      console.error('RendererMain onUnmounted error:', error);
     }
   }
 
@@ -112,10 +144,21 @@ export class RendererMain {
     });
   }
 
+  /**
+   * 判断当前 setSchema 调用是否仍为最新版本，用于忽略过期的并发调用。
+   *
+   * @param version - 本次 setSchema 的版本号
+   * @returns 若已被更新的 schema 取代则返回 true
+   */
+  private isStaleSchemaVersion(version: number): boolean {
+    return version !== this.schemaVersion;
+  }
+
   private async setSchema(data: any) {
     if (!data || !Object.keys(data).length) {
       return;
     }
+    const version = ++this.schemaVersion;
     const newSchema = JSON.parse(JSON.stringify(data));
     const context = {
       state: this.state,
@@ -124,9 +167,41 @@ export class RendererMain {
     this.contextService.setContext(context, true);
     this.setMethods(newSchema.methods || {}, true);
     this._setState(newSchema.state || {}, true);
-    Object.assign(this.pageSchema, newSchema);
+
+    await this.invokePageOnUnmounted();
+    if (this.isStaleSchemaVersion(version)) {
+      return;
+    }
+
+    const { onMounted: onMountedFn, onUnmounted: onUnmountedFn } = getPageLifeCycleFns(
+      newSchema.lifeCycles,
+      () => this.contextService.getContext(),
+    );
+    this.pageOnUnmounted = onUnmountedFn;
+
     await new Promise((resolve) => setTimeout(resolve, 0));
+    if (this.isStaleSchemaVersion(version)) {
+      return;
+    }
+
     setPageCss(newSchema.css || '', this.cssScopeId);
+    delete newSchema.lifeCycles;
+    Object.assign(this.pageSchema, newSchema);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    if (this.isStaleSchemaVersion(version)) {
+      return;
+    }
+
+    try {
+      await onMountedFn?.();
+      if (this.isStaleSchemaVersion(version)) {
+        return;
+      }
+      this.ngZone.run(() => this.cdr.detectChanges());
+    } catch (error) {
+      console.error('RendererMain onMounted error:', error);
+    }
   }
 
   public detectChanges() {

--- a/projects/tiny-schema-renderer-ng/projects/renderer/src/renderer-main.ts
+++ b/projects/tiny-schema-renderer-ng/projects/renderer/src/renderer-main.ts
@@ -160,8 +160,6 @@ export class RendererMain implements OnDestroy {
       () => this.contextService.getContext(),
     );
 
-    await new Promise((resolve) => setTimeout(resolve, 0));
-
     setPageCss(newSchema.css || '', this.cssScopeId);
     delete newSchema.lifeCycles;
     Object.assign(this.pageSchema, newSchema);

--- a/projects/tiny-schema-renderer-ng/projects/renderer/src/renderer-main.ts
+++ b/projects/tiny-schema-renderer-ng/projects/renderer/src/renderer-main.ts
@@ -81,7 +81,8 @@ export class RendererMain implements OnDestroy {
   }
 
   ngOnDestroy() {
-    this.invokePageOnUnmounted();
+    // Angular 不会等待 Promise 完成，异步 onUnmounted 回调可能无法在销毁前执行完毕
+    void this.invokePageOnUnmounted();
   }
 
   /**
@@ -177,7 +178,6 @@ export class RendererMain implements OnDestroy {
       newSchema.lifeCycles,
       () => this.contextService.getContext(),
     );
-    this.pageOnUnmounted = onUnmountedFn;
 
     await new Promise((resolve) => setTimeout(resolve, 0));
     if (this.isStaleSchemaVersion(version)) {
@@ -198,6 +198,7 @@ export class RendererMain implements OnDestroy {
       if (this.isStaleSchemaVersion(version)) {
         return;
       }
+      this.pageOnUnmounted = onUnmountedFn;
       this.ngZone.run(() => this.cdr.detectChanges());
     } catch (error) {
       console.error('RendererMain onMounted error:', error);


### PR DESCRIPTION
## Summary
- Add `life-cycles.ts` to parse schema `lifeCycles.onMounted` / `lifeCycles.onUnmounted` into executable callbacks in the Angular schema renderer.
- Update `RendererMain` to run unmount-before-mount lifecycle order, guard concurrent `setSchema` calls with a version counter, strip `lifeCycles` from `pageSchema`, and trigger change detection after `onMounted`.
- Strip `lifeCycles` from incomplete streaming JSON in `GenuiRenderer`, matching the Vue renderer behavior.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added schema-driven per-page lifecycle callbacks with mount and unmount support.

* **Bug Fixes**
  * Omitted lifecycle data from schema updates while content is incomplete.
  * Improved lifecycle flow with explicit unmount cleanup on component destroy, safer mount invocation, and more reliable change detection.
  * Added clearer error handling for lifecycle callback execution.

* **Other**
  * Ensured lifecycle-derived updates don’t apply out of order and refresh the UI after successful mounting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->