### PR TITLE
fix(playground): fall back to A2A 0.3 when 1.0 invoke fails

### DIFF
--- a/sites/playground/server/src/a2a-tools/invoke-agent/invoke-a2a-agent.ts
+++ b/sites/playground/server/src/a2a-tools/invoke-agent/invoke-a2a-agent.ts
@@ -50,6 +50,7 @@ export async function invokeA2aAgent(
     const text = await invokeAgentWithOfficialSdk(
       agent,
       version,
+      url,
       input,
       headers,
       abortSignal,

--- a/sites/playground/server/src/a2a-tools/invoke-agent/send-message/adapters/v0_3.ts
+++ b/sites/playground/server/src/a2a-tools/invoke-agent/send-message/adapters/v0_3.ts
@@ -1,9 +1,9 @@
 import { ClientFactory } from '@a2a-js/sdk/client';
-import { buildMessageBodyV03 } from '../build-body.js';
+import { buildMessageBodyV0_3 } from '../build-body.js';
 import { buildSdkRequestOptions } from '../build-options.js';
 import { extractA2aResponseText } from '../parse-response.js';
 
-export async function sendA2aMessageV03(
+export async function sendA2aMessageV0_3(
   agentCard: Record<string, unknown>,
   input: string,
   headers: Record<string, string>,
@@ -12,7 +12,7 @@ export async function sendA2aMessageV03(
   const factory = new ClientFactory();
   const client = await factory.createFromAgentCard(agentCard as never);
   const result = await client.sendMessage(
-    buildMessageBodyV03(input) as never,
+    buildMessageBodyV0_3(input) as never,
     buildSdkRequestOptions(headers, abortSignal),
   );
   return extractA2aResponseText(result);

--- a/sites/playground/server/src/a2a-tools/invoke-agent/send-message/adapters/v1_0.ts
+++ b/sites/playground/server/src/a2a-tools/invoke-agent/send-message/adapters/v1_0.ts
@@ -1,9 +1,9 @@
 import { ClientFactory } from '@a2a-js/sdk-v1/client';
-import { buildMessageBodyV10 } from '../build-body.js';
+import { buildMessageBodyV1_0 } from '../build-body.js';
 import { buildSdkRequestOptions } from '../build-options.js';
 import { extractA2aResponseText } from '../parse-response.js';
 
-export async function sendA2aMessageV10(
+export async function sendA2aMessageV1_0(
   agentCard: Record<string, unknown>,
   input: string,
   headers: Record<string, string>,
@@ -12,7 +12,7 @@ export async function sendA2aMessageV10(
   const factory = new ClientFactory();
   const client = await factory.createFromAgentCard(agentCard as never);
   const result = await client.sendMessage(
-    buildMessageBodyV10(input) as never,
+    buildMessageBodyV1_0(input) as never,
     buildSdkRequestOptions(headers, abortSignal) as never,
   );
   return extractA2aResponseText(result);

--- a/sites/playground/server/src/a2a-tools/invoke-agent/send-message/build-body.ts
+++ b/sites/playground/server/src/a2a-tools/invoke-agent/send-message/build-body.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 
-export function buildMessageBodyV03(input: string): Record<string, unknown> {
+export function buildMessageBodyV0_3(input: string): Record<string, unknown> {
   return {
     message: {
       messageId: randomUUID(),
@@ -10,7 +10,7 @@ export function buildMessageBodyV03(input: string): Record<string, unknown> {
   };
 }
 
-export function buildMessageBodyV10(input: string): Record<string, unknown> {
+export function buildMessageBodyV1_0(input: string): Record<string, unknown> {
   return {
     message: {
       messageId: randomUUID(),

--- a/sites/playground/server/src/a2a-tools/invoke-agent/send-message/invoke.ts
+++ b/sites/playground/server/src/a2a-tools/invoke-agent/send-message/invoke.ts
@@ -1,26 +1,36 @@
 import type { A2aProtocolVersion } from '../../parse-card/index.js';
 import type { PlaygroundAgentConfig } from '../../types.js';
-import { sendA2aMessageV03, sendA2aMessageV10 } from './adapters/index.js';
+import { sendA2aMessageV0_3, sendA2aMessageV1_0 } from './adapters/index.js';
 
 function toAgentCard(agent: PlaygroundAgentConfig): Record<string, unknown> {
   const { agentCardUrl: _agentCardUrl, enabled: _enabled, ...card } = agent;
   return card as Record<string, unknown>;
 }
 
+function withCardUrl(card: Record<string, unknown>, url: string): Record<string, unknown> {
+  return { ...card, url };
+}
+
 export async function invokeAgentWithOfficialSdk(
   agent: PlaygroundAgentConfig,
   version: A2aProtocolVersion,
+  url: string,
   input: string,
   headers: Record<string, string>,
   abortSignal?: AbortSignal,
 ): Promise<string> {
   const agentCard = toAgentCard(agent);
+  const legacyCard = withCardUrl(agentCard, url);
 
   switch (version) {
     case '0.3':
-      return sendA2aMessageV03(agentCard, input, headers, abortSignal);
+      return sendA2aMessageV0_3(legacyCard, input, headers, abortSignal);
     case '1.0':
-      return sendA2aMessageV10(agentCard, input, headers, abortSignal);
+      try {
+        return await sendA2aMessageV1_0(agentCard, input, headers, abortSignal);
+      } catch {
+        return sendA2aMessageV0_3(legacyCard, input, headers, abortSignal);
+      }
     default:
       throw new Error(`不支持 A2A 协议版本 "${version}"`);
   }


### PR DESCRIPTION
@a2a-js/sdk v1 对 JSON-RPC 发的是 SendMessage；有些公网 Agent（如 specification.website）虽然 Card 写了 protocolVersion: 1.0，实际仍只实现旧方法 message/send，于是报 Method not found: SendMessage。


## Summary
- Fall back from A2A 1.0 invoke to 0.3 when the 1.0 request fails, so agents that advertise 1.0 but still implement `message/send` work.
- Pass the resolved endpoint URL into the 0.3 SDK path so Agent Cards without a top-level `url` can still connect.
- Rename `V10`/`V03` helpers to `V1_0`/`V0_3` to avoid confusing version naming.

## Summary by CodeRabbit

* **New Features**
  * Improved agent invocation across A2A protocol versions 0.3 and 1.0.
  * Added support for resolving and applying the target agent URL during requests.
  * Added automatic fallback to the legacy protocol when newer-protocol communication fails.

* **Bug Fixes**
  * Corrected message formatting and role handling for both supported protocol versions.
  * Improved compatibility with agents using different A2A message conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->