### PR TITLE
docs: vue demos use local source code at dev mode

### DIFF
--- a/docs/.vitepress/config/shared.ts
+++ b/docs/.vitepress/config/shared.ts
@@ -56,8 +56,7 @@ export const sharedConfig: UserConfig = {
       serveOnly(nodePolyfills()),
     ],
     server: {
-      host: '0.0.0.0',
-      port: 8100,
+      host: '127.0.0.1',
       open: true,
     },
   },

--- a/docs/.vitepress/config/shared.ts
+++ b/docs/.vitepress/config/shared.ts
@@ -1,12 +1,19 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import type { Plugin } from 'vite';
 import type { UserConfig } from 'vitepress';
+import tsconfigPaths from 'vite-jsconfig-paths';
+import { nodePolyfills } from 'vite-plugin-node-polyfills';
 import { vitepressDemoPlugin } from 'vitepress-demo-plugin';
 import { tabsMarkdownPlugin } from 'vitepress-plugin-tabs';
 
 const docsRoot = path.dirname(fileURLToPath(import.meta.url));
 const srcDir = path.resolve(docsRoot, '../../src');
+
+function serveOnly(plugin: Plugin): Plugin {
+  return { ...plugin, apply: 'serve' };
+}
 
 export const sharedConfig: UserConfig = {
   base: '/genui-sdk-docs/',
@@ -40,8 +47,17 @@ export const sharedConfig: UserConfig = {
     },
   },
   vite: {
+    plugins: [
+      serveOnly(
+        tsconfigPaths({
+          projects: [path.resolve(docsRoot, '../../tsconfig.dev.json')],
+        }),
+      ),
+      serveOnly(nodePolyfills()),
+    ],
     server: {
       host: '0.0.0.0',
+      port: 8100,
       open: true,
     },
   },

--- a/docs/package.json
+++ b/docs/package.json
@@ -19,6 +19,8 @@
     "@opentiny/genui-sdk-materials-vue-opentiny-vue": "workspace:*"
   },
   "devDependencies": {
+    "vite-jsconfig-paths": "^2.0.1",
+    "vite-plugin-node-polyfills": "^0.24.0",
     "vitepress": "^1.6.3",
     "vitepress-demo-plugin": "^1.4.1",
     "vitepress-plugin-tabs": "^0.7.3"

--- a/docs/tsconfig.dev.json
+++ b/docs/tsconfig.dev.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./",
+    "paths": {
+      "@opentiny/genui-sdk-vue": ["../packages/frameworks/vue/src/index.ts"],
+      "@opentiny/genui-sdk-core": ["../packages/core/src/index.ts"],
+      "@opentiny/tiny-schema-renderer": ["../projects/tiny-schema-renderer/index.js"],
+      "@opentiny/genui-sdk-materials-vue-opentiny-vue/materials": [
+        "../packages/materials/vue-opentiny-vue/src/materials/index.ts"
+      ]
+    }
+  },
+  "include": [".vitepress/**/*", "demos/**/*", "src/**/*", "../packages/**/*", "../projects/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,12 @@ importers:
         specifier: workspace:*
         version: link:../packages/frameworks/vue
     devDependencies:
+      vite-jsconfig-paths:
+        specifier: ^2.0.1
+        version: 2.0.1(vite@5.4.21(@types/node@25.5.0)(less@4.5.1)(sass@1.97.1)(terser@5.44.1))
+      vite-plugin-node-polyfills:
+        specifier: ^0.24.0
+        version: 0.24.0(rollup@4.54.0)(vite@5.4.21(@types/node@25.5.0)(less@4.5.1)(sass@1.97.1)(terser@5.44.1))
       vitepress:
         specifier: ^1.6.3
         version: 1.6.4(@algolia/client-search@5.35.0)(@types/node@25.5.0)(async-validator@4.2.5)(less@4.5.1)(postcss@8.5.6)(qrcode@1.5.1)(sass@1.97.1)(search-insights@2.17.3)(terser@5.44.1)(typescript@5.9.3)
@@ -20558,6 +20564,16 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite-jsconfig-paths@2.0.1(vite@5.4.21(@types/node@25.5.0)(less@4.5.1)(sass@1.97.1)(terser@5.44.1)):
+    dependencies:
+      debug: 4.4.3
+      globrex: 0.1.2
+      recrawl-sync: 2.2.3
+      tsconfig-paths: 3.15.0
+      vite: 5.4.21(@types/node@25.5.0)(less@4.5.1)(sass@1.97.1)(terser@5.44.1)
+    transitivePeerDependencies:
+      - supports-color
+
   vite-jsconfig-paths@2.0.1(vite@6.4.1(@types/node@25.5.0)(less@4.5.1)(sass@1.90.0)(terser@5.44.1)(tsx@4.21.0)):
     dependencies:
       debug: 4.4.3
@@ -20747,6 +20763,14 @@ snapshots:
       vite: 7.3.0(@types/node@17.0.45)(less@4.5.1)(sass@1.97.1)(terser@5.44.1)(tsx@4.21.0)
     transitivePeerDependencies:
       - supports-color
+
+  vite-plugin-node-polyfills@0.24.0(rollup@4.54.0)(vite@5.4.21(@types/node@25.5.0)(less@4.5.1)(sass@1.97.1)(terser@5.44.1)):
+    dependencies:
+      '@rollup/plugin-inject': 5.0.5(rollup@4.54.0)
+      node-stdlib-browser: 1.3.1
+      vite: 5.4.21(@types/node@25.5.0)(less@4.5.1)(sass@1.97.1)(terser@5.44.1)
+    transitivePeerDependencies:
+      - rollup
 
   vite-plugin-node-polyfills@0.24.0(rollup@4.54.0)(vite@7.3.0(@types/node@25.5.0)(less@4.5.1)(sass@1.97.1)(terser@5.44.1)(tsx@4.21.0)):
     dependencies:


### PR DESCRIPTION
dev开发模式，demo无法显示，控制台会有报错。
<img width="2214" height="769" alt="PixPin_2026-08-11_11-24-58" src="https://github.com/user-attachments/assets/188a3b37-4fad-4d80-a248-6ea6608994c0" />

tiny-schema-renderer 构建时
lib mode 下某些 Node / 非浏览器依赖被 Vite 处理成了 `projects/tiny-schema-renderer/dist/___vite-browser-external_commonjs-proxy.js`
里面混了 @vue/shared 片段、类 picocolors 的空实现，以及真正的 empty external stub。

genui-sdk-vue 再打包时
@opentiny/tiny-schema-renderer 只在 devDependencies，不在 dependencies，所以 vite.config.ts 的 external 没把它外置，整包打进 vue 的 dist，于是又出现：
`packages/frameworks/vue/dist/___vite-browser-external_commonjs-proxy-4gYZYw55.js`

docs 加载 dist 时
Vite 看到文件名里的 commonjs-proxy + 文件内残留的 exports 形态，会把：
```
import { d as qr, ... } from "./___vite-browser-external_commonjs-proxy-...."
```
改写成类似：
```
import __vite__cjsImport0 from "./___vite-browser-external_commonjs-proxy-...."
const qr = __vite__cjsImport0["d"]
```
但该 chunk 实际是 ESM named exports，没有 default，于是就报错了

**解决方案：**
将dev模式改为源码引用
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved the local documentation development environment with TypeScript path alias and Node-compatible module support.
  * Configured the documentation server to run on port 8100 and be accessible only from the local machine.

* **Documentation**
  * Added development configuration to streamline work across SDK, schema renderer, and materials packages.
  * Improved compatibility and setup for local documentation development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->