### PR TITLE
fix(playground): only show prompt variants in vue framework

### DIFF
--- a/sites/playground/web/src/App.vue
+++ b/sites/playground/web/src/App.vue
@@ -245,6 +245,7 @@ const playgroundContext = {
   themeData,
   conversation,
   customExamples,
+  framework,
 };
 
 provide('playgroundContext', playgroundContext);

--- a/sites/playground/web/src/components/tab-components/ModelConfig.vue
+++ b/sites/playground/web/src/components/tab-components/ModelConfig.vue
@@ -20,7 +20,7 @@ const promptVariantLabelMap = {
 
 const emit = defineEmits(['update:llmConfig', 'createNewTemplate', 'update-custom-examples']);
 const playgroundContext = inject('playgroundContext');
-const { llmConfig, modelData, customExamples } = playgroundContext;
+const { llmConfig, modelData, customExamples, framework } = playgroundContext;
 
 const IconPlus = iconPlus();
 const IconEllipsis = iconEllipsis();
@@ -127,14 +127,16 @@ const createNewTemplate = () => {
       <b>{{ slotScope.slotScope }}</b>
     </template>
   </tiny-slider>
-  <div class="config-title">{{ t('model.promptVariant') }}</div>
-  <tiny-base-select
-    :model-value="llmConfig.promptVariant || 'standard'"
-    @update:model-value="updatePromptVariant"
-    :options="promptVariantOptions"
-    class="config-content"
-    style="margin-bottom: 12px"
-  />
+  <template v-if="framework === 'Vue'">
+    <div class="config-title">{{ t('model.promptVariant') }}</div>
+    <tiny-base-select
+      :model-value="llmConfig.promptVariant || 'standard'"
+      @update:model-value="updatePromptVariant"
+      :options="promptVariantOptions"
+      class="config-content"
+      style="margin-bottom: 12px"
+    />
+  </template>
   <div class="config-title prompt-title">
     <span>{{ t('model.prompt') }}</span>
     <span>


### PR DESCRIPTION
仅在vue框架才显示提示词版本

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The prompt variant setting is now shown only when using the Vue framework.
  * Framework selection is correctly shared with playground configuration components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->