### PR TITLE
ci: fix github page check-openapi-tools url error

### DIFF
--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -48,6 +48,7 @@ jobs:
           VITE_CHECK_MCP_URL: ${{ vars.PLAYGROUND_BACKEND_URL }}/check-mcp
           VITE_FETCH_AGENT_CARD_URL: ${{ vars.PLAYGROUND_BACKEND_URL }}/fetch-agent-card
           VITE_CHAT_TEMPLATE_URL: ${{ vars.PLAYGROUND_BACKEND_URL }}/chat-template
+          VITE_CHECK_OPENAPI_TOOLS_URL: ${{ vars.PLAYGROUND_BACKEND_URL }}/check-openapi-tools
         run: node scripts/build-github-pages.mjs
 
       - name: Upload Pages artifact


### PR DESCRIPTION
修复github page部署中check-openapi-tools接口 url错误问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * GitHub Pages builds now include the OpenAPI tools check endpoint configuration.
  * No changes were made to deployment steps or permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->