### PR TITLE
feat(benchmarks): align bench with SDK core materials path

### DIFF
--- a/packages/benchmarks/.env.example
+++ b/packages/benchmarks/.env.example
@@ -1,12 +1,15 @@
-# 和 genui-sdk-playground-server 中配置一致，用来发送 chat 请求的 api key 和 base url
+# API Key / Base URL（变量名由 maas-models.json 中 apiKeyEnvName / baseUrlEnvName 决定）
 DEEPSEEK_API_KEY=<your-api-key-here>
 DEEPSEEK_BASE_URL=https://api.modelarts-maas.com/v1/
 
 # 为 true 时默认使用 maas-models.json 中的全部模型（多模型）；可被 BENCH_MODELS 覆盖
 # BENCH_MODELS_FROM_MAAS=true
 
-# 使用 maas 清单拉模型名时必填：相对本包根目录（与 main.ts、.env 同级），或绝对路径
-BENCH_MAAS_MODELS_PATH=../../sites/playground/server/maas-models.json
+# 模型 Provider 清单（解析 API 用）。 可选；未设时默认 ../../sites/playground/server/maas-models.json
+# BENCH_MAAS_MODELS_PATH=../../sites/playground/server/maas-models.json
+
+# 物料 meta：standard（materialsMeta）| mini（Vue miniMaterialsMeta）；默认 standard
+# BENCH_MATERIALS_VARIANT=standard
 
 # 单次 streamText 超时（毫秒）；默认同 benchmark.config 的 streamTimeoutMs（600000）；0=不限制
 # BENCH_STREAM_TIMEOUT_MS=900000

--- a/packages/benchmarks/README.md
+++ b/packages/benchmarks/README.md
@@ -96,7 +96,7 @@ src/
 在 **本包根目录**（与 `main.ts` 同级）放置 `.env`。可参考 `.env.example`。
 
 - **API Key / Base URL 的环境变量名**由 `maas-models.json`（及你配置的 `BENCH_MAAS_MODELS_PATH`）里各 provider 的 **`apiKeyEnvName`**、**`baseUrlEnvName`** 决定；仓库自带清单里常见为 **`DEEPSEEK_API_KEY`**，可选 **`DEEPSEEK_BASE_URL`** 覆盖默认 `baseUrl`。
-- 须在 `.env` 中设置 **`BENCH_MAAS_MODELS_PATH`** 指向 `maas-models.json`（见上文「`maas-models.json` 路径」）；未设置或仅空白会在枚举模型名或解析模型实例时抛错。
+- **`BENCH_MAAS_MODELS_PATH` 可选**（见上文「`maas-models.json` 路径」）：未设置或仅空白时回退到仓库默认清单；文件不存在时才会报错。
 
 布尔型环境变量：未设置、空字符串或**仅空白**表示「用 `benchmark.config.ts` 默认值」；若去掉首尾空白后非空，则 **`1`**、**`true`**、**`yes`**（后两者**大小写不敏感**）为真，其它非空值（如 `false`、`0`）为假。
 
@@ -118,7 +118,7 @@ src/
 | `BENCH_JSON` | `true` 时控制台输出 JSON；否则表格 + Summary |
 | `BENCH_WRITE_EXCEL` | 是否生成 `report_<runDir>.xlsx`（`runDir` 为本次样本/报告所在子目录名；默认 `true`） |
 | `BENCH_MODELS_FROM_MAAS` | 为真且 **`models` 在 config 中为空** 时，用 `BENCH_MAAS_MODELS_PATH` 清单中的模型名作为多模型列表（config 里 `modelsFromMaasManifest: true` 时不必再设此项） |
-| `BENCH_MAAS_MODELS_PATH` | `maas-models.json`：**绝对路径**，或相对 **benchmarks 包根目录**（与 `main.ts`、`.env` 同级）。**枚举模型名**与 **`resolveAiSdkModelForBench` 解析实例**共用此路径；未设置或仅空白会报错（见 `.env.example`） |
+| `BENCH_MAAS_MODELS_PATH` | `maas-models.json`：**绝对路径**，或相对 **benchmarks 包根目录**（与 `main.ts`、`.env` 同级）。**枚举模型名**与 **`resolveAiSdkModelForBench` 解析实例**共用此路径；未设置或仅空白时使用仓库默认清单（见 `.env.example`） |
 | `BENCH_COMPARE_EMPTY_SYSTEM` | 在**非**「仅 plain」模式下，是否额外生成空 system 对照样本（`*_plain.json`） |
 | `BENCH_PLAIN_ONLY` | 仅生成 plain、不生成 full（常与 `TARGET` 配合向已有 run 补文件） |
 | `BENCH_TARGET_SAMPLE_RUN_DIR` | 样本与报告写入**已有**子目录（相对样本根目录或绝对路径），不再新建北京时间戳目录 |

--- a/packages/benchmarks/README.md
+++ b/packages/benchmarks/README.md
@@ -1,6 +1,6 @@
 # @opentiny/genui-sdk-benchmarks
 
-基于 `@opentiny/genui-sdk-core` 的大模型 **schemaJson 生成** 基准：在线拉流生成样本（Vercel AI SDK + playground 的 Provider 映射），再离线校验、统计并输出 JSON / HTML / Excel 报告。
+验证 **SDK 核心能力**（非演练场）：以 `@opentiny/genui-sdk-core` 的 `genPrompt` + materials 包 `materialsMeta` 生成 system，驱动大模型输出 **schemaJson**，再用 `genRootSchema()` 等协议校验。模型 Provider 仅作跑数基建。
 
 ## 关注指标
 
@@ -10,6 +10,36 @@
 - **TPOT**：首 Token 之后平均每输出 Token 耗时（见下文公式）
 - **Token**：`promptTokens` / `completionTokens` / `totalTokens`
 - **LLM-as-a-Judge**（可选）：对输出质量打分 **1～10**，并给出简要原因
+
+## 与 SDK 主包的关系
+
+对齐方式与 [core README](../core/README.md) / materials 包文档一致：
+
+```ts
+import { genPrompt } from '@opentiny/genui-sdk-core';
+import { materialsMeta } from '@opentiny/genui-sdk-materials-vue-opentiny-vue/meta';
+
+const system = genPrompt('Vue', materialsMeta, tgCustomConfig);
+```
+
+- **会随依赖自动跟上**：`genPrompt` 拼装逻辑、`materialsMeta` / `miniMaterialsMeta` 内容、`genRootSchema` 协议。
+- **升级 SDK 后**：重装 workspace 依赖并跑一次烟雾即可；无需与 playground 同步。
+- **`BENCH_MATERIALS_VARIANT`**：在 materials 包导出的 `materialsMeta`（standard）与 Vue `miniMaterialsMeta`（mini）之间选择，不是演练场配置。
+- **`specificPrompt` / `userAppendPrompt`**：基准侧可选附加约束（如要求 ````schemaJson```` 包裹），不属于 core API。
+
+### 核心能力覆盖（相对 `@opentiny/genui-sdk-core`）
+
+| Core 能力 | 基准用法 |
+|-----------|----------|
+| `genPrompt` + materials `materialsMeta` | 生成阶段 system（默认 full，非 plain） |
+| `PatternExtractor` / `SchemaJsonPattern` | 报告阶段提取 ```schemaJson``` |
+| `repairJson` | 解析 schema 块（与渲染器路径一致） |
+| `genRootSchema(whiteList)` | 协议校验（whiteList 来自 materialsMeta） |
+| `wrapperComponent` | 首个可观测容器耗时（Vue `TinyCard` / Angular `TiCard`） |
+| `StreamPatternExtractor` / `DeltaPatcher` | **不在本基准范围**（流式增量 patch；由 core 单测覆盖） |
+| `buildMaterialDefaultValueMap` | **不在本基准范围**（渲染侧） |
+
+默认配置走 **full system（`genPrompt`）**；`BENCH_PLAIN_ONLY` / `BENCH_COMPARE_EMPTY_SYSTEM` 仅用于对照实验。
 
 ## 目录结构
 
@@ -50,7 +80,7 @@ src/
     └── number.ts
 ```
 
-系统提示词由 `genPrompt(framework, materialsMeta, tgCustomConfig)` + `specificPrompt` + `userAppendPrompt` 拼出，与 playground `chat-genui` 思路一致；**无**单独的 `llm.config.ts`。
+系统提示词：`genPrompt(framework, materialsMeta|miniMaterialsMeta, tgCustomConfig)`（SDK 主路径），再按需拼接 `specificPrompt` / `userAppendPrompt`。
 
 ### `maas-models.json` 路径（`BENCH_MAAS_MODELS_PATH`）
 
@@ -59,7 +89,7 @@ src/
 | **解析模型实例**（实际请求） | `resolve-ai-sdk-model.ts` | 通过 **`resolveMaasModelsJsonPath()`**（与下表同源）读取 `BENCH_MAAS_MODELS_PATH` 指向的清单，构建 `ProviderModelMapper` 与 AI SDK model。 |
 | **枚举多模型名称列表** | `maas-manifest-models.ts` | `listMaasManifestModelNames()` 同样使用 **`resolveMaasModelsJsonPath()`**。 |
 
-须在 **`packages/benchmarks/.env`** 中设置 **`BENCH_MAAS_MODELS_PATH`**（相对 benchmarks 包根或绝对路径）；未设置或仅空白时，拉模型列表与实际请求解析都会抛错。
+须在 **`packages/benchmarks/.env`** 中配置 **API Key**（见 `.env.example`）。`BENCH_MAAS_MODELS_PATH` 可选：未设置时默认使用仓库内 `sites/playground/server/maas-models.json`（仅作 Provider 基建）。该路径用于解析模型实例发请求；与 `modelsFromMaasManifest` / `BENCH_MODELS_FROM_MAAS` 无关——后两者只控制是否用清单**枚举**多模型名。
 
 ## 环境与 API Key
 
@@ -77,6 +107,7 @@ src/
 | `BENCH_MODEL` | 单模型 id；与 `BENCH_MODELS` / 配置里的 `models` **至少其一非空**即可；仅多模型时可不设此项 |
 | `BENCH_MODELS` | 逗号分隔多模型；非空时只跑列表内模型，报告也只统计这些模型 |
 | `BENCH_FRAMEWORK` | `Vue` 或 `Angular` |
+| `BENCH_MATERIALS_VARIANT` | `standard`（默认，`materialsMeta`）或 `mini`（Vue `miniMaterialsMeta`）。勿与样本的 `promptVariant`（full/plain）混淆 |
 | `BENCH_SCENARIO` | 单场景 id 过滤 |
 | `BENCH_SCENARIOS` | 逗号分隔多场景；**优先级高于** `BENCH_SCENARIO` |
 | `BENCH_REPEAT` | 每个「模型 × 场景」重复次数（正整数，默认取自 config） |
@@ -103,9 +134,7 @@ src/
 
 - **`compareEmptySystemPlainOnly === true`（仅 plain）**：每个任务只写 **空 system** 的 `*_plain.json`，不写 full。
 - **`compareEmptySystem === true` 且 plainOnly 为 false**：每个「模型 × 场景 × run」写 **full + plain** 各一份。
-- **二者均为 false**：只写 **full**。
-
-当前仓库默认配置里 **`compareEmptySystemPlainOnly` 为 `true`**，即**默认只生成 plain 样本**。若要默认跑完整 system 的 schema 基准，请在 config 或环境中关闭「仅 plain」（例如 `.env` 中 `BENCH_PLAIN_ONLY=false`，并按需设置 `BENCH_COMPARE_EMPTY_SYSTEM`）。
+- **二者均为 false（默认）**：只写 **full**（走 `genPrompt` 主路径）。
 
 ## 中断后继续
 

--- a/packages/benchmarks/main.ts
+++ b/packages/benchmarks/main.ts
@@ -9,6 +9,7 @@ import { runReport } from './src/run-report';
 import {
   envBool,
   envFramework,
+  envMaterialsVariant,
   envPositiveInt,
   envStreamTimeoutMs,
   envString,
@@ -29,6 +30,7 @@ function resolveRunOptions(): LlmBenchmarkRunOptions {
     models: configModels,
     modelsFromMaasManifest,
     framework,
+    materialsVariant: defaultMaterialsVariant,
     scenario,
     scenarios: defaultScenarios,
     repeat,
@@ -67,6 +69,7 @@ function resolveRunOptions(): LlmBenchmarkRunOptions {
     ...(trimmedModel ? { model: trimmedModel } : {}),
     models: models && models.length > 0 ? models : undefined,
     framework: envFramework('BENCH_FRAMEWORK', framework),
+    materialsVariant: envMaterialsVariant('BENCH_MATERIALS_VARIANT', defaultMaterialsVariant),
     scenario: envString('BENCH_SCENARIO', scenario),
     scenarios,
     repeat: envPositiveInt('BENCH_REPEAT', repeat ?? 1),

--- a/packages/benchmarks/src/benchmark.config.ts
+++ b/packages/benchmarks/src/benchmark.config.ts
@@ -17,7 +17,7 @@ export const benchmarkConfig: LlmBenchmarkRunOptions = {
   // 单场景过滤（兼容项）；为空时不过滤
   scenario: undefined,
   // 多场景过滤（优先级高于 scenario）；为空时跑全部内置场景
-  scenarios: ['simple-form'],
+  scenarios: undefined,
   // 每个“模型 × 场景”重复执行次数（最小为 1）
   repeat: 1,
   // 为 true 时额外生成空 system 的「纯文本」对照样本（*_plain.json）；可用 BENCH_COMPARE_EMPTY_SYSTEM=true
@@ -42,7 +42,7 @@ export const benchmarkConfig: LlmBenchmarkRunOptions = {
   // LLM-as-a-Judge 配置（默认关闭，避免报告阶段额外模型调用）
   llmJudge: {
     // 是否启用 Judge 评估
-    enabled: true,
+    enabled: false,
     // Judge 模型 id；为空则复用 model
     model: undefined,
     // 可选 system prompt；为空时使用内置默认规则

--- a/packages/benchmarks/src/benchmark.config.ts
+++ b/packages/benchmarks/src/benchmark.config.ts
@@ -9,19 +9,21 @@ export const benchmarkConfig: LlmBenchmarkRunOptions = {
   // 多模型对比列表；有值时优先于 model，按列表逐模型生成并汇总报告
   models: undefined,
   // 为 true 时默认用 maas-models.json 中全部模型名填满 models（显式 models / BENCH_MODELS 优先）
-  modelsFromMaasManifest: true,
+  modelsFromMaasManifest: false,
   // Prompt 生成使用的前端框架物料（影响系统提示词的配置）
   framework: 'Vue',
+  // materials 包 meta：standard → materialsMeta；Vue mini → miniMaterialsMeta（BENCH_MATERIALS_VARIANT）
+  materialsVariant: 'standard',
   // 单场景过滤（兼容项）；为空时不过滤
   scenario: undefined,
   // 多场景过滤（优先级高于 scenario）；为空时跑全部内置场景
-  scenarios: undefined,
+  scenarios: ['simple-form'],
   // 每个“模型 × 场景”重复执行次数（最小为 1）
   repeat: 1,
   // 为 true 时额外生成空 system 的「纯文本」对照样本（*_plain.json）；可用 BENCH_COMPARE_EMPTY_SYSTEM=true
-  compareEmptySystem: true,
-  // 为 true 时仅生成 plain（不生成 full）；与已有 full 同目录对比时配合 targetSampleRunDir / BENCH_TARGET_SAMPLE_RUN_DIR
-  compareEmptySystemPlainOnly: true,
+  compareEmptySystem: false,
+  // 为 true 时仅生成 plain（不生成 full）。默认 false：走 SDK genPrompt 主路径
+  compareEmptySystemPlainOnly: false,
   // 非空时样本直接写入该目录（不新建时间戳子目录）；相对路径相对于样本根目录（默认 reports/）
   targetSampleRunDir: undefined,
   // 生成阶段并发度（最小为 1）；值越大请求并发越高
@@ -40,7 +42,7 @@ export const benchmarkConfig: LlmBenchmarkRunOptions = {
   // LLM-as-a-Judge 配置（默认关闭，避免报告阶段额外模型调用）
   llmJudge: {
     // 是否启用 Judge 评估
-    enabled: false,
+    enabled: true,
     // Judge 模型 id；为空则复用 model
     model: undefined,
     // 可选 system prompt；为空时使用内置默认规则

--- a/packages/benchmarks/src/framework/types.ts
+++ b/packages/benchmarks/src/framework/types.ts
@@ -203,6 +203,10 @@ export interface LlmBenchmarkSample {
   promptVariant?: 'full' | 'plain';
   runIndex?: number;
   model: string;
+  /** 生成时使用的框架；缺省时报告阶段回退到运行配置 */
+  framework?: 'Vue' | 'Angular';
+  /** 生成时使用的 materials 档位；缺省时报告阶段回退到运行配置 */
+  materialsVariant?: 'mini' | 'standard';
   messages: LlmBenchmarkMessage[];
   output: string;
   generatedAt: string;

--- a/packages/benchmarks/src/framework/types.ts
+++ b/packages/benchmarks/src/framework/types.ts
@@ -39,7 +39,8 @@ export interface LlmBenchmarkMessageFinishInfo {
 }
 
 /**
- * 生成样本时 system prompt 的配置（与 chat-genui 对齐：genPrompt + specificPrompt + userAppendPrompt）。
+ * 生成样本时 system prompt 的配置。
+ * 核心为 SDK `genPrompt` 的 `tgCustomConfig`；`specificPrompt` / `userAppendPrompt` 为基准可选附加约束。
  */
 export type LlmBenchmarkPromptConfig = {
   tgCustomConfig: IGenPromptCustomConfig;
@@ -67,8 +68,14 @@ export interface LlmBenchmarkRunOptions {
   model?: string;
   /** 多模型对比：非空时按列表逐模型生成/过滤报告；与 `model` 可只配置其一或并存（并存时常用于指定主模型 + 多模型列表）。 */
   models?: string[];
-  // 与 chat-genui 一致，决定 genPrompt 使用的物料 materialsMeta（Vue / Angular）
+  // 决定 genPrompt 使用的物料包 materialsMeta（Vue / Angular）
   framework?: 'Vue' | 'Angular';
+  /**
+   * 选用 materials 包导出的哪份 meta：`standard` → `materialsMeta`；Vue `mini` → `miniMaterialsMeta`。
+   * 勿与样本字段 `promptVariant`（full / plain 空 system 对照）混淆。
+   * 可用 `BENCH_MATERIALS_VARIANT` 覆盖。
+   */
+  materialsVariant?: 'mini' | 'standard';
   // 单场景过滤（兼容旧配置）
   scenario?: string;
   // 多场景过滤（优先级高于 scenario）
@@ -132,7 +139,7 @@ export interface LlmBenchmarkResultItem {
   // 自请求开始到首个可观测输出 token 的毫秒数；未观测到则缺省。
   ttftMs?: number;
   totalMs: number;
-  // 自请求开始到输出中首次出现 `TinyCard` 节点（`"componentName": "TinyCard"`）的毫秒数；未出现则缺省。
+  // 自请求开始到输出中首次出现 materialsMeta.wrapperComponent 节点的毫秒数；未出现则缺省。
   firstObservableComponentMs?: number;
   // TPOT（Time Per Output Token），ms/token；completionTokens≤1 时无意义，省略
   tpotMs?: number;

--- a/packages/benchmarks/src/generate-samples.ts
+++ b/packages/benchmarks/src/generate-samples.ts
@@ -1,15 +1,14 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { genPrompt, type IMaterialsMeta } from '@opentiny/genui-sdk-core';
-import { materialsMeta } from '@opentiny/genui-sdk-materials-vue-opentiny-vue/meta';
-import { materialsMeta as ngMaterialsMeta } from '@opentiny/genui-sdk-materials-angular-opentiny-ng/meta';
+import { genPrompt } from '@opentiny/genui-sdk-core';
 import type { LlmBenchmarkRunOptions, LlmBenchmarkSample, LlmBenchmarkSampleCase } from './framework/index';
 import { coreLlmBenchmarkSampleCases } from './samples';
 import {
   formatBeijingRunDirName,
   getSampleFilePath,
-  hasTinyCardComponentDeclaration,
+  hasWrapperComponentDeclaration,
   resolveAiSdkModelForBench,
+  resolveMaterialsMeta,
   resolveModelsForBench,
   resolveSamplesDir,
   resolveStreamTextUsage,
@@ -20,23 +19,20 @@ import { computeTpotMs } from './utils';
 import { streamText } from 'ai';
 
 type IFrameworkKey = 'Vue' | 'Angular';
-type IMetaMap = Record<IFrameworkKey, IMaterialsMeta>;
-
-const metaMap: IMetaMap = {
-  Vue: materialsMeta,
-  Angular: ngMaterialsMeta
-};
+type IMaterialsVariant = 'mini' | 'standard';
 
 /**
- * 与 chat-genui 一致的 system 拼接；framework 来自运行配置（env / benchmark.config），其余来自 llm.config。
- * @param framework 前端框架类型（影响 materialsMeta）
- * @param promptConfig prompt 拼接配置
- * @returns 最终 system prompt
+ * SDK 主路径 system：`genPrompt(framework, materialsMeta, tgCustomConfig)`；
+ * 其后可选附加 bench 约束文案（非 SDK API）。
  */
-function buildSystemPrompt(framework: IFrameworkKey, promptConfig: LlmBenchmarkRunOptions['promptConfig']) {
+function buildSystemPrompt(
+  framework: IFrameworkKey,
+  materialsVariant: IMaterialsVariant,
+  promptConfig: LlmBenchmarkRunOptions['promptConfig'],
+) {
   const { tgCustomConfig, specificPrompt, userAppendPrompt } = promptConfig;
-  const materialsMetaForFramework = metaMap[framework];
-  return genPrompt(framework, materialsMetaForFramework, tgCustomConfig) + '\n' + specificPrompt + '\n' + userAppendPrompt;
+  const base = genPrompt(framework, resolveMaterialsMeta(framework, materialsVariant), tgCustomConfig);
+  return [base, specificPrompt, userAppendPrompt].filter((s) => s.trim().length > 0).join('\n');
 }
 /**
  * 根据 `scenarios` / `scenario` 过滤要生成样本的场景。
@@ -75,6 +71,7 @@ async function generateSingleSample(
   system: string,
   promptVariant: 'full' | 'plain',
   streamTimeoutMs: number | undefined,
+  wrapperComponent: string,
 ): Promise<LlmBenchmarkSample> {
   const start = Date.now();
   let firstTokenAt = 0;
@@ -103,7 +100,11 @@ async function generateSingleSample(
         const before = output;
         output += chunk.text;
         const now = Date.now();
-        if (!firstTinyCardAt && hasTinyCardComponentDeclaration(output) && !hasTinyCardComponentDeclaration(before)) {
+        if (
+          !firstTinyCardAt &&
+          hasWrapperComponentDeclaration(output, wrapperComponent) &&
+          !hasWrapperComponentDeclaration(before, wrapperComponent)
+        ) {
           firstTinyCardAt = now;
         }
       }
@@ -172,7 +173,10 @@ async function generateSingleSample(
 export async function generateSamples(options: LlmBenchmarkRunOptions) {
   (globalThis as any).AI_SDK_LOG_WARNINGS = false;
   const framework = options.framework ?? 'Vue';
-  const systemFull = buildSystemPrompt(framework, options.promptConfig);
+  const materialsVariant = options.materialsVariant ?? 'standard';
+  const materialsMetaForRun = resolveMaterialsMeta(framework, materialsVariant);
+  const wrapperComponent = materialsMetaForRun.wrapperComponent ?? 'TinyCard';
+  const systemFull = buildSystemPrompt(framework, materialsVariant, options.promptConfig);
   const plainOnly = options.compareEmptySystemPlainOnly === true;
   const compareBoth = options.compareEmptySystem === true && !plainOnly;
   const selected = selectSampleCases(coreLlmBenchmarkSampleCases, options);
@@ -187,7 +191,7 @@ export async function generateSamples(options: LlmBenchmarkRunOptions) {
   let doneJobs = 0;
   const startedAt = Date.now();
   console.log(
-    `[bench] Start generate samples: framework=${framework}, models=${modelIds.length}, scenarios=${selected.length}, repeat=${repeat}, plainOnly=${plainOnly}, compareFullPlusPlain=${compareBoth} (total jobs=${totalJobs})`,
+    `[bench] Start generate samples: framework=${framework}, materialsVariant=${materialsVariant}, models=${modelIds.length}, scenarios=${selected.length}, repeat=${repeat}, plainOnly=${plainOnly}, compareFullPlusPlain=${compareBoth} (total jobs=${totalJobs})`,
   );
 
   const samplesRootDir = resolveSamplesDir(options.samplesDir);
@@ -321,6 +325,7 @@ export async function generateSamples(options: LlmBenchmarkRunOptions) {
         job.system,
         job.promptVariant,
         options.streamTimeoutMs,
+        wrapperComponent,
       );
 
       // 防御式：即使父目录没创建成功或 sampleFile 被拼成多级目录，也能避免 ENOENT。

--- a/packages/benchmarks/src/generate-samples.ts
+++ b/packages/benchmarks/src/generate-samples.ts
@@ -72,6 +72,8 @@ async function generateSingleSample(
   promptVariant: 'full' | 'plain',
   streamTimeoutMs: number | undefined,
   wrapperComponent: string,
+  framework: IFrameworkKey,
+  materialsVariant: IMaterialsVariant,
 ): Promise<LlmBenchmarkSample> {
   const start = Date.now();
   let firstTokenAt = 0;
@@ -148,6 +150,8 @@ async function generateSingleSample(
     promptVariant,
     runIndex,
     model,
+    framework,
+    materialsVariant,
     messages: sampleCase.messages,
     output,
     generatedAt: new Date().toISOString(),
@@ -326,6 +330,8 @@ export async function generateSamples(options: LlmBenchmarkRunOptions) {
         job.promptVariant,
         options.streamTimeoutMs,
         wrapperComponent,
+        framework,
+        materialsVariant,
       );
 
       // 防御式：即使父目录没创建成功或 sampleFile 被拼成多级目录，也能避免 ENOENT。

--- a/packages/benchmarks/src/run-report.ts
+++ b/packages/benchmarks/src/run-report.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs';
-import { genRootSchema } from '@opentiny/genui-sdk-core';
+import { genRootSchema, repairJson, RepairJsonState } from '@opentiny/genui-sdk-core';
 import { streamText } from 'ai';
 import type { ZodIssue } from 'zod';
 import type { LlmBenchmarkResultItem, LlmBenchmarkRunOptions, LlmBenchmarkSample } from './framework/index';
@@ -9,6 +9,7 @@ import {
   extractSchemaJsonBlock,
   parseJudgeJson,
   resolveAiSdkModelForBench,
+  resolveMaterialsMeta,
   resolvePrimaryBenchmarkModelId,
   resolveSamplesDir,
   resolveStreamTextUsage,
@@ -60,9 +61,9 @@ type SchemaJsonValidation = {
 };
 
 /**
- * 校验 schemaJson：是否存在代码块、块内是否合法 JSON、是否通过协议。
+ * 校验 schemaJson：PatternExtractor 提取 → repairJson 解析 → genRootSchema(whiteList) 协议。
  */
-function validateSchemaJson(schemaJsonText: string | null): SchemaJsonValidation {
+function validateSchemaJson(schemaJsonText: string | null, componentWhiteList?: string[]): SchemaJsonValidation {
   if (!schemaJsonText) {
     return {
       isSchemaJsonBlockFound: false,
@@ -72,36 +73,39 @@ function validateSchemaJson(schemaJsonText: string | null): SchemaJsonValidation
     };
   }
 
-  try {
-    const parsed = JSON.parse(schemaJsonText);
-    const result = genRootSchema().safeParse(parsed);
-    if (result.success) {
-      return {
-        isSchemaJsonBlockFound: true,
-        isSchemaJsonValidJson: true,
-        isSchemaJsonValidAgainstProtocol: true,
-      };
-    }
-    const issue = pickMostSpecificIssue(result.error.issues);
-    const path = issue?.path?.length ? issue.path.join('.') : '(root)';
-    const message = issue
-      ? `[${issue.code}] ${issue.message}`
-      : `schema safeParse failed (issues=${result.error.issues.length})`;
-    return {
-      isSchemaJsonBlockFound: true,
-      isSchemaJsonValidJson: true,
-      isSchemaJsonValidAgainstProtocol: false,
-      schemaValidationError: `${path}: ${message}`,
-    };
-  } catch (error) {
-    const detail = error instanceof Error ? error.message : String(error);
+  const repaired = repairJson(schemaJsonText);
+  if (
+    repaired.state === RepairJsonState.INVALID_INPUT ||
+    repaired.state === RepairJsonState.FAILED ||
+    repaired.value === undefined
+  ) {
     return {
       isSchemaJsonBlockFound: true,
       isSchemaJsonValidJson: false,
       isSchemaJsonValidAgainstProtocol: false,
-      schemaValidationError: `schema parse failed: ${detail}`,
+      schemaValidationError: `schema JSON repair/parse failed (state=${repaired.state})`,
     };
   }
+
+  const result = genRootSchema(componentWhiteList).safeParse(repaired.value);
+  if (result.success) {
+    return {
+      isSchemaJsonBlockFound: true,
+      isSchemaJsonValidJson: true,
+      isSchemaJsonValidAgainstProtocol: true,
+    };
+  }
+  const issue = pickMostSpecificIssue(result.error.issues);
+  const path = issue?.path?.length ? issue.path.join('.') : '(root)';
+  const message = issue
+    ? `[${issue.code}] ${issue.message}`
+    : `schema safeParse failed (issues=${result.error.issues.length})`;
+  return {
+    isSchemaJsonBlockFound: true,
+    isSchemaJsonValidJson: true,
+    isSchemaJsonValidAgainstProtocol: false,
+    schemaValidationError: `${path}: ${message}`,
+  };
 }
 
 type LlmJudgeResult = {
@@ -207,11 +211,16 @@ async function judgeOneSample(sample: LlmBenchmarkSample, options: LlmBenchmarkR
  * 将单个样本转为报告结果项。
  * @param sample 由生成阶段写入的样本对象
  * @param judge Judge 结果（可选）
+ * @param componentWhiteList materialsMeta.whiteList，传入 genRootSchema
  * @returns 用于汇总/展示的指标结果
  */
-function toReportItem(sample: LlmBenchmarkSample, judge?: LlmJudgeResult): LlmBenchmarkResultItem {
+function toReportItem(
+  sample: LlmBenchmarkSample,
+  judge?: LlmJudgeResult,
+  componentWhiteList?: string[],
+): LlmBenchmarkResultItem {
   const schemaJsonText = extractSchemaJsonBlock(sample.output);
-  const validation = validateSchemaJson(schemaJsonText);
+  const validation = validateSchemaJson(schemaJsonText, componentWhiteList);
   const ttftMs = typeof sample.metrics.ttftMs === 'number' ? sample.metrics.ttftMs : undefined;
   const tpotMs =
     typeof sample.metrics.tpotMs === 'number'
@@ -291,6 +300,8 @@ export async function runReport(options: LlmBenchmarkRunOptions) {
 
   const judgeEnabled = options.llmJudge?.enabled === true;
   const judgeResults: Array<LlmJudgeResult | undefined> = [];
+  const materialsMetaForRun = resolveMaterialsMeta(options.framework ?? 'Vue', options.materialsVariant ?? 'standard');
+  const componentWhiteList = materialsMetaForRun.whiteList;
   if (judgeEnabled) {
     const toJudgeCount = parsedSamples.filter((s) => (s.promptVariant ?? 'full') !== 'plain').length;
     console.log(
@@ -320,7 +331,7 @@ export async function runReport(options: LlmBenchmarkRunOptions) {
   }
 
   const results: LlmBenchmarkResultItem[] = parsedSamples.map((sample, index) =>
-    toReportItem(sample, judgeEnabled ? judgeResults[index] : undefined),
+    toReportItem(sample, judgeEnabled ? judgeResults[index] : undefined, componentWhiteList),
   );
 
   if (results.length === 0) {

--- a/packages/benchmarks/src/run-report.ts
+++ b/packages/benchmarks/src/run-report.ts
@@ -203,9 +203,8 @@ async function judgeOneSample(sample: LlmBenchmarkSample, options: LlmBenchmarkR
     if (parsed.ok === false) {
       return { error: formatJudgeParseError(parsed), ...usage };
     }
-    const score = Math.min(10, Math.max(1, parsed.score));
     return {
-      score,
+      score: parsed.score,
       reason: parsed.reason,
       ...usage,
     };
@@ -222,16 +221,20 @@ async function judgeOneSample(sample: LlmBenchmarkSample, options: LlmBenchmarkR
  * 将单个样本转为报告结果项。
  * @param sample 由生成阶段写入的样本对象
  * @param judge Judge 结果（可选）
- * @param componentWhiteList materialsMeta.whiteList，传入 genRootSchema
+ * @param options 运行配置；whiteList 优先按样本上的 framework / materialsVariant 解析
  * @returns 用于汇总/展示的指标结果
  */
 function toReportItem(
   sample: LlmBenchmarkSample,
   judge?: LlmJudgeResult,
-  componentWhiteList?: string[],
+  options?: LlmBenchmarkRunOptions,
 ): LlmBenchmarkResultItem {
+  const materialsMeta = resolveMaterialsMeta(
+    sample.framework ?? options?.framework ?? 'Vue',
+    sample.materialsVariant ?? options?.materialsVariant ?? 'standard',
+  );
   const schemaJsonText = extractSchemaJsonBlock(sample.output);
-  const validation = validateSchemaJson(schemaJsonText, componentWhiteList);
+  const validation = validateSchemaJson(schemaJsonText, materialsMeta.whiteList);
   const ttftMs = typeof sample.metrics.ttftMs === 'number' ? sample.metrics.ttftMs : undefined;
   const tpotMs =
     typeof sample.metrics.tpotMs === 'number'
@@ -311,8 +314,6 @@ export async function runReport(options: LlmBenchmarkRunOptions) {
 
   const judgeEnabled = options.llmJudge?.enabled === true;
   const judgeResults: Array<LlmJudgeResult | undefined> = [];
-  const materialsMetaForRun = resolveMaterialsMeta(options.framework ?? 'Vue', options.materialsVariant ?? 'standard');
-  const componentWhiteList = materialsMetaForRun.whiteList;
   if (judgeEnabled) {
     const toJudgeCount = parsedSamples.filter((s) => (s.promptVariant ?? 'full') !== 'plain').length;
     console.log(
@@ -346,7 +347,7 @@ export async function runReport(options: LlmBenchmarkRunOptions) {
   }
 
   const results: LlmBenchmarkResultItem[] = parsedSamples.map((sample, index) =>
-    toReportItem(sample, judgeEnabled ? judgeResults[index] : undefined, componentWhiteList),
+    toReportItem(sample, judgeEnabled ? judgeResults[index] : undefined, options),
   );
 
   if (results.length === 0) {

--- a/packages/benchmarks/src/run-report.ts
+++ b/packages/benchmarks/src/run-report.ts
@@ -7,6 +7,8 @@ import { printLlmBenchmarkResults } from './framework/index';
 import {
   computeTpotMs,
   extractSchemaJsonBlock,
+  formatJudgeParseError,
+  isJudgeTimeoutError,
   parseJudgeJson,
   resolveAiSdkModelForBench,
   resolveMaterialsMeta,
@@ -119,9 +121,9 @@ type LlmJudgeResult = {
 
 /**
  * 使用 LLM-as-a-Judge 对单条样本做质量评估。
- * @param sample 样本数据
- * @param options 运行配置（读取 Judge 模型）
- * @returns Judge 结果（分数与原因）
+ * 错误信息带前缀便于区分：`judge_timeout` / `judge_empty_output` / `judge_non_json` /
+ * `judge_invalid_json` / `judge_missing_score` / `judge_invalid_score` /
+ * `judge_stream_error` / `judge_request_failed`。
  */
 async function judgeOneSample(sample: LlmBenchmarkSample, options: LlmBenchmarkRunOptions): Promise<LlmJudgeResult> {
   const judgeCfg = options.llmJudge;
@@ -159,7 +161,7 @@ async function judgeOneSample(sample: LlmBenchmarkSample, options: LlmBenchmarkR
     let promptTokens = 0;
     let completionTokens = 0;
     let totalTokens = 0;
-    let streamError: string | undefined;
+    let streamError: unknown;
     for await (const chunk of streamResult.fullStream) {
       if (chunk.type === 'text-delta' && chunk.text) {
         output += chunk.text;
@@ -171,7 +173,7 @@ async function judgeOneSample(sample: LlmBenchmarkSample, options: LlmBenchmarkR
         totalTokens = u?.totalTokens ?? totalTokens;
       }
       if (chunk.type === 'error') {
-        streamError = chunk.error instanceof Error ? chunk.error.message : String(chunk.error);
+        streamError = chunk.error;
       }
     }
     const settled = await resolveStreamTextUsage(streamResult);
@@ -189,12 +191,17 @@ async function judgeOneSample(sample: LlmBenchmarkSample, options: LlmBenchmarkR
       completionTokens,
       totalTokens,
     };
-    if (streamError) {
-      return { error: streamError, ...usage };
+    if (streamError != null) {
+      const detail = streamError instanceof Error ? streamError.message : String(streamError);
+      if (isJudgeTimeoutError(streamError) || isJudgeTimeoutError(detail)) {
+        return { error: `judge_timeout: ${detail}`, ...usage };
+      }
+      return { error: `judge_stream_error: ${detail}`, ...usage };
     }
+
     const parsed = parseJudgeJson(output);
-    if (!parsed || typeof parsed.score !== 'number') {
-      return { error: 'Judge output JSON parse failed', ...usage };
+    if (parsed.ok === false) {
+      return { error: formatJudgeParseError(parsed), ...usage };
     }
     const score = Math.min(10, Math.max(1, parsed.score));
     return {
@@ -203,7 +210,11 @@ async function judgeOneSample(sample: LlmBenchmarkSample, options: LlmBenchmarkR
       ...usage,
     };
   } catch (error) {
-    return { error: error instanceof Error ? error.message : String(error) };
+    const detail = error instanceof Error ? error.message : String(error);
+    if (isJudgeTimeoutError(error) || isJudgeTimeoutError(detail)) {
+      return { error: `judge_timeout: ${detail}` };
+    }
+    return { error: `judge_request_failed: ${detail}` };
   }
 }
 
@@ -321,10 +332,14 @@ export async function runReport(options: LlmBenchmarkRunOptions) {
         }
         const judged = await judgeOneSample(sample, options);
         judgeResults[index] = judged;
-        const score = judged.score == null ? '-' : judged.score.toFixed(2);
-        console.log(
-          `[bench][judge] ${index + 1}/${parsedSamples.length} ${sample.scenario} score=${score}${judged.error ? ' error' : ''}`,
-        );
+        if (judged.error) {
+          console.log(
+            `[bench][judge] ${index + 1}/${parsedSamples.length} ${sample.scenario} error=${judged.error}`,
+          );
+        } else {
+          const score = judged.score == null ? '-' : judged.score.toFixed(2);
+          console.log(`[bench][judge] ${index + 1}/${parsedSamples.length} ${sample.scenario} score=${score}`);
+        }
       }
     }
     await Promise.all(Array.from({ length: Math.min(concurrency, parsedSamples.length) }, () => worker()));

--- a/packages/benchmarks/src/utils/env.ts
+++ b/packages/benchmarks/src/utils/env.ts
@@ -102,3 +102,20 @@ export function envFramework(key: string, fallback: 'Vue' | 'Angular' | undefine
   }
   return 'Vue';
 }
+
+/**
+ * 读取物料档位：`standard` → materialsMeta；`mini` → miniMaterialsMeta（Vue materials 包导出）。
+ */
+export function envMaterialsVariant(
+  key: string,
+  fallback: 'mini' | 'standard' | undefined,
+): 'mini' | 'standard' {
+  const v = process.env[key]?.trim();
+  if (v === 'mini' || v === 'standard') {
+    return v;
+  }
+  if (fallback === 'mini' || fallback === 'standard') {
+    return fallback;
+  }
+  return 'standard';
+}

--- a/packages/benchmarks/src/utils/extract-schema-json.ts
+++ b/packages/benchmarks/src/utils/extract-schema-json.ts
@@ -1,12 +1,19 @@
+import { PatternExtractor } from '@opentiny/genui-sdk-core';
+
 /**
- * 从完整模型输出中提取 ```schemaJson ...``` 代码块内容。
- * @param content 模型完整文本输出
- * @returns 提取出的 schemaJson 字符串；未命中时返回 null
+ * 用 core `PatternExtractor`（默认 `SchemaJsonPattern`）从完整输出中提取 schemaJson 段。
+ * 与 SDK 流式拆分路径一致，避免手写正则与主包分叉。
  */
 export function extractSchemaJsonBlock(content: string): string | null {
-  const match = content.match(/```schemaJson\s*([\s\S]*?)```/);
-  if (!match) {
-    return null;
-  }
-  return match[1].trim();
+  if (!content) return null;
+  let handled = '';
+  const extractor = new PatternExtractor({
+    onNormalWrite() {},
+    onHandledWrite(chunk) {
+      handled += chunk;
+    },
+  });
+  extractor.handleContent(content);
+  const text = handled.trim();
+  return text.length > 0 ? text : null;
 }

--- a/packages/benchmarks/src/utils/extract-schema-json.ts
+++ b/packages/benchmarks/src/utils/extract-schema-json.ts
@@ -7,10 +7,13 @@ import { PatternExtractor } from '@opentiny/genui-sdk-core';
 export function extractSchemaJsonBlock(content: string): string | null {
   if (!content) return null;
   let handled = '';
+  let firstBlockDone = false;
   const extractor = new PatternExtractor({
-    onNormalWrite() {},
+    onNormalWrite() {
+      if (handled.length > 0) firstBlockDone = true;
+    },
     onHandledWrite(chunk) {
-      handled += chunk;
+      if (!firstBlockDone) handled += chunk;
     },
   });
   extractor.handleContent(content);

--- a/packages/benchmarks/src/utils/first-observable-component.ts
+++ b/packages/benchmarks/src/utils/first-observable-component.ts
@@ -1,7 +1,9 @@
 /**
- * 是否已出现 `TinyCard` 节点的完整 `"componentName": "TinyCard"` 声明。
- * 与流式输出配合：用于记录首块业务容器在 schema 文本中的出现时刻。
+ * 输出中是否已出现指定 wrapper 组件的 `"componentName": "<name>"` 声明。
+ * 名称来自 materialsMeta.wrapperComponent（Vue 默认 TinyCard，Angular 默认 TiCard）。
  */
-export function hasTinyCardComponentDeclaration(text: string): boolean {
-  return /"componentName"\s*:\s*"TinyCard"/.test(text);
+export function hasWrapperComponentDeclaration(text: string, wrapperComponent: string): boolean {
+  if (!wrapperComponent) return false;
+  const escaped = wrapperComponent.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`"componentName"\\s*:\\s*"${escaped}"`).test(text);
 }

--- a/packages/benchmarks/src/utils/index.ts
+++ b/packages/benchmarks/src/utils/index.ts
@@ -7,6 +7,7 @@ export * from './fs-paths';
 export * from './judge';
 export * from './maas-manifest-models';
 export * from './number';
+export * from './resolve-materials-meta';
 export * from './resolve-models';
 export * from './resolve-ai-sdk-model';
 export * from './stats';

--- a/packages/benchmarks/src/utils/judge.ts
+++ b/packages/benchmarks/src/utils/judge.ts
@@ -42,7 +42,12 @@ export function parseJudgeJson(text: string): ParseJudgeJsonResult {
   if (parsed.score === undefined || parsed.score === null) {
     return { ok: false, code: 'missing_score', preview: truncatePreview(JSON.stringify(parsed)) };
   }
-  if (typeof parsed.score !== 'number' || !Number.isFinite(parsed.score)) {
+  if (
+    typeof parsed.score !== 'number' ||
+    !Number.isFinite(parsed.score) ||
+    parsed.score < 1 ||
+    parsed.score > 10
+  ) {
     return {
       ok: false,
       code: 'invalid_score',

--- a/packages/benchmarks/src/utils/judge.ts
+++ b/packages/benchmarks/src/utils/judge.ts
@@ -1,23 +1,90 @@
+export type JudgeParseFailureCode =
+  | 'empty'
+  | 'non_json'
+  | 'invalid_json'
+  | 'missing_score'
+  | 'invalid_score';
+
+export type ParseJudgeJsonResult =
+  | { ok: true; score: number; reason?: string }
+  | { ok: false; code: JudgeParseFailureCode; preview?: string };
+
+function truncatePreview(text: string, max = 120): string {
+  const oneLine = text.replace(/\s+/g, ' ').trim();
+  if (oneLine.length <= max) return oneLine;
+  return `${oneLine.slice(0, max)}…`;
+}
+
 /**
- * 从 Judge 输出中提取 JSON 对象。
- * @param text Judge 模型原始文本
- * @returns 结构化对象；失败时返回 null
+ * 从 Judge 输出中提取 JSON 对象，失败时返回可区分的错误码。
  */
-export function parseJudgeJson(text: string): { score?: number; reason?: string } | null {
-  const blockMatch = text.match(/```json\s*([\s\S]*?)```/i);
-  const raw = (blockMatch?.[1] ?? text).trim();
+export function parseJudgeJson(text: string): ParseJudgeJsonResult {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return { ok: false, code: 'empty' };
+  }
+
+  const blockMatch = trimmed.match(/```json\s*([\s\S]*?)```/i);
+  const raw = (blockMatch?.[1] ?? trimmed).trim();
   const start = raw.indexOf('{');
   const end = raw.lastIndexOf('}');
   if (start < 0 || end <= start) {
-    return null;
+    return { ok: false, code: 'non_json', preview: truncatePreview(trimmed) };
   }
+
+  let parsed: { score?: unknown; reason?: unknown };
   try {
-    const parsed = JSON.parse(raw.slice(start, end + 1)) as { score?: unknown; reason?: unknown };
-    return {
-      score: typeof parsed.score === 'number' ? parsed.score : undefined,
-      reason: typeof parsed.reason === 'string' ? parsed.reason : undefined,
-    };
+    parsed = JSON.parse(raw.slice(start, end + 1)) as { score?: unknown; reason?: unknown };
   } catch {
-    return null;
+    return { ok: false, code: 'invalid_json', preview: truncatePreview(raw.slice(start, end + 1)) };
+  }
+
+  if (parsed.score === undefined || parsed.score === null) {
+    return { ok: false, code: 'missing_score', preview: truncatePreview(JSON.stringify(parsed)) };
+  }
+  if (typeof parsed.score !== 'number' || !Number.isFinite(parsed.score)) {
+    return {
+      ok: false,
+      code: 'invalid_score',
+      preview: truncatePreview(`score=${String(parsed.score)}`),
+    };
+  }
+
+  return {
+    ok: true,
+    score: parsed.score,
+    reason: typeof parsed.reason === 'string' ? parsed.reason : undefined,
+  };
+}
+
+export function isJudgeTimeoutError(error: unknown): boolean {
+  if (error == null) return false;
+  if (typeof error === 'object') {
+    const name = (error as { name?: string }).name;
+    if (name === 'TimeoutError' || name === 'AbortError') return true;
+  }
+  const message = error instanceof Error ? error.message : String(error);
+  const lower = message.toLowerCase();
+  return (
+    lower.includes('timeout') ||
+    lower.includes('timed out') ||
+    lower.includes('aborted') ||
+    lower.includes('abort') ||
+    lower.includes('deadline')
+  );
+}
+
+export function formatJudgeParseError(result: Extract<ParseJudgeJsonResult, { ok: false }>): string {
+  switch (result.code) {
+    case 'empty':
+      return 'judge_empty_output';
+    case 'non_json':
+      return result.preview ? `judge_non_json: ${result.preview}` : 'judge_non_json';
+    case 'invalid_json':
+      return result.preview ? `judge_invalid_json: ${result.preview}` : 'judge_invalid_json';
+    case 'missing_score':
+      return result.preview ? `judge_missing_score: ${result.preview}` : 'judge_missing_score';
+    case 'invalid_score':
+      return result.preview ? `judge_invalid_score: ${result.preview}` : 'judge_invalid_score';
   }
 }

--- a/packages/benchmarks/src/utils/maas-manifest-models.ts
+++ b/packages/benchmarks/src/utils/maas-manifest-models.ts
@@ -5,6 +5,9 @@ import { fileURLToPath } from 'node:url';
 /** 与 `main.ts`、`.env` 同级：packages/benchmarks */
 const benchmarksPackageDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
 
+/** 未配置环境变量时的默认清单（仓库内相对 benchmarks 包根） */
+const DEFAULT_MAAS_MODELS_RELATIVE = path.join('..', '..', 'sites', 'playground', 'server', 'maas-models.json');
+
 /**
  * 读取环境变量并 trim；`undefined`、空串、仅空白视为未设置。
  */
@@ -16,24 +19,25 @@ function envTrimmed(key: string): string | undefined {
 }
 
 /**
- * 解析 `BENCH_MAAS_MODELS_PATH` 指向的 `maas-models.json` 绝对路径（相对 benchmarks 包根或绝对路径）。
- * 与 {@link listMaasManifestModelNames}、`resolveAiSdkModelForBench` 使用同一清单文件。
+ * 解析 `maas-models.json` 绝对路径。
+ * 优先 `BENCH_MAAS_MODELS_PATH`；未设置时回退到仓库默认相对路径。
  */
 export function resolveMaasModelsJsonPath(): string {
-  const configured = envTrimmed('BENCH_MAAS_MODELS_PATH');
-  if (configured === undefined) {
-    throw new Error(
-      'BENCH_MAAS_MODELS_PATH is not set (or is blank). Set it in packages/benchmarks/.env to the maas-models.json path: absolute, or relative to the benchmarks package root (next to main.ts).',
-    );
-  }
+  const configured = envTrimmed('BENCH_MAAS_MODELS_PATH') ?? DEFAULT_MAAS_MODELS_RELATIVE;
   const absolute = path.isAbsolute(configured)
     ? configured
     : path.resolve(benchmarksPackageDir, configured);
-  return path.normalize(absolute);
+  const normalized = path.normalize(absolute);
+  if (!fs.existsSync(normalized)) {
+    throw new Error(
+      `maas-models.json not found at ${normalized}. Set BENCH_MAAS_MODELS_PATH in packages/benchmarks/.env (absolute, or relative to the benchmarks package root).`,
+    );
+  }
+  return normalized;
 }
 
 /**
- * 读取 `maas-models.json` 中全部模型的 `name`（与 playground / resolveAiSdkModelForBench 的展示名一致）。
+ * 读取 `maas-models.json` 中全部模型的 `name`（与 resolveAiSdkModelForBench 使用的展示名一致）。
  */
 export function listMaasManifestModelNames(): string[] {
   const filePath = resolveMaasModelsJsonPath();

--- a/packages/benchmarks/src/utils/resolve-ai-sdk-model.ts
+++ b/packages/benchmarks/src/utils/resolve-ai-sdk-model.ts
@@ -44,7 +44,7 @@ function resolveModelInfoById(providerModelsData: Record<string, any> | null, mo
 }
 
 /**
- * 与 playground chat-genui 对齐：通过 ProviderModelMapper 解析模型并生成 AI SDK 模型实例。
+ * 按模型清单解析 AI SDK 模型实例，供基准在线生成样本。
  * @param modelName 业务配置中的模型名称（例如 DeepSeek-V3.2）
  */
 export async function resolveAiSdkModelForBench(modelName: string) {

--- a/packages/benchmarks/src/utils/resolve-materials-meta.ts
+++ b/packages/benchmarks/src/utils/resolve-materials-meta.ts
@@ -1,0 +1,25 @@
+import { type IMaterialsMeta } from '@opentiny/genui-sdk-core';
+import { materialsMeta, miniMaterialsMeta } from '@opentiny/genui-sdk-materials-vue-opentiny-vue/meta';
+import { materialsMeta as ngMaterialsMeta } from '@opentiny/genui-sdk-materials-angular-opentiny-ng/meta';
+
+export type BenchFrameworkKey = 'Vue' | 'Angular';
+export type BenchMaterialsVariant = 'mini' | 'standard';
+
+const metaMap: Record<BenchFrameworkKey, IMaterialsMeta> = {
+  Vue: materialsMeta,
+  Angular: ngMaterialsMeta,
+};
+
+/**
+ * 选用 materials 包导出的 meta（与 core / chat-completions 用法一致）。
+ * Vue `mini` → `miniMaterialsMeta`；其余 → 对应框架的 `materialsMeta`。
+ */
+export function resolveMaterialsMeta(
+  framework: BenchFrameworkKey = 'Vue',
+  materialsVariant: BenchMaterialsVariant = 'standard',
+): IMaterialsMeta {
+  if (framework === 'Vue' && materialsVariant === 'mini') {
+    return miniMaterialsMeta;
+  }
+  return metaMap[framework] ?? materialsMeta;
+}

--- a/packages/core/src/stream-pattern-extractor/schema-json-pattern.ts
+++ b/packages/core/src/stream-pattern-extractor/schema-json-pattern.ts
@@ -5,8 +5,8 @@ export class SchemaJsonPattern {
   protected startRegex: RegExp = new RegExp(`${this.startFlag}`);
   protected partialStartRegex: RegExp = new RegExp(`${getPartialStartRegString(this.startFlag)}$`);
   protected endFlag: string = '```';
-  protected endRegex: RegExp = new RegExp(`\\n\\s*${this.endFlag}`);
-  protected partialEndRegex: RegExp = new RegExp(`\\n(\\s*${getPartialStartRegString(this.endFlag)})?$`);
+  protected endRegex: RegExp = new RegExp(`(?:\\n\\s*)?${this.endFlag}`);
+  protected partialEndRegex: RegExp = new RegExp(`(?:\\n\\s*)?(\\s*${getPartialStartRegString(this.endFlag)})?$`);
 
   get regExpMap() {
     return {


### PR DESCRIPTION
## 基准对齐 SDK 主路径，并细化 Judge 错误分类

### 背景动机
原先 benchmarks 更偏 playground 演练场用法（plain-only、手写 schema 正则、`JSON.parse`），与 `@opentiny/genui-sdk-core` + materials 包的真实调用链不一致，升级 SDK 后容易「基准绿、业务红」。

### 变更简述
- 生成阶段默认走 `genPrompt` + materials `materialsMeta` / Vue `miniMaterialsMeta`（`materialsVariant` / `BENCH_MATERIALS_VARIANT`），不再默认只跑空 system plain
- 报告校验对齐 core：`PatternExtractor` 提块 → `repairJson` → `genRootSchema(whiteList)`；首个可观测容器按 `wrapperComponent` 计时
- Judge 失败可区分：超时 / 空输出 / 非 JSON / 非法 JSON / 缺 score 等前缀错误；`BENCH_MAAS_MODELS_PATH` 未设时回退仓库默认清单

### 方案设计
- **物料选择**：`resolveMaterialsMeta(framework, materialsVariant)` 统一给生成与报告用，whiteList / wrapperComponent 同源
- **对照实验**：`BENCH_PLAIN_ONLY` / `BENCH_COMPARE_EMPTY_SYSTEM` 仍保留，但默认关闭
- **Provider**：`maas-models.json` 仅作发请求基建，不是能力验证对象


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added support for selecting standard or mini benchmark materials.
- Added framework-aware materials metadata for Vue and Angular benchmarks.
- Added automatic fallback to the default model manifest when no custom path is configured.
- Benchmark results now record the selected framework and materials variant.

## Bug Fixes
- Improved handling of malformed benchmark and judge responses with clearer error classification.
- Enhanced schema validation, JSON extraction, and component checks.

## Documentation
- Updated benchmark setup guidance, environment variables, supported materials, and default behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->