### PR TITLE
fix(genui-sdk-vue): change image content type to openai

### DIFF
--- a/docs/demos/chat/image-upload.vue
+++ b/docs/demos/chat/image-upload.vue
@@ -16,7 +16,7 @@ const messages = [
   {
     role: 'user',
     content: [
-      { type: 'image', filename: 'circle.png', image: 'data:image/png;base64,XXXXXXXXXXX' },
+      { type: 'image_url', filename: 'circle.png', image_url: { url: 'data:image/png;base64,XXXXXXXXXXX' } },
       { type: 'text', text: '分析一下这张图片' },
     ],
     messages: [

--- a/docs/demos/en/chat/image-upload.vue
+++ b/docs/demos/en/chat/image-upload.vue
@@ -16,7 +16,7 @@ const messages = [
   {
     role: 'user',
     content: [
-      { type: 'image', filename: 'circle.png', image: 'data:image/png;base64,XXXXXXXXXXX' },
+      { type: 'image_url', filename: 'circle.png', image_url: { url: 'data:image/png;base64,XXXXXXXXXXX' } },
       { type: 'text', text: 'Analyze this image' },
     ],
     messages: [

--- a/docs/src/en/examples/chat/image-upload.md
+++ b/docs/src/en/examples/chat/image-upload.md
@@ -49,7 +49,7 @@ After upload, the data structure follows the OpenAI-compatible format. The messa
 {
   "role": "user",
   "content": [
-    { "type": "image", "filename": "circle.png", "image": "data:image/png;base64,XXXXXXXXXXX" },
+    { "type": "image_url", "filename": "circle.png", "image_url": { "url": "data:image/png;base64,XXXXXXXXXXX" } },
     { "type": "text", "text": "Analyze this image" }
   ]
 }

--- a/docs/src/examples/chat/image-upload.md
+++ b/docs/src/examples/chat/image-upload.md
@@ -49,7 +49,7 @@ const modelFeatures = {
 {
   "role": "user",
   "content": [
-    { "type": "image", "filename": "circle.png", "image": "data:image/png;base64,XXXXXXXXXXX" },
+    { "type": "image_url", "filename": "circle.png", "image_url": { "url": "data:image/png;base64,XXXXXXXXXXX" } },
     { "type": "text", "text": "分析一下这张图片" }
   ]
 }

--- a/packages/frameworks/vue/src/chat/file-upload/file-utils.ts
+++ b/packages/frameworks/vue/src/chat/file-upload/file-utils.ts
@@ -140,11 +140,12 @@ const processFile = async (file: FileMeta, features: ModelCapability): Promise<a
   const maxSize = features.supportImage?.maxImageSize || 0;
   validateFileSize(file, maxSize);
 
-  // ai-sdk格式要求
   if (fileCategory === 'image') {
     return {
-      type: 'image',
-      image: file.base64,
+      type: 'image_url',
+      image_url: {
+        url: file.base64,
+      },
       filename: file.name,
     };
   }

--- a/sites/playground/server/src/chat-genui.ts
+++ b/sites/playground/server/src/chat-genui.ts
@@ -25,6 +25,7 @@ import { buildSkillTools } from './skills/index.js';
 import { buildOpenApiTools, previewOpenApiTools } from './openapi-tools/index.js';
 import type { IPlaygroundConfig, LLMConfig, LLMConfigParams, McpServer, McpServersConfig } from './types/index.js';
 import { genPlaygroundPrompt } from './gen-prompt/index.js';
+import { normalizeMessagesForAiSdk } from './normalize-messages.js';
 
 type StreamTextOptions = Parameters<typeof streamText>[0];
 
@@ -325,7 +326,7 @@ export function createChatGenui() {
         userAppendPrompt +
         '\n' +
         skillPrompt,
-      messages: body.messages,
+      messages: normalizeMessagesForAiSdk(body.messages),
       abortSignal: abort.signal,
       tools,
       toolChoice: 'auto',

--- a/sites/playground/server/src/chat-template.ts
+++ b/sites/playground/server/src/chat-template.ts
@@ -11,6 +11,7 @@ import { generateLlmConfig, generateAiSdkTools } from './chat-genui.js';
 import { buildOpenApiTools } from './openapi-tools/index.js';
 import { genPlaygroundPrompt } from './gen-prompt/index.js';
 import { generateJsonPatchPrompt } from './json-patch-prompt.js';
+import { normalizeMessagesForAiSdk } from './normalize-messages.js';
 import type { IPlaygroundConfig, LLMConfigParams } from './types/index.js';
 
 type StreamTextOptions = Parameters<typeof streamText>[0];
@@ -101,7 +102,7 @@ export const createChatTemplate = () => {
       ${specificPrompt}
       ${customSystemPrompt}`;
 
-      const messages = body.messages;
+      const messages = normalizeMessagesForAiSdk(body.messages);
       if (body.templateSchema) {
         const schemaJsonContext = `
           **当前 schemaJson（这是唯一可信的 ID 来源）：**

--- a/sites/playground/server/src/normalize-messages.ts
+++ b/sites/playground/server/src/normalize-messages.ts
@@ -1,0 +1,35 @@
+function transformImageContent(contentItem) {
+  if (!contentItem || typeof contentItem !== 'object') {
+    return contentItem;
+  }
+
+  if (contentItem.type === 'image_url') {
+    const imageUrl = contentItem.image_url;
+    if (typeof imageUrl?.url === 'string') {
+      return { type: 'image', image: imageUrl.url };
+    }
+  }
+
+  return contentItem;
+}
+
+export function normalizeMessagesForAiSdk(messages) {
+  if (!Array.isArray(messages)) {
+    return messages;
+  }
+
+  return messages.map((message) => {
+    if (!message || typeof message !== 'object') {
+      return message;
+    }
+
+    if (!Array.isArray(message.content)) {
+      return message;
+    }
+
+    return {
+      ...message,
+      content: message.content.map(transformImageContent).filter(Boolean),
+    };
+  });
+}


### PR DESCRIPTION
将 image content的类型转换为openai兼容格式

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed image uploads in chat messages to use a compatible image URL format.
  * Improved chat request handling by normalizing image content before processing.
  * Updated playground chat examples and demos to reflect the corrected image upload format.

* **Documentation**
  * Updated image upload documentation and examples with the new payload structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->