### PR TITLE
fix(materials-vue-opentiny-vue): rename export names to include Tiny prefix for consistency

### DIFF
--- a/packages/materials/vue-opentiny-vue/src/meta/materials/bundle.json
+++ b/packages/materials/vue-opentiny-vue/src/meta/materials/bundle.json
@@ -18,7 +18,7 @@
           "devMode": "proCode",
           "npm": {
             "package": "@opentiny/vue",
-            "exportName": "CarouselItem",
+            "exportName": "TinyCarouselItem",
             "destructuring": true
           },
           "group": "component",
@@ -149,7 +149,7 @@
           "devMode": "proCode",
           "npm": {
             "package": "@opentiny/vue",
-            "exportName": "Carousel",
+            "exportName": "TinyCarousel",
             "destructuring": true
           },
           "group": "component",
@@ -1744,7 +1744,7 @@
           "devMode": "proCode",
           "npm": {
             "package": "@opentiny/vue",
-            "exportName": "ButtonGroup",
+            "exportName": "TinyButtonGroup",
             "destructuring": true
           },
           "group": "component",
@@ -1900,7 +1900,7 @@
           "devMode": "proCode",
           "npm": {
             "package": "@opentiny/vue",
-            "exportName": "Row",
+            "exportName": "TinyRow",
             "destructuring": true
           },
           "group": "component",
@@ -2048,7 +2048,7 @@
           "devMode": "proCode",
           "npm": {
             "package": "@opentiny/vue",
-            "exportName": "Layout",
+            "exportName": "TinyLayout",
             "version": "3.20.0",
             "destructuring": true
           },
@@ -2159,7 +2159,7 @@
           "devMode": "proCode",
           "npm": {
             "package": "@opentiny/vue",
-            "exportName": "Form",
+            "exportName": "TinyForm",
             "destructuring": true
           },
           "group": "component",
@@ -2502,7 +2502,7 @@
           "devMode": "proCode",
           "npm": {
             "package": "@opentiny/vue",
-            "exportName": "FormItem",
+            "exportName": "TinyFormItem",
             "destructuring": true
           },
           "group": "component",
@@ -2631,7 +2631,7 @@
           "devMode": "proCode",
           "npm": {
             "package": "@opentiny/vue",
-            "exportName": "Col",
+            "exportName": "TinyCol",
             "destructuring": true
           },
           "group": "component",
@@ -2907,7 +2907,7 @@
           "devMode": "proCode",
           "npm": {
             "package": "@opentiny/vue",
-            "exportName": "Button",
+            "exportName": "TinyButton",
             "destructuring": true
           },
           "group": "component",
@@ -3242,7 +3242,7 @@
           "devMode": "proCode",
           "npm": {
             "package": "@opentiny/vue",
-            "exportName": "Input",
+            "exportName": "TinyInput",
             "destructuring": true
           },
           "group": "component",
@@ -3643,7 +3643,7 @@
           "devMode": "proCode",
           "npm": {
             "package": "@opentiny/vue",
-            "exportName": "Radio",
+            "exportName": "TinyRadio",
             "destructuring": true
           },
           "group": "component",
@@ -3874,6 +3874,9 @@
           "keywords": "",
           "dev_mode": "proCode",
           "npm": {
+            "package": "@opentiny/vue",
+            "exportName": "TinyRadioGroup",
+            "destructuring": true
           },
           "group": "component",
           "configure": {
@@ -4076,7 +4079,7 @@
           "devMode": "proCode",
           "npm": {
             "package": "@opentiny/vue",
-            "exportName": "Select",
+            "exportName": "TinySelect",
             "destructuring": true
           },
           "group": "component",
@@ -4479,7 +4482,7 @@
           "devMode": "proCode",
           "npm": {
             "package": "@opentiny/vue",
-            "exportName": "Switch",
+            "exportName": "TinySwitch",
             "destructuring": true
           },
           "group": "component",
@@ -4673,7 +4676,7 @@
           "devMode": "proCode",
           "npm": {
             "package": "@opentiny/vue",
-            "exportName": "Search",
+            "exportName": "TinySearch",
             "destructuring": true
           },
           "group": "component",
@@ -4940,7 +4943,7 @@
           "devMode": "proCode",
           "npm": {
             "package": "@opentiny/vue",
-            "exportName": "Checkbox",
+            "exportName": "TinyCheckbox",
             "destructuring": true
           },
           "group": "component",
@@ -5193,7 +5196,7 @@
           "devMode": "proCode",
           "npm": {
             "package": "@opentiny/vue",
-            "exportName": "CheckboxButton",
+            "exportName": "TinyCheckboxButton",
             "destructuring": true
           },
           "group": "component",
@@ -5375,7 +5378,7 @@
           "devMode": "proCode",
           "npm": {
             "package": "@opentiny/vue",
-            "exportName": "CheckboxGroup",
+            "exportName": "TinyCheckboxGroup",
             "destructuring": true
           },
           "group": "component",
@@ -5572,7 +5575,7 @@
           "devMode": "proCode",
           "npm": {
             "package": "@opentiny/vue",
-            "exportName": "DialogBox",
+            "exportName": "TinyDialogBox",
             "destructuring": true
           },
           "group": "component",
@@ -5845,7 +5848,7 @@
           "devMode": "proCode",
           "npm": {
             "package": "@opentiny/vue",
-            "exportName": "Tabs",
+            "exportName": "TinyTabs",
             "destructuring": true
           },
           "group": "component",
@@ -6095,7 +6098,7 @@
           "devMode": "proCode",
           "npm": {
             "package": "@opentiny/vue",
-            "exportName": "TabItem",
+            "exportName": "TinyTabItem",
             "destructuring": true
           },
           "group": "component",
@@ -6202,7 +6205,7 @@
           "devMode": "proCode",
           "npm": {
             "package": "@opentiny/vue",
-            "exportName": "Breadcrumb",
+            "exportName": "TinyBreadcrumb",
             "destructuring": true
           },
           "group": "component",
@@ -6338,7 +6341,7 @@
           "devMode": "proCode",
           "npm": {
             "package": "@opentiny/vue",
-            "exportName": "BreadcrumbItem",
+            "exportName": "TinyBreadcrumbItem",
             "destructuring": true
           },
           "group": "component",
@@ -6425,7 +6428,7 @@
           "devMode": "proCode",
           "npm": {
             "package": "@opentiny/vue",
-            "exportName": "Collapse",
+            "exportName": "TinyCollapse",
             "destructuring": true
           },
           "group": "component",
@@ -6546,7 +6549,7 @@
           "devMode": "proCode",
           "npm": {
             "package": "@opentiny/vue",
-            "exportName": "CollapseItem",
+            "exportName": "TinyCollapseItem",
             "destructuring": true
           },
           "group": "component",
@@ -6655,7 +6658,7 @@
           "devMode": "proCode",
           "npm": {
             "package": "@opentiny/vue",
-            "exportName": "Grid",
+            "exportName": "TinyGrid",
             "destructuring": true
           },
           "group": "component",
@@ -7561,7 +7564,7 @@
           "devMode": "proCode",
           "npm": {
             "package": "@opentiny/vue",
-            "exportName": "Pager",
+            "exportName": "TinyPager",
             "destructuring": true
           },
           "group": "component",
@@ -7785,7 +7788,7 @@
           "devMode": "proCode",
           "npm": {
             "package": "@opentiny/vue",
-            "exportName": "Popeditor",
+            "exportName": "TinyPopeditor",
             "destructuring": true
           },
           "group": "component",
@@ -8158,7 +8161,7 @@
           "devMode": "proCode",
           "npm": {
             "package": "@opentiny/vue",
-            "exportName": "Tree",
+            "exportName": "TinyTree",
             "destructuring": true
           },
           "group": "component",
@@ -8474,7 +8477,7 @@
           "devMode": "proCode",
           "npm": {
             "package": "@opentiny/vue",
-            "exportName": "TimeLine",
+            "exportName": "TinyTimeLine",
             "destructuring": true
           },
           "group": "component",
@@ -8627,7 +8630,7 @@
           "devMode": "proCode",
           "npm": {
             "package": "@opentiny/vue",
-            "exportName": "Tooltip",
+            "exportName": "TinyTooltip",
             "destructuring": true
           },
           "group": "component",
@@ -8843,7 +8846,7 @@
           "devMode": "proCode",
           "npm": {
             "package": "@opentiny/vue",
-            "exportName": "Popover",
+            "exportName": "TinyPopover",
             "destructuring": true
           },
           "group": "component",
@@ -9332,6 +9335,9 @@
           "keywords": "",
           "dev_mode": "proCode",
           "npm": {
+            "package": "@opentiny/vue",
+            "exportName": "TinyCard",
+            "destructuring": true
           },
           "group": "component",
           "configure": {
@@ -9422,7 +9428,7 @@
           "devMode": "proCode",
           "npm": {
             "package": "@opentiny/vue",
-            "exportName": "DatePicker",
+            "exportName": "TinyDatePicker",
             "destructuring": true
           },
           "group": "component",
@@ -9824,7 +9830,7 @@
           "devMode": "proCode",
           "npm": {
             "package": "@opentiny/vue",
-            "exportName": "Numeric",
+            "exportName": "TinyNumeric",
             "destructuring": true
           },
           "group": "component",

--- a/packages/materials/vue-opentiny-vue/src/meta/materials/bundle.json
+++ b/packages/materials/vue-opentiny-vue/src/meta/materials/bundle.json
@@ -2049,7 +2049,6 @@
           "npm": {
             "package": "@opentiny/vue",
             "exportName": "TinyLayout",
-            "version": "3.20.0",
             "destructuring": true
           },
           "group": "component",

--- a/packages/materials/vue-opentiny-vue/src/meta/materials/chart.json
+++ b/packages/materials/vue-opentiny-vue/src/meta/materials/chart.json
@@ -16,6 +16,11 @@
           "tags": "",
           "keywords": "",
           "devMode": "proCode",
+          "npm": {
+            "package": "@opentiny/vue-huicharts",
+            "exportName": "TinyHuichartsLine",
+            "destructuring": true
+          },
           "group": "chart",
           "category": "图表组件",
           "priority": 2,
@@ -324,12 +329,9 @@
           "keywords": "",
           "devMode": "proCode",
           "npm": {
-            "destructuring": true,
-            "exportName": "TinyHuichartsHistogram",
-            "name": "TinyVueHuicharts组件库",
             "package": "@opentiny/vue-huicharts",
-            "version": "3.22.0",
-            "script": "https://registry.npmmirror.com/@opentiny/vue-runtime/3.22/files/dist3/tiny-vue-huicharts.mjs"
+            "exportName": "TinyHuichartsHistogram",
+            "destructuring": true
           },
           "group": "chart",
           "category": "图表组件",
@@ -832,12 +834,9 @@
           "keywords": "",
           "devMode": "proCode",
           "npm": {
-            "destructuring": true,
-            "exportName": "TinyHuichartsBar",
-            "name": "TinyVueHuicharts组件库",
             "package": "@opentiny/vue-huicharts",
-            "version": "3.22.0",
-            "script": "https://registry.npmmirror.com/@opentiny/vue-runtime/3.22/files/dist3/tiny-vue-huicharts.mjs"
+            "exportName": "TinyHuichartsBar",
+            "destructuring": true
           },
           "group": "chart",
           "category": "图表组件",
@@ -1174,12 +1173,9 @@
           "keywords": "",
           "devMode": "proCode",
           "npm": {
-            "destructuring": true,
-            "exportName": "TinyHuichartsPie",
-            "name": "TinyVueHuicharts组件库",
             "package": "@opentiny/vue-huicharts",
-            "version": "3.22.0",
-            "script": "https://registry.npmmirror.com/@opentiny/vue-runtime/3.22/files/dist3/tiny-vue-huicharts.mjs"
+            "exportName": "TinyHuichartsPie",
+            "destructuring": true
           },
           "group": "chart",
           "category": "图表组件",
@@ -1446,12 +1442,9 @@
           "keywords": "",
           "devMode": "proCode",
           "npm": {
-            "destructuring": true,
-            "exportName": "TinyHuichartsRing",
-            "name": "TinyVueHuicharts组件库",
             "package": "@opentiny/vue-huicharts",
-            "version": "3.22.0",
-            "script": "https://registry.npmmirror.com/@opentiny/vue-runtime/3.22/files/dist3/tiny-vue-huicharts.mjs"
+            "exportName": "TinyHuichartsRing",
+            "destructuring": true
           },
           "group": "chart",
           "category": "图表组件",
@@ -1755,12 +1748,9 @@
           "keywords": "",
           "devMode": "proCode",
           "npm": {
-            "destructuring": true,
-            "exportName": "TinyHuichartsRadar",
-            "name": "TinyVueHuicharts组件库",
             "package": "@opentiny/vue-huicharts",
-            "version": "3.22.0",
-            "script": "https://registry.npmmirror.com/@opentiny/vue-runtime/3.22/files/dist3/tiny-vue-huicharts.mjs"
+            "exportName": "TinyHuichartsRadar",
+            "destructuring": true
           },
           "group": "chart",
           "category": "图表组件",
@@ -2067,12 +2057,9 @@
           "keywords": "",
           "devMode": "proCode",
           "npm": {
-            "destructuring": true,
-            "exportName": "TinyHuichartsFunnel",
-            "name": "TinyVueHuicharts组件库",
             "package": "@opentiny/vue-huicharts",
-            "version": "3.22.0",
-            "script": "https://registry.npmmirror.com/@opentiny/vue-runtime/3.22/files/dist3/tiny-vue-huicharts.mjs"
+            "exportName": "TinyHuichartsFunnel",
+            "destructuring": true
           },
           "group": "chart",
           "category": "图表组件",
@@ -2320,12 +2307,9 @@
           "keywords": "",
           "devMode": "proCode",
           "npm": {
-            "destructuring": true,
-            "exportName": "TinyHuichartsScatter",
-            "name": "TinyVueHuicharts组件库",
             "package": "@opentiny/vue-huicharts",
-            "version": "3.22.0",
-            "script": "https://registry.npmmirror.com/@opentiny/vue-runtime/3.22/files/dist3/tiny-vue-huicharts.mjs"
+            "exportName": "TinyHuichartsScatter",
+            "destructuring": true
           },
           "group": "chart",
           "category": "图表组件",
@@ -2634,12 +2618,9 @@
           "keywords": "",
           "devMode": "proCode",
           "npm": {
-            "destructuring": true,
-            "exportName": "TinyHuichartsWaterfall",
-            "name": "TinyVueHuicharts组件库",
             "package": "@opentiny/vue-huicharts",
-            "version": "3.22.0",
-            "script": "https://registry.npmmirror.com/@opentiny/vue-runtime/3.22/files/dist3/tiny-vue-huicharts.mjs"
+            "exportName": "TinyHuichartsWaterfall",
+            "destructuring": true
           },
           "group": "chart",
           "category": "图表组件",
@@ -2949,12 +2930,9 @@
           "keywords": "",
           "devMode": "proCode",
           "npm": {
-            "destructuring": true,
-            "exportName": "TinyHuichartsGauge",
-            "name": "TinyVueHuicharts组件库",
             "package": "@opentiny/vue-huicharts",
-            "version": "3.22.0",
-            "script": "https://registry.npmmirror.com/@opentiny/vue-runtime/3.22/files/dist3/tiny-vue-huicharts.mjs"
+            "exportName": "TinyHuichartsGauge",
+            "destructuring": true
           },
           "group": "chart",
           "category": "图表组件",
@@ -3292,12 +3270,9 @@
           "keywords": "",
           "devMode": "proCode",
           "npm": {
-            "destructuring": true,
-            "exportName": "TinyHuichartsGraph",
-            "name": "TinyVueHuicharts组件库",
             "package": "@opentiny/vue-huicharts",
-            "version": "3.22.0",
-            "script": "https://registry.npmmirror.com/@opentiny/vue-runtime/3.22/files/dist3/tiny-vue-huicharts.mjs"
+            "exportName": "TinyHuichartsGraph",
+            "destructuring": true
           },
           "group": "chart",
           "category": "图表组件",
@@ -3498,12 +3473,9 @@
           "keywords": "",
           "devMode": "proCode",
           "npm": {
-            "destructuring": true,
-            "exportName": "TinyHuichartsProcess",
-            "name": "TinyVueHuicharts组件库",
             "package": "@opentiny/vue-huicharts",
-            "version": "3.22.0",
-            "script": "https://registry.npmmirror.com/@opentiny/vue-runtime/3.22/files/dist3/tiny-vue-huicharts.mjs"
+            "exportName": "TinyHuichartsProcess",
+            "destructuring": true
           },
           "group": "chart",
           "category": "图表组件",


### PR DESCRIPTION
1、TinyCard和TinyCheckboxGroup增加npm字段信息
2、统一修改组件导出名，新增Tiny前缀

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added package metadata for the `TinyRadioGroup` and `TinyCard` components.
  * Added standardized package metadata for 12 chart components.
* **Improvements**
  * Standardized exported component names across the TinyVue component library using the `Tiny*` naming convention.
  * Improved component discoverability and compatibility when importing UI and chart components from their packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->