### PR TITLE
fix(genui-sdk-vue): optimize assistant show at only markdown scene

### DIFF
--- a/packages/frameworks/vue/src/chat/GeneratingComponent.vue
+++ b/packages/frameworks/vue/src/chat/GeneratingComponent.vue
@@ -10,6 +10,8 @@ const { t } = useI18n();
 
 const loadingText = ref(t('loading.response'));
 
+const hasSchemaCard = ref(false);
+
 const toolStatusTextMap = new Map<string, { textKey: string }>([
   ['running', { textKey: 'toolStatus.running' }],
   ['success', { textKey: 'toolStatus.success' }],
@@ -43,7 +45,10 @@ const handleNotification = (payload: INotificationPayload) => {
   // type === 'markdown'
   const lastMessage = payload.chatMessage.messages[payload.chatMessage.messages.length - 1];
   if (lastMessage) {
-    loadingText.value = `${lastMessage.content}...`;
+    if (!hasSchemaCard.value) {
+      hasSchemaCard.value = payload.chatMessage.messages?.some((item: any) => item.type.startsWith('schema-card'));
+    }
+    loadingText.value = hasSchemaCard.value ? `${lastMessage.content}...` : t('loading.response');
   }
 };
 
@@ -58,7 +63,7 @@ onBeforeUnmount(() => {
 
 <template>
   <div v-if="loadingText" class="loading-wrapper">
-    <div  class="loading-container" type="loading-text">{{ loadingText }}</div>
+    <div class="loading-container" type="loading-text">{{ loadingText }}</div>
   </div>
 </template>
 <style scoped lang="less">
@@ -66,15 +71,19 @@ onBeforeUnmount(() => {
   width: fit-content;
   max-width: 100%;
   overflow: hidden;
-  direction: rtl;
+  width: 100%;
+  min-height: 45px;
+  position: relative;
 }
 .loading-container[type='loading-text'] {
+  position: absolute;
+  right: 0;
+  min-width: 100%;
   margin: 10px 0;
   color: #666;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  direction: ltr;
   display: inline-block;
 }
 

--- a/packages/frameworks/vue/src/chat/GenuiChat.vue
+++ b/packages/frameworks/vue/src/chat/GenuiChat.vue
@@ -581,7 +581,7 @@ defineExpose({
     box-shadow: none;
   }
 }
-:deep(.tr-bubble[data-role='assistant'] .tr-bubble__content-items) {
+:deep(.tr-bubble[data-role='assistant'] .tr-bubble__content-items:has([type^='schema-card'])) {
   // 匹配：type非空 + 排除 schema-card/loading-text 这两个值
   > [type]:not([type='']):not([type='schema-card']):not([type='loading-text']) {
     display: var(--thinking-display, initial);

--- a/sites/playground/web/src/App.vue
+++ b/sites/playground/web/src/App.vue
@@ -109,7 +109,7 @@ const customExamples = ref(normalizeCustomExamples(cacheCustomExamples));
 const chatConfig = reactive(
   cacheChatConfig || {
     addToolCallContext: false,
-    showThinkingResult: false,
+    showThinkingResult: true,
   },
 );
 


### PR DESCRIPTION
优化当配置了showToolReuslt为false后在只有Markdown内容的场景下的显示

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated chat loading indicators to display relevant response content when schema-card messages are present.
  * Refined assistant message styling so specialized schema-card layouts apply only where relevant.
  * Enabled thinking results by default in the playground chat experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->