### PR TITLE
fix(genui-sdk-angular): apply default properties in attribute parsing

### DIFF
--- a/projects/tiny-schema-renderer-ng/projects/renderer/src/renderer-template.component.html
+++ b/projects/tiny-schema-renderer-ng/projects/renderer/src/renderer-template.component.html
@@ -42,7 +42,7 @@
       attrAndEvent
       [attrs]="
         [
-          context | parseData: schema.props : mergeScope | propsFilter: 'attributes' : (schema.componentName | getComponent),
+          context | parseData: schema.props : mergeScope | applyDefaultProps: schema.componentName | propsFilter: 'attributes' : (schema.componentName | getComponent),
           internalAttributes
         ] | mergeObject
       "


### PR DESCRIPTION
修复attrs上的属性无法应用默认值问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Rendered components now correctly receive their default property values when applying schema-defined attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->