### PR TITLE
fix(genui-sdk-vue): increase maxLength for input fields to 20000

### DIFF
--- a/packages/frameworks/vue/src/chat/GenuiChat.vue
+++ b/packages/frameworks/vue/src/chat/GenuiChat.vue
@@ -519,7 +519,7 @@ defineExpose({
         v-model:template-data="templateData"
         @update:template-data="handleTemplateDataUpdate"
         :showWordLimit="true"
-        :maxLength="1000"
+        :maxLength="20000"
         @clear="clearInputMessage"
         @submit="handleSendMessage"
         @cancel="abortRequest"

--- a/sites/playground/web/src/components/genui-template/GenuiTemplateChat.vue
+++ b/sites/playground/web/src/components/genui-template/GenuiTemplateChat.vue
@@ -354,7 +354,7 @@ onUnmounted(() => {
         :clearable="true"
         :loading="generating"
         :showWordLimit="true"
-        :maxLength="5000"
+        :maxLength="20000"
         @clear="clearInputMessage"
         @submit="handleSendMessage"
         @cancel="() => messageManager?.abortRequest()"


### PR DESCRIPTION
将chat的文本输入限制提升至20K长度

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Increased the maximum chat message length to 20,000 characters, allowing users to send substantially longer prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->