### PR TITLE
build: workflow add element-plus angular build add external

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -13,6 +13,7 @@ on:
           - '@opentiny/genui-sdk-angular'
           - '@opentiny/genui-sdk-core'
           - '@opentiny/genui-sdk-materials-vue-opentiny-vue'
+          - '@opentiny/genui-sdk-materials-vue-element-plus'
           - '@opentiny/genui-sdk-materials-angular-opentiny-ng'
       version:
         description: '发布版本号（将写入对应包的 package.json，例如 1.0.0-beta.3）'
@@ -106,6 +107,13 @@ jobs:
               echo "filter=@opentiny/genui-sdk-materials-vue-opentiny-vue" >> "$GITHUB_OUTPUT"
               echo "build_script=build" >> "$GITHUB_OUTPUT"
               echo "publish_dir=packages/materials/vue-opentiny-vue" >> "$GITHUB_OUTPUT"
+              ;;
+            @opentiny/genui-sdk-materials-vue-element-plus)
+              echo "pkg_json=packages/materials/vue-element-plus/package.json" >> "$GITHUB_OUTPUT"
+              echo "sync_pkg_json=packages/materials/vue-element-plus/package.json" >> "$GITHUB_OUTPUT"
+              echo "filter=@opentiny/genui-sdk-materials-vue-element-plus" >> "$GITHUB_OUTPUT"
+              echo "build_script=build" >> "$GITHUB_OUTPUT"
+              echo "publish_dir=packages/materials/vue-element-plus" >> "$GITHUB_OUTPUT"
               ;;
             @opentiny/genui-sdk-materials-angular-opentiny-ng)
               echo "pkg_json=packages/materials/angular-opentiny-ng/package.json" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -26,7 +26,7 @@ on:
           - beta
           - alpha
       publish_optional_packages:
-        description: '同时发布 core 与物料包（vue / angular）'
+        description: '同时发布 core 与物料包（vue-opentiny / vue-element-plus / angular）'
         required: false
         default: false
         type: boolean
@@ -89,6 +89,7 @@ jobs:
           if [ "${{ github.event.inputs.publish_optional_packages }}" = "true" ]; then
             node ./scripts/update-package-version.js packages/core/package.json "$VERSION"
             node ./scripts/update-package-version.js packages/materials/vue-opentiny-vue/package.json "$VERSION"
+            node ./scripts/update-package-version.js packages/materials/vue-element-plus/package.json "$VERSION"
             node ./scripts/update-package-version.js packages/materials/angular-opentiny-ng/package.json "$VERSION"
           fi
 
@@ -99,6 +100,10 @@ jobs:
       - name: Build Vue materials
         if: github.event.inputs.publish_optional_packages == 'true'
         run: pnpm --filter @opentiny/genui-sdk-materials-vue-opentiny-vue build
+
+      - name: Build Element Plus materials
+        if: github.event.inputs.publish_optional_packages == 'true'
+        run: pnpm --filter @opentiny/genui-sdk-materials-vue-element-plus build
 
       - name: Build Angular materials
         if: github.event.inputs.publish_optional_packages == 'true'
@@ -120,7 +125,7 @@ jobs:
         run: |
           PUBLISH_PKG_JSONS="packages/server/output/package.json,packages/frameworks/vue/package.json,packages/frameworks/angular/output/package.json"
           if [ "${{ github.event.inputs.publish_optional_packages }}" = "true" ]; then
-            PUBLISH_PKG_JSONS="${PUBLISH_PKG_JSONS},packages/core/package.json,packages/materials/vue-opentiny-vue/package.json,packages/materials/angular-opentiny-ng/package.json"
+            PUBLISH_PKG_JSONS="${PUBLISH_PKG_JSONS},packages/core/package.json,packages/materials/vue-opentiny-vue/package.json,packages/materials/vue-element-plus/package.json,packages/materials/angular-opentiny-ng/package.json"
           fi
           export PUBLISH_PKG_JSONS
           node ./scripts/ci-replace-workspace-deps.js
@@ -136,6 +141,11 @@ jobs:
       - name: Publish Vue materials to npm
         if: github.event.inputs.publish_optional_packages == 'true'
         working-directory: packages/materials/vue-opentiny-vue
+        run: pnpm publish --no-git-checks --access public --tag ${{ github.event.inputs.npm_tag }}
+
+      - name: Publish Element Plus materials to npm
+        if: github.event.inputs.publish_optional_packages == 'true'
+        working-directory: packages/materials/vue-element-plus
         run: pnpm publish --no-git-checks --access public --tag ${{ github.event.inputs.npm_tag }}
 
       - name: Publish Angular materials to npm

--- a/packages/frameworks/angular/build-from-dist/vite.config.lib.ts
+++ b/packages/frameworks/angular/build-from-dist/vite.config.lib.ts
@@ -4,6 +4,7 @@ import escapeStringRegexp from 'escape-string-regexp';
 import tsconfigPaths from 'vite-jsconfig-paths';
 import dts from 'vite-plugin-dts';
 import packageJson from '../package.json';
+import rendererPackageJson from '../projects/renderer/package.json';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
 export default defineConfig(({ mode }) => {
   return {
@@ -33,7 +34,7 @@ export default defineConfig(({ mode }) => {
             '../dist/renderer': ['../../dist/renderer/index.d.ts'] // hack for fix relative path for 'output/dist'
           },
         },
-        bundledPackages: ['@opentiny/tiny-schema-renderer-ng', '@opentiny/genui-sdk-core', 'jsondiffpatch', '@dmsnell/diff-match-patch'],
+        bundledPackages: ['@opentiny/tiny-schema-renderer-ng', 'jsondiffpatch', '@dmsnell/diff-match-patch'],
       }),
       viteStaticCopy({
         targets: [
@@ -80,7 +81,10 @@ export default defineConfig(({ mode }) => {
         },
       },
       rollupOptions: {
-        external: [...Object.keys(packageJson.dependencies || {}).map(name => new RegExp(`^${escapeStringRegexp(name)}(/|$)`))],
+        external: [
+          ...Object.keys(packageJson.dependencies || {}).map(name => new RegExp(`^${escapeStringRegexp(name)}(/|$)`)),
+          ...Object.keys(rendererPackageJson.dependencies || {}).map(name => new RegExp(`^${escapeStringRegexp(name)}(/|$)`))
+        ],
       },
     },
   };

--- a/packages/frameworks/angular/projects/renderer/ng-package.json
+++ b/packages/frameworks/angular/projects/renderer/ng-package.json
@@ -5,6 +5,7 @@
     "entryFile": "src/public-api.ts"
   },
   "allowedNonPeerDependencies": [
+    "@opentiny/genui-sdk-core",
     "@opentiny/genui-sdk-materials-angular-opentiny-ng"
   ]
 }

--- a/packages/frameworks/angular/projects/renderer/package.json
+++ b/packages/frameworks/angular/projects/renderer/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "tslib": "^2.3.0",
+    "@opentiny/genui-sdk-core": "workspace:*",
     "@opentiny/genui-sdk-materials-angular-opentiny-ng": "workspace:*"
   },
   "sideEffects": false


### PR DESCRIPTION
1、github action发包工作流添加element-plus
2、angular构建新增external，将core包和物料包从构建产物移除

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for publishing the Vue Element Plus materials package.
  * The new package can be built, versioned, and released through the standard publishing workflows.

* **Bug Fixes**
  * Improved Angular renderer packaging by correctly handling shared core dependencies.
  * Updated Angular library builds to avoid bundling dependencies unnecessarily, helping produce cleaner and more reliable packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->