### PR TITLE
fix(docs): keep top nav highlight when switching sidebar pages

### DIFF
--- a/docs/.vitepress/config/en-theme.ts
+++ b/docs/.vitepress/config/en-theme.ts
@@ -6,10 +6,14 @@ export const enThemeConfig: DefaultTheme.Config = {
     label: 'On this page',
   },
   nav: [
-    { text: 'Quick Start', link: '/en/guide/quick-start' },
-    { text: 'Components', link: '/en/components/renderer' },
-    { text: 'Examples', link: '/en/examples/renderer/custom-actions' },
-    { text: 'Protocol', link: '/en/schema/protocol' },
+    { text: 'Quick Start', link: '/en/guide/quick-start', activeMatch: '/en/guide/' },
+    { text: 'Reference', link: '/en/components/renderer', activeMatch: '/en/components/' },
+    {
+      text: 'Examples',
+      link: '/en/examples/renderer/custom-actions',
+      activeMatch: '/en/examples/',
+    },
+    { text: 'Protocol', link: '/en/schema/protocol', activeMatch: '/en/schema/' },
   ],
   sidebar: {
     '/en/guide/': [

--- a/docs/.vitepress/config/zh-theme.ts
+++ b/docs/.vitepress/config/zh-theme.ts
@@ -6,10 +6,10 @@ export const zhThemeConfig: DefaultTheme.Config = {
     label: '目录',
   },
   nav: [
-    { text: '快速开始', link: '/guide/quick-start' },
-    { text: '组件文档', link: '/components/renderer' },
-    { text: '特性示例', link: '/examples/renderer/custom-actions' },
-    { text: '协议规范', link: '/schema/protocol' },
+    { text: '快速开始', link: '/guide/quick-start', activeMatch: '/guide/' },
+    { text: '组件文档', link: '/components/renderer', activeMatch: '/components/' },
+    { text: '特性示例', link: '/examples/renderer/custom-actions', activeMatch: '/examples/' },
+    { text: '协议规范', link: '/schema/protocol', activeMatch: '/schema/' },
   ],
   sidebar: {
     '/guide/': [


### PR DESCRIPTION
## Summary

- 为 VitePress 顶部 nav 添加 `activeMatch`，按模块前缀（`/guide/`、`/components/` 等）判断高亮
- 修复左侧切换同模块文章后，顶部 tab 高亮消失的问题
- 中英文 locale 均已同步

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced navigation items to highlight the active section based on the current page location, providing clear visual feedback when users navigate through different documentation areas
  * Updated the top navigation menu label from "Components" to "Reference" across both English and Chinese versions for improved semantic consistency and clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->