### PR TITLE
docs: add copy page markdown button to VitePress docs

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -10,14 +10,14 @@ export default defineConfig({
   locales: {
     root: {
       label: '中文',
-      lang: 'zh_CN',
+      lang: 'zh-CN',
       title: 'GenUI SDK',
       description: 'GenUI SDK 文档',
       themeConfig: zhThemeConfig,
     },
     en: {
       label: 'English',
-      lang: 'en_US',
+      lang: 'en-US',
       link: '/en/',
       title: 'GenUI SDK',
       description: 'GenUI SDK Documentation',

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -10,14 +10,14 @@ export default defineConfig({
   locales: {
     root: {
       label: '中文',
-      lang: 'zh-CN',
+      lang: 'zh_CN',
       title: 'GenUI SDK',
       description: 'GenUI SDK 文档',
       themeConfig: zhThemeConfig,
     },
     en: {
       label: 'English',
-      lang: 'en-US',
+      lang: 'en_US',
       link: '/en/',
       title: 'GenUI SDK',
       description: 'GenUI SDK Documentation',

--- a/docs/.vitepress/config/shared.ts
+++ b/docs/.vitepress/config/shared.ts
@@ -16,17 +16,15 @@ export const sharedConfig: UserConfig = {
       return;
     }
 
-    const filePath = path.join(srcDir, pageData.filePath);
-    if (!fs.existsSync(filePath)) {
+    try {
+      const content = fs.readFileSync(path.join(srcDir, pageData.filePath), 'utf-8');
+      return {
+        // Base64 避免 Markdown 中的 </template> 等字符破坏 VitePress 生成的 SFC
+        markdownSource: Buffer.from(content, 'utf-8').toString('base64'),
+      };
+    } catch {
       return;
     }
-
-    const content = fs.readFileSync(filePath, 'utf-8');
-
-    return {
-      // Base64 避免 Markdown 中的 </template> 等字符破坏 VitePress 生成的 SFC
-      markdownSource: Buffer.from(content, 'utf-8').toString('base64'),
-    };
   },
   markdown: {
     config(md) {

--- a/docs/.vitepress/config/shared.ts
+++ b/docs/.vitepress/config/shared.ts
@@ -1,10 +1,33 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { UserConfig } from 'vitepress';
 import { vitepressDemoPlugin } from 'vitepress-demo-plugin';
 import { tabsMarkdownPlugin } from 'vitepress-plugin-tabs';
 
+const docsRoot = path.dirname(fileURLToPath(import.meta.url));
+const srcDir = path.resolve(docsRoot, '../../src');
+
 export const sharedConfig: UserConfig = {
   base: '/genui-sdk-docs/',
   ignoreDeadLinks: true,
+  transformPageData(pageData) {
+    if (pageData.isNotFound || !pageData.filePath) {
+      return;
+    }
+
+    const filePath = path.join(srcDir, pageData.filePath);
+    if (!fs.existsSync(filePath)) {
+      return;
+    }
+
+    const content = fs.readFileSync(filePath, 'utf-8');
+
+    return {
+      // Base64 避免 Markdown 中的 </template> 等字符破坏 VitePress 生成的 SFC
+      markdownSource: Buffer.from(content, 'utf-8').toString('base64'),
+    };
+  },
   markdown: {
     config(md) {
       md.use(vitepressDemoPlugin);

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+import DefaultTheme from 'vitepress/theme';
+import { CopyMarkdownButton } from './copy-page';
+
+const { Layout } = DefaultTheme;
+</script>
+
+<template>
+  <Layout>
+    <template #doc-top>
+      <CopyMarkdownButton />
+    </template>
+  </Layout>
+</template>

--- a/docs/.vitepress/theme/copy-page/CopyMarkdownButton.vue
+++ b/docs/.vitepress/theme/copy-page/CopyMarkdownButton.vue
@@ -1,0 +1,122 @@
+<script setup lang="ts">
+import { computed, onUnmounted, ref } from 'vue';
+import { useData } from 'vitepress';
+import { getCopyPageMessages } from './copyPageMessages';
+import { getPageMarkdownSource, hasPageMarkdownSource } from './pageMarkdownSource';
+import { useTitleAnchor } from './useTitleAnchor';
+
+const { page, lang } = useData();
+const { anchor } = useTitleAnchor();
+const copied = ref(false);
+let resetTimer: ReturnType<typeof setTimeout> | undefined;
+
+const markdownSource = computed(() => getPageMarkdownSource(page.value));
+const visible = computed(() => {
+  if (page.value.isNotFound || !page.value.filePath) {
+    return false;
+  }
+
+  return hasPageMarkdownSource(page.value) && Boolean(anchor.value);
+});
+const messages = computed(() => getCopyPageMessages(lang.value));
+const label = computed(() => (copied.value ? messages.value.copied : messages.value.copy));
+
+/**
+ * 将文本写入系统剪贴板。
+ * 优先使用 Clipboard API，不支持时回退到 execCommand。
+ */
+async function writeToClipboard(text: string): Promise<boolean> {
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    // fall through to legacy copy
+  }
+
+  try {
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.setAttribute('readonly', '');
+    textarea.style.position = 'fixed';
+    textarea.style.opacity = '0';
+    document.body.appendChild(textarea);
+    textarea.select();
+    const ok = document.execCommand('copy');
+    document.body.removeChild(textarea);
+    return ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * 一键复制当前页面的 Markdown 源码到剪贴板。
+ */
+async function copyMarkdown(): Promise<void> {
+  const source = markdownSource.value;
+  if (!source) {
+    return;
+  }
+
+  const ok = await writeToClipboard(source);
+  if (!ok) {
+    return;
+  }
+
+  copied.value = true;
+  clearTimeout(resetTimer);
+  resetTimer = setTimeout(() => {
+    copied.value = false;
+  }, 2000);
+}
+
+onUnmounted(() => {
+  clearTimeout(resetTimer);
+});
+</script>
+
+<template>
+  <Teleport v-if="visible && anchor" :to="anchor">
+    <button
+      type="button"
+      class="copy-page-btn"
+      :class="{ copied }"
+      :aria-label="label"
+      :title="label"
+      @click="copyMarkdown"
+    >
+      <span class="copy-page-btn-icon" aria-hidden="true">
+        <svg
+          v-if="!copied"
+          viewBox="0 0 24 24"
+          width="14"
+          height="14"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+          <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+        </svg>
+        <svg
+          v-else
+          viewBox="0 0 24 24"
+          width="14"
+          height="14"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <polyline points="20 6 9 17 4 12" />
+        </svg>
+      </span>
+      <span class="copy-page-btn-text">{{ label }}</span>
+    </button>
+  </Teleport>
+</template>

--- a/docs/.vitepress/theme/copy-page/copyPageMessages.ts
+++ b/docs/.vitepress/theme/copy-page/copyPageMessages.ts
@@ -1,9 +1,9 @@
 export const copyPageMessages = {
-  'zh_CN': {
+  'zh-CN': {
     copy: '复制页面',
     copied: '已复制',
   },
-  'en_US': {
+  'en-US': {
     copy: 'Copy page',
     copied: 'Copied',
   },
@@ -16,5 +16,5 @@ export function getCopyPageMessages(lang: string) {
     return copyPageMessages[lang as CopyPageLocale];
   }
 
-  return copyPageMessages['zh_CN'];
+  return copyPageMessages['zh-CN'];
 }

--- a/docs/.vitepress/theme/copy-page/copyPageMessages.ts
+++ b/docs/.vitepress/theme/copy-page/copyPageMessages.ts
@@ -1,0 +1,20 @@
+export const copyPageMessages = {
+  'zh_CN': {
+    copy: '复制页面',
+    copied: '已复制',
+  },
+  'en_US': {
+    copy: 'Copy page',
+    copied: 'Copied',
+  },
+} as const;
+
+export type CopyPageLocale = keyof typeof copyPageMessages;
+
+export function getCopyPageMessages(lang: string) {
+  if (lang in copyPageMessages) {
+    return copyPageMessages[lang as CopyPageLocale];
+  }
+
+  return copyPageMessages['zh_CN'];
+}

--- a/docs/.vitepress/theme/copy-page/index.ts
+++ b/docs/.vitepress/theme/copy-page/index.ts
@@ -1,0 +1,9 @@
+export { default as CopyMarkdownButton } from './CopyMarkdownButton.vue';
+export { getCopyPageMessages } from './copyPageMessages';
+export {
+  decodeMarkdownSource,
+  getPageMarkdownEncoded,
+  getPageMarkdownSource,
+  hasPageMarkdownSource,
+} from './pageMarkdownSource';
+export { useTitleAnchor } from './useTitleAnchor';

--- a/docs/.vitepress/theme/copy-page/pageMarkdownSource.ts
+++ b/docs/.vitepress/theme/copy-page/pageMarkdownSource.ts
@@ -1,0 +1,32 @@
+import type { PageData } from 'vitepress';
+
+interface DocPageData extends PageData {
+  markdownSource?: string;
+}
+
+export function getPageMarkdownEncoded(page: PageData): string | undefined {
+  return (page as DocPageData).markdownSource;
+}
+
+export function decodeMarkdownSource(encoded: string): string {
+  const binary = atob(encoded);
+  const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
+}
+
+export function getPageMarkdownSource(page: PageData): string {
+  const encoded = getPageMarkdownEncoded(page);
+  if (!encoded) {
+    return '';
+  }
+
+  try {
+    return decodeMarkdownSource(encoded);
+  } catch {
+    return '';
+  }
+}
+
+export function hasPageMarkdownSource(page: PageData): boolean {
+  return Boolean(getPageMarkdownEncoded(page));
+}

--- a/docs/.vitepress/theme/copy-page/style.css
+++ b/docs/.vitepress/theme/copy-page/style.css
@@ -1,0 +1,80 @@
+.vp-doc-title-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin: 0 0 24px;
+}
+
+.vp-doc-title-row > h1 {
+  flex: 1;
+  min-width: 0;
+  margin: 0 !important;
+  padding: 0;
+  border-top: none !important;
+}
+
+.vp-doc-title-actions {
+  flex-shrink: 0;
+  padding-top: 0.35em;
+}
+
+.copy-page-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 32px;
+  padding: 0 10px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 8px;
+  background-color: var(--vp-c-bg);
+  color: var(--vp-c-text-2);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1;
+  white-space: nowrap;
+  cursor: pointer;
+  user-select: none;
+  transition:
+    color 0.15s ease,
+    border-color 0.15s ease,
+    background-color 0.15s ease;
+}
+
+.copy-page-btn:hover {
+  color: var(--vp-c-text-1);
+  border-color: var(--vp-c-text-3);
+  background-color: var(--vp-c-bg-soft);
+}
+
+.copy-page-btn.copied {
+  color: var(--vp-c-brand-1);
+  border-color: var(--vp-c-brand-soft);
+  background-color: var(--vp-c-brand-soft);
+}
+
+.copy-page-btn-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.copy-page-btn-text {
+  display: inline-block;
+}
+
+@media (max-width: 640px) {
+  .vp-doc-title-row {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+  }
+
+  .vp-doc-title-actions {
+    padding-top: 0;
+  }
+
+  .copy-page-btn {
+    align-self: flex-start;
+  }
+}

--- a/docs/.vitepress/theme/copy-page/useTitleAnchor.ts
+++ b/docs/.vitepress/theme/copy-page/useTitleAnchor.ts
@@ -1,0 +1,85 @@
+import { nextTick, onUnmounted, ref, watch } from 'vue';
+import { useRoute } from 'vitepress';
+
+const COPY_ANCHOR_ID = 'vp-doc-copy-anchor';
+const MAX_MOUNT_RETRIES = 30;
+const MOUNT_RETRY_INTERVAL = 100;
+
+function cleanupTitleRow(): void {
+  const row = document.querySelector('.vp-doc-title-row');
+  if (!row?.parentElement) {
+    return;
+  }
+
+  const h1 = row.querySelector('h1');
+  if (h1) {
+    row.parentElement.insertBefore(h1, row);
+  }
+
+  row.remove();
+}
+
+function mountTitleActions(): HTMLElement | null {
+  cleanupTitleRow();
+
+  const doc = document.querySelector('.VPDoc .vp-doc');
+  const h1 = doc?.querySelector('h1');
+  if (!h1?.parentElement) {
+    return null;
+  }
+
+  const row = document.createElement('div');
+  row.className = 'vp-doc-title-row';
+  h1.parentElement.insertBefore(row, h1);
+  row.appendChild(h1);
+
+  const actions = document.createElement('div');
+  actions.className = 'vp-doc-title-actions';
+  actions.id = COPY_ANCHOR_ID;
+  row.appendChild(actions);
+
+  return actions;
+}
+
+export function useTitleAnchor() {
+  const anchor = ref<HTMLElement | null>(null);
+  const route = useRoute();
+  let retryTimer: ReturnType<typeof setTimeout> | undefined;
+
+  function clearRetryTimer(): void {
+    if (retryTimer) {
+      clearTimeout(retryTimer);
+      retryTimer = undefined;
+    }
+  }
+
+  async function refreshAnchor(retries = MAX_MOUNT_RETRIES): Promise<void> {
+    await nextTick();
+    anchor.value = mountTitleActions();
+
+    if (!anchor.value && retries > 0) {
+      clearRetryTimer();
+      retryTimer = setTimeout(() => {
+        refreshAnchor(retries - 1);
+      }, MOUNT_RETRY_INTERVAL);
+    }
+  }
+
+  watch(
+    () => route.path,
+    () => {
+      clearRetryTimer();
+      anchor.value = null;
+      refreshAnchor();
+    },
+    { immediate: true },
+  );
+
+  onUnmounted(() => {
+    clearRetryTimer();
+    cleanupTitleRow();
+    anchor.value = null;
+  });
+
+  return { anchor };
+}

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,9 +1,13 @@
+import type { Theme } from 'vitepress';
 import DefaultTheme from 'vitepress/theme';
 import { enhanceAppWithTabs } from 'vitepress-plugin-tabs/client';
+import Layout from './Layout.vue';
+import './copy-page/style.css';
 
 export default {
-  ...DefaultTheme,
+  extends: DefaultTheme,
+  Layout,
   enhanceApp({ app }) {
     enhanceAppWithTabs(app);
   },
-};
+} satisfies Theme;


### PR DESCRIPTION
## Summary

- 在 VitePress 文档页标题旁新增「复制页面」按钮，支持一键复制当前页面的 Markdown 源码
- 构建时通过 `transformPageData` 注入 Base64 编码的 Markdown 源码，避免特殊字符破坏 SFC
- 扩展默认主题 Layout，支持中英文文案与响应式布局

## 按钮样式
<img width="1176" height="860" alt="image" src="https://github.com/user-attachments/assets/8b1c18c4-3922-4881-866a-becbbf97aa44" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a "copy page" button to documentation pages, enabling users to quickly copy the Markdown source to their clipboard
  * Displays a confirmation indicator that briefly shows when content is successfully copied
  * Supports multiple languages (Chinese and English)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->