### PR TITLE
feat(genui-sdk-server): support custom materialsMeta at startup

### DIFF
--- a/docs/src/components/server/api.md
+++ b/docs/src/components/server/api.md
@@ -20,23 +20,33 @@ interface IStartServerOptions {
   port?: number;
   /** 端口被占用时的最大尝试次数，默认 10 */
   maxAttempts?: number;
+  /**
+   * 启动时固定的物料元数据；传入后用于生成 system prompt。
+   * 不传则按请求 tinygenui.framework 选择内置物料：
+   * - Vue → `@opentiny/genui-sdk-materials-vue-opentiny-vue`
+   * - Angular → `@opentiny/genui-sdk-materials-angular-opentiny-ng`
+   * - 其他 / 未传 framework → 默认 Vue 物料
+   */
+  materialsMeta?: IMaterialsMeta;
 }
 ```
 
 - **详细信息**
 
-创建一个 Express 应用并启用 CORS，自动注册对话路由（`/chat/completions`）。如果指定端口被占用，会自动尝试下一个端口（最多尝试 `maxAttempts` 次）。启动成功后会在控制台输出服务器地址。
+创建一个 Express 应用并启用 CORS，自动注册对话路由（`/chat/completions`）。如果指定端口被占用，会自动尝试下一个端口（最多尝试 `maxAttempts` 次）。启动成功后会在控制台输出服务器地址。物料在启动时通过 `materialsMeta` 固定，请求侧无法切换；未配置时按请求 `framework` 映射内置物料（Vue → OpenTiny Vue，Angular → OpenTiny Angular）。
 
 - **示例**
 
 ```typescript
 import { startServer } from '@opentiny/genui-sdk-server';
+import { materialsMeta } from '@opentiny/genui-sdk-materials-vue-element-plus/meta';
 
 startServer({
   port: 3100,
   baseURL: 'https://api.openai.com/v1',
   apiKey: '',
   maxAttempts: 10,
+  materialsMeta,
 });
 ```
 
@@ -59,18 +69,27 @@ interface IEquipChatCompletionsOptions {
   apiKey: string;
   /** API 基础 URL */
   baseURL: string;
+  /**
+   * 启动时固定的物料元数据；传入后用于生成 system prompt。
+   * 不传则按请求 tinygenui.framework 选择内置物料：
+   * - Vue → `@opentiny/genui-sdk-materials-vue-opentiny-vue`
+   * - Angular → `@opentiny/genui-sdk-materials-angular-opentiny-ng`
+   * - 其他 / 未传 framework → 默认 Vue 物料
+   */
+  materialsMeta?: IMaterialsMeta;
 }
 ```
 
 - **详细信息**
 
-创建一个对话请求的实例，创建请求处理器，并将处理器注册到指定的路由路径（POST 方法）。
+创建一个对话请求的实例，创建请求处理器，并将处理器注册到指定的路由路径（POST 方法）。物料在装备路由时通过 `materialsMeta` 固定；未配置时按请求 `framework` 映射内置物料（Vue → OpenTiny Vue，Angular → OpenTiny Angular）。
 
 - **示例**
 
 ```typescript
 import express from 'express';
 import { equipChatCompletions } from '@opentiny/genui-sdk-server';
+import { materialsMeta } from '@opentiny/genui-sdk-materials-vue-element-plus/meta';
 
 const app = express();
 
@@ -78,6 +97,7 @@ equipChatCompletions(app, {
   route: '/chat/completions',
   apiKey: '',
   baseURL: 'https://api.openai.com/v1',
+  materialsMeta,
 });
 
 app.listen(3000);

--- a/docs/src/en/components/server/api.md
+++ b/docs/src/en/components/server/api.md
@@ -20,23 +20,33 @@ interface IStartServerOptions {
   port?: number;
   /** Max attempts when port is in use, default 10 */
   maxAttempts?: number;
+  /**
+   * Materials metadata fixed at startup for system prompt generation.
+   * If omitted, built-in materials are selected by request tinygenui.framework:
+   * - Vue → `@opentiny/genui-sdk-materials-vue-opentiny-vue`
+   * - Angular → `@opentiny/genui-sdk-materials-angular-opentiny-ng`
+   * - Other / missing framework → Vue materials by default
+   */
+  materialsMeta?: IMaterialsMeta;
 }
 ```
 
 - **Details**
 
-Creates an Express app with CORS enabled and registers the chat route (`/chat/completions`). If the specified port is in use, it automatically tries the next port (up to `maxAttempts` times). On success, the server address is printed to the console.
+Creates an Express app with CORS enabled and registers the chat route (`/chat/completions`). If the specified port is in use, it automatically tries the next port (up to `maxAttempts` times). On success, the server address is printed to the console. Materials are fixed at startup via `materialsMeta` and cannot be switched per request. When omitted, they follow the request `framework` mapping (Vue → OpenTiny Vue, Angular → OpenTiny Angular).
 
 - **Example**
 
 ```typescript
 import { startServer } from '@opentiny/genui-sdk-server';
+import { materialsMeta } from '@opentiny/genui-sdk-materials-vue-element-plus/meta';
 
 startServer({
   port: 3100,
   baseURL: 'https://api.openai.com/v1',
   apiKey: '',
   maxAttempts: 10,
+  materialsMeta,
 });
 ```
 
@@ -59,18 +69,27 @@ interface IEquipChatCompletionsOptions {
   apiKey: string;
   /** API base URL */
   baseURL: string;
+  /**
+   * Materials metadata fixed when equipping the route for system prompt generation.
+   * If omitted, built-in materials are selected by request tinygenui.framework:
+   * - Vue → `@opentiny/genui-sdk-materials-vue-opentiny-vue`
+   * - Angular → `@opentiny/genui-sdk-materials-angular-opentiny-ng`
+   * - Other / missing framework → Vue materials by default
+   */
+  materialsMeta?: IMaterialsMeta;
 }
 ```
 
 - **Details**
 
-Creates a chat completion request instance, builds a request handler, and registers it on the specified route (POST).
+Creates a chat completion request instance, builds a request handler, and registers it on the specified route (POST). Materials are fixed via `materialsMeta` when equipping the route. When omitted, they follow the request `framework` mapping (Vue → OpenTiny Vue, Angular → OpenTiny Angular).
 
 - **Example**
 
 ```typescript
 import express from 'express';
 import { equipChatCompletions } from '@opentiny/genui-sdk-server';
+import { materialsMeta } from '@opentiny/genui-sdk-materials-vue-element-plus/meta';
 
 const app = express();
 
@@ -78,6 +97,7 @@ equipChatCompletions(app, {
   route: '/chat/completions',
   apiKey: '',
   baseURL: 'https://api.openai.com/v1',
+  materialsMeta,
 });
 
 app.listen(3000);

--- a/docs/src/en/guide/server-usage.md
+++ b/docs/src/en/guide/server-usage.md
@@ -72,12 +72,14 @@ export API_KEY= BASE_URL=https://your-llm-server.com/api && npx genui-sdk-server
 
 ```typescript
 import { startServer } from '@opentiny/genui-sdk-server';
+import { materialsMeta } from '@opentiny/genui-sdk-materials-vue-element-plus/meta';
 
 startServer({
   port: 3100,
   baseURL: 'https://api.openai.com/v1',
   apiKey: '',
   maxAttempts: 10, // Max retries when port is in use
+  materialsMeta,
 });
 ```
 
@@ -86,6 +88,7 @@ startServer({
 ```typescript
 import express from 'express';
 import { equipChatCompletions } from '@opentiny/genui-sdk-server';
+import { materialsMeta } from '@opentiny/genui-sdk-materials-vue-element-plus/meta';
 import cors from 'cors';
 
 const app = express();
@@ -95,6 +98,7 @@ equipChatCompletions(app, {
   route: '/chat/completions',
   apiKey: '',
   baseURL: 'https://api.openai.com/v1',
+  materialsMeta, // If omitted, default materials are selected by request framework (Vue → OpenTiny Vue, Angular → OpenTiny Angular)
 });
 
 app.listen(3000);

--- a/docs/src/guide/server-usage.md
+++ b/docs/src/guide/server-usage.md
@@ -72,12 +72,14 @@ export API_KEY= BASE_URL=https://your-llm-server.com/api && npx genui-sdk-server
 
 ```typescript
 import { startServer } from '@opentiny/genui-sdk-server';
+import { materialsMeta } from '@opentiny/genui-sdk-materials-vue-element-plus/meta';
 
 startServer({
   port: 3100,
   baseURL: 'https://api.openai.com/v1',
   apiKey: '',
   maxAttempts: 10, // 端口冲突时最大尝试次数
+  materialsMeta,
 });
 ```
 
@@ -86,6 +88,7 @@ startServer({
 ```typescript
 import express from 'express';
 import { equipChatCompletions } from '@opentiny/genui-sdk-server';
+import { materialsMeta } from '@opentiny/genui-sdk-materials-vue-element-plus/meta';
 import cors from 'cors';
 
 const app = express();
@@ -95,6 +98,7 @@ equipChatCompletions(app, {
   route: '/chat/completions',
   apiKey: '',
   baseURL: 'https://api.openai.com/v1',
+  materialsMeta, // 不传则根据请求的 framework 取默认物料（Vue → OpenTiny Vue，Angular → OpenTiny Angular）
 });
 
 app.listen(3000);

--- a/packages/chat-completions/src/ai-sdk-chat/ai-sdk-chat-completion.ts
+++ b/packages/chat-completions/src/ai-sdk-chat/ai-sdk-chat-completion.ts
@@ -3,7 +3,7 @@ import { createOpenAI, type OpenAIProvider } from '@ai-sdk/openai';
 import { createAnthropic, type AnthropicProvider } from '@ai-sdk/anthropic';
 import { createDeepSeek, type DeepSeekProvider } from '@ai-sdk/deepseek';
 import type { ChatCompletionCreateParamsBase } from 'openai/resources/chat/completions';
-import type { AsyncIterableStream, ChatCompletionChunk, IRequestOptions } from '../types';
+import type { AsyncIterableStream, ChatCompletionChunk, IChatCompletionsConfig, IRequestOptions } from '../types';
 import { openaiCompatibleTransformChunk } from './openai-compatible-transform';
 import { ChatCompletions } from '../chat-completions';
 import { createAsyncIterableStream } from './async-iterable-stream';
@@ -34,8 +34,8 @@ export class AiSdkChatCompletions extends ChatCompletions<AsyncIterableStream<Te
   protected readonly providerInstance: ProviderInstance;
   protected modelInstance: LanguageModel;
 
-  constructor({ apiKey, baseURL, provider }: { apiKey: string; baseURL: string; provider: ProviderType }) {
-    super();
+  constructor({ apiKey, baseURL, provider, materialsMeta }: IDefaultModelProviderConfig & { baseURL: string } & IChatCompletionsConfig) {
+    super({ materialsMeta });
     const providerCreator = providerMap[provider];
     this.providerInstance = providerCreator({
       apiKey,

--- a/packages/chat-completions/src/chat-completions.ts
+++ b/packages/chat-completions/src/chat-completions.ts
@@ -2,13 +2,20 @@ import type {
   ChatCompletionResponse,
   ChatCompletionCreateParamsBase,
   IChatCompletionCreateParams,
+  IChatCompletionsConfig,
   IRequestOptions,
 } from "./types";
 import { requestTransform } from "./request-transform";
 
 export abstract class ChatCompletions<T = ChatCompletionResponse, R = ChatCompletionResponse> {
+  protected readonly materialsMeta?: IChatCompletionsConfig['materialsMeta'];
+
+  constructor(config?: IChatCompletionsConfig) {
+    this.materialsMeta = config?.materialsMeta;
+  }
+
   protected async preTransform(params: IChatCompletionCreateParams): Promise<ChatCompletionCreateParamsBase> {
-    return requestTransform(params);
+    return requestTransform(params, { materialsMeta: this.materialsMeta });
   }
   protected async postTransform(response: T): Promise<R> {
     return response as unknown as R;
@@ -33,4 +40,3 @@ export abstract class ChatCompletions<T = ChatCompletionResponse, R = ChatComple
     options?: IRequestOptions
   ): Promise<T>;
 }
-

--- a/packages/chat-completions/src/fetch-chat-completions.ts
+++ b/packages/chat-completions/src/fetch-chat-completions.ts
@@ -1,6 +1,7 @@
 import { ChatCompletions } from "./chat-completions";
 import type {
   ChatCompletionCreateParamsBase,
+  IChatCompletionsConfig,
   IRequestOptions,
   ChatCompletionResponse
 } from "./types";
@@ -9,8 +10,8 @@ export class FetchChatCompletions extends ChatCompletions<Response, ChatCompleti
   protected readonly apiKey: string;
   protected readonly baseURL: string;
 
-  constructor(config: { apiKey: string; baseURL: string }) {
-    super();
+  constructor(config: { apiKey: string; baseURL: string } & IChatCompletionsConfig) {
+    super(config);
     this.apiKey = config.apiKey;
     this.baseURL = config.baseURL.replace(/\/$/, '');
   }

--- a/packages/chat-completions/src/request-transform.ts
+++ b/packages/chat-completions/src/request-transform.ts
@@ -1,7 +1,12 @@
 import { genPrompt, type IMaterialsMeta } from '@opentiny/genui-sdk-core';
 import { materialsMeta } from '@opentiny/genui-sdk-materials-vue-opentiny-vue/meta';
 import { materialsMeta as ngMaterialsMeta } from '@opentiny/genui-sdk-materials-angular-opentiny-ng/meta';
-import { IChatCompletionCreateParams, ChatCompletionCreateParamsBase, type IGenPromptConfig } from './types';
+import {
+  IChatCompletionCreateParams,
+  ChatCompletionCreateParamsBase,
+  type IChatCompletionsConfig,
+  type IGenPromptConfig,
+} from './types';
 
 
 type IFrameworkKey = 'Vue' | 'Angular';
@@ -27,7 +32,8 @@ function mergePrompt(
 }
 
 export function requestTransform(
-  params: IChatCompletionCreateParams
+  params: IChatCompletionCreateParams,
+  config?: IChatCompletionsConfig,
 ): ChatCompletionCreateParamsBase {
   const newParams = structuredClone(params);
 
@@ -43,10 +49,10 @@ export function requestTransform(
 
   const { framework = 'Vue', strategy = 'append', ...promptConfig } = tgCustomConfig;
 
-  const materialsMetaForFramework =
-    metaMap[framework] ?? materialsMeta;
+  const resolvedMaterialsMeta =
+    config?.materialsMeta ?? metaMap[framework as IFrameworkKey] ?? materialsMeta;
   const systemMessages = newParams.messages?.find((message) => message.role === 'system');
-  const prompt = genPrompt(framework, materialsMetaForFramework, promptConfig);
+  const prompt = genPrompt(framework, resolvedMaterialsMeta, promptConfig);
   if (systemMessages) {
     systemMessages.content = mergePrompt(systemMessages.content as string, prompt, strategy);
   } else {

--- a/packages/chat-completions/src/types.ts
+++ b/packages/chat-completions/src/types.ts
@@ -1,10 +1,14 @@
 import type { ChatCompletionChunk } from "openai/resources/chat/completions";
 import type { ChatCompletionCreateParamsBase } from "openai/resources/chat/completions";
-import type { IGenPromptCustomConfig } from "@opentiny/genui-sdk-core";
+import type { IGenPromptCustomConfig, IMaterialsMeta } from "@opentiny/genui-sdk-core";
 
 export interface IGenPromptConfig extends IGenPromptCustomConfig {
   framework?: 'Vue' | 'Angular' | string;
   strategy?: 'append' | 'override' | 'prepend';
+}
+
+export interface IChatCompletionsConfig {
+  materialsMeta?: IMaterialsMeta;
 }
 
 declare global {

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -30,6 +30,7 @@ npx genui-sdk-server -e .env.production
 
 ```typescript
 import { startServer, equipChatCompletions } from '@opentiny/genui-sdk-server';
+import { materialsMeta } from '@opentiny/genui-sdk-materials-vue-element-plus/meta';
 import express from 'express';
 
 // Option 1: Use startServer (includes default route /chat/completions)
@@ -37,6 +38,7 @@ startServer({
   port: 3100,
   baseURL: 'https://api.openai.com/v1',
   apiKey: 'your-api-key',
+  materialsMeta, // optional: fix materials at startup
 });
 
 // Option 2: Custom Express app
@@ -45,6 +47,7 @@ equipChatCompletions(app, {
   route: '/api/chat',
   baseURL: 'https://api.openai.com/v1',
   apiKey: 'your-api-key',
+  materialsMeta,
 });
 app.listen(3100);
 ```

--- a/packages/server/src/equip-chat-completions.ts
+++ b/packages/server/src/equip-chat-completions.ts
@@ -1,4 +1,5 @@
 import type { Express } from 'express';
+import type { IMaterialsMeta } from '@opentiny/genui-sdk-core';
 import { FetchChatCompletions } from '@opentiny/genui-sdk-chat-completions';
 import { createChatCompletionHandler } from './handler/create-chat-completion';
 
@@ -6,14 +7,16 @@ export interface IEquipChatCompletionsOptions {
   route: string;
   apiKey: string;
   baseURL: string;
+  materialsMeta?: IMaterialsMeta;
 }
 
 export function equipChatCompletions(app: Express, options: IEquipChatCompletionsOptions) {
-  const { route, apiKey, baseURL } = options;
+  const { route, apiKey, baseURL, materialsMeta } = options;
 
   const chatCompletion = new FetchChatCompletions({
     apiKey,
     baseURL,
+    materialsMeta,
   });
 
   const { handler: chatCompletionHandler } = createChatCompletionHandler({

--- a/packages/server/src/start-server.ts
+++ b/packages/server/src/start-server.ts
@@ -14,7 +14,7 @@ export interface IStartServerOptions extends Omit<IEquipChatCompletionsOptions, 
  * @param maxAttempts 最大尝试次数，默认10次
  */
 export function startServer(options: IStartServerOptions): void {
-  const { baseURL, apiKey, maxAttempts = 10, port = 3100 } = options;
+  const { baseURL, apiKey, materialsMeta, maxAttempts = 10, port = 3100 } = options;
 
   const app = express();
   app.use(cors());
@@ -23,6 +23,7 @@ export function startServer(options: IStartServerOptions): void {
     route: '/chat/completions',
     apiKey,
     baseURL,
+    materialsMeta,
   });
 
   let currentPort = port ?? 3100;


### PR DESCRIPTION
## Summary
**server支持自定义传入物料**
- `startServer` / `equipChatCompletions` 支持启动时传入 `materialsMeta`，用于固定生成 system prompt 的物料包
- `@opentiny/genui-sdk-chat-completions` 在构造时注入物料，未传时仍按请求 `tinygenui.framework` 回退内置物料（Vue → OpenTiny Vue，Angular → OpenTiny Angular）
- 同步更新中英文 Server 使用文档与 API 文档

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional material metadata configuration for server startup and chat completion integrations.
  - Material selection can be fixed explicitly or chosen automatically based on the requested framework, with Vue used as the fallback.
  - Chat completion requests now apply the configured material metadata consistently.

- **Documentation**
  - Updated API references, usage guides, and examples in English and Chinese to demonstrate the new configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->