### PR TITLE
feat(materials): add TiIcon material for angular-opentiny-ng

### DIFF
--- a/packages/materials/angular-opentiny-ng/src/materials/components/ng-components.ts
+++ b/packages/materials/angular-opentiny-ng/src/materials/components/ng-components.ts
@@ -2,6 +2,8 @@ import { Type } from '@angular/core';
 import {
   TiButtonComponent,
   TiButtonModule,
+  TiIconComponent,
+  TiIconModule,
   TiSelectComponent,
   TiSelectModule,
   TiTextComponent,
@@ -50,6 +52,7 @@ import {
 
 export const components: Record<string, Type<any>> = {
   TiButton: TiButtonComponent,
+  TiIcon: TiIconComponent,
   TiSelect: TiSelectComponent,
   TiText: TiTextComponent,
   TiTable: TiTableComponent,
@@ -76,6 +79,7 @@ export const components: Record<string, Type<any>> = {
 
 export const modules: Record<string, Type<any>> = {
   TiButton: TiButtonModule,
+  TiIcon: TiIconModule,
   TiSelect: TiSelectModule,
   TiText: TiTextModule,
   TiTable: TiTableModule,

--- a/packages/materials/angular-opentiny-ng/src/meta/materials/bundle.json
+++ b/packages/materials/angular-opentiny-ng/src/meta/materials/bundle.json
@@ -11,7 +11,7 @@
           },
           "component": "TiButton",
           "icon": "button",
-          "description": "按钮组件，支持多种样式和尺寸",
+          "description": "按钮组件，支持多种样式和尺寸。带图标时把 TiIcon 放在 children；icon 与 onlyIcon 二选一：文字+图标用 icon=true（例：{\"componentName\":\"TiButton\",\"props\":{\"icon\":true,\"color\":\"default\"},\"children\":[{\"componentName\":\"span\",\"children\":\"搜索\"},{\"componentName\":\"TiIcon\",\"props\":{\"name\":\"search\"}}]}）；纯图标用 onlyIcon=true（children 仅 TiIcon）。",
           "doc_url": "https://www.opentiny.design/tiny-ng/components/button",
           "screenshot": "",
           "tags": "button,按钮,基础组件",
@@ -44,7 +44,9 @@
               "properties": [
                 "color",
                 "size",
-                "disabled"
+                "disabled",
+                "icon",
+                "onlyIcon"
               ]
             },
             "contextMenu": {
@@ -191,6 +193,50 @@
                       "props": {
                       }
                     }
+                  },
+                  {
+                    "property": "icon",
+                    "label": {
+                      "text": {
+                        "zh_CN": "图标按钮样式"
+                      }
+                    },
+                    "description": {
+                      "zh_CN": "文字+图标按钮样式；与 onlyIcon 二选一。children 为 [span 包裹文案, TiIcon]"
+                    },
+                    "required": false,
+                    "readOnly": false,
+                    "disabled": false,
+                    "cols": 12,
+                    "labelPosition": "left",
+                    "type": "boolean",
+                    "widget": {
+                      "component": "CheckBoxConfigurator",
+                      "props": {
+                      }
+                    }
+                  },
+                  {
+                    "property": "onlyIcon",
+                    "label": {
+                      "text": {
+                        "zh_CN": "纯图标按钮"
+                      }
+                    },
+                    "description": {
+                      "zh_CN": "纯图标按钮样式；与 icon 二选一。children 放 TiIcon 即可"
+                    },
+                    "required": false,
+                    "readOnly": false,
+                    "disabled": false,
+                    "cols": 12,
+                    "labelPosition": "left",
+                    "type": "boolean",
+                    "widget": {
+                      "component": "CheckBoxConfigurator",
+                      "props": {
+                      }
+                    }
                   }
                 ],
                 "description": {
@@ -221,6 +267,107 @@
                   }
                 }
               }
+            },
+            "slots": {
+            }
+          }
+        },
+        {
+          "id": 26,
+          "version": "3.8.0",
+          "name": {
+            "zh_CN": "图标"
+          },
+          "component": "TiIcon",
+          "icon": "icon",
+          "description": "TinyNG 官方字体图标组件（ti-icon）。独立节点：{\"componentName\":\"TiIcon\",\"props\":{\"name\":\"search\"}}。name 为 TinyNG 字体图标名（小写，如 search），挂 class ti3-icon-${name}。作为 TiButton 子节点时，按钮侧用 icon 或 onlyIcon 二选一。",
+          "doc_url": "https://www.opentiny.design/tiny-ng/components/icon",
+          "screenshot": "",
+          "tags": "icon,图标,基础组件",
+          "keywords": "icon,图标,ti-icon",
+          "dev_mode": "proCode",
+          "npm": {
+            "package": "@opentiny/ng",
+            "exportName": "TiIconComponent",
+            "destructuring": false
+          },
+          "group": "基础组件",
+          "category": "opentiny-ng",
+          "configure": {
+            "loop": true,
+            "condition": true,
+            "styles": true,
+            "isContainer": false,
+            "isModal": false,
+            "isPopper": false,
+            "nestingRule": {
+              "childWhitelist": "",
+              "parentWhitelist": "",
+              "descendantBlacklist": "",
+              "ancestorWhitelist": ""
+            },
+            "isNullNode": false,
+            "isLayout": false,
+            "rootSelector": "",
+            "shortcuts": {
+              "properties": [
+                "name"
+              ]
+            },
+            "contextMenu": {
+              "actions": [
+                "copy",
+                "remove",
+                "insert",
+                "updateAttr",
+                "bindEvent",
+                "createBlock"
+              ],
+              "disable": [
+              ]
+            },
+            "invalidity": [
+            ],
+            "clickCapture": true,
+            "framework": "Angular"
+          },
+          "schema": {
+            "properties": [
+              {
+                "name": "0",
+                "label": {
+                  "zh_CN": "基础属性"
+                },
+                "content": [
+                  {
+                    "property": "name",
+                    "label": {
+                      "text": {
+                        "zh_CN": "图标名称"
+                      }
+                    },
+                    "description": {
+                      "zh_CN": "TinyNG 字体图标名（小写）。优先使用以下精选：search（搜索）、edit（编辑）、delete（删除）、delete-1（删除）、add（添加）、add1（添加）、close（关闭）、clear（清除）、x-thin（细关闭）、cancel（取消）、checkmark（勾选）、checkmark-small（小勾选）、check-circle（圆圈勾选）、warn（警告）、alert-warn（警告提示）、alert-error（错误）、alert-success（成功）、alert-prompt（提示）、info-circle（信息）、exclamation-circle（感叹）、calendar（日历）、time（时间）、config（配置）、filter（筛选）、sort（排序）、sort-ascent（升序）、sort-descent（降序）、arrow-down（向下箭头）、arrow-right（向右箭头）、angle-left（左角）、angle-right（右角）、left-1（向左）、right-1（向右）、refresh（刷新）、refresh-1（刷新）、document（文档）、file（文件）、star（星标）、alarm（告警）、location（定位）、reduce（减少）、plus-square（加号方块）、minus-square（减号方块）、accordion-fold（折叠）、accordion-unfold（展开）。勿使用 Vue/EP 风格名称（如 Search、IconSearch）。"
+                    },
+                    "required": true,
+                    "readOnly": false,
+                    "disabled": false,
+                    "cols": 12,
+                    "labelPosition": "left",
+                    "type": "string",
+                    "widget": {
+                      "component": "InputConfigurator",
+                      "props": {
+                      }
+                    }
+                  }
+                ],
+                "description": {
+                  "zh_CN": ""
+                }
+              }
+            ],
+            "events": {
             },
             "slots": {
             }
@@ -5205,6 +5352,20 @@
                 "props": {
                   "color": "primary",
                   "size": "middle"
+                }
+              }
+            },
+            {
+              "name": {
+                "zh_CN": "图标"
+              },
+              "icon": "icon",
+              "screenshot": "",
+              "snippetName": "TiIcon",
+              "schema": {
+                "componentName": "TiIcon",
+                "props": {
+                  "name": "search"
                 }
               }
             },

--- a/packages/materials/angular-opentiny-ng/src/meta/white-list.ts
+++ b/packages/materials/angular-opentiny-ng/src/meta/white-list.ts
@@ -1,6 +1,7 @@
 export const whiteList = [
   // OpenTiny NG 组件
   'TiButton',
+  'TiIcon',
   'TiText',
   'TiSelect',
   'TiDate',
@@ -57,7 +58,6 @@ export const whiteList = [
   'textarea',
   // 内置组件
   'Text',
-  'Icon',
   'Img',
   'Slot',
   // 图表组件（如果支持）

--- a/projects/tiny-schema-renderer-ng/projects/renderer/src/parser/material-getter.ts
+++ b/projects/tiny-schema-renderer-ng/projects/renderer/src/parser/material-getter.ts
@@ -27,8 +27,6 @@ export const directiveMap: Record<string, Type<any>> = {
 (DefaultValueAccessor['ɵdir'] as any).standalone = true;
 (CheckboxControlValueAccessor['ɵdir'] as any).standalone = true;
 
-export const iconMap: Record<string, any> = {};
-
 export const customElements: Record<string, Type<any>> = {};
 
 export const getMaterials = (context: Record<PropertyKey, any> = {}): IRendererMaterials =>

--- a/projects/tiny-schema-renderer-ng/projects/renderer/src/parser/schema-parser.ts
+++ b/projects/tiny-schema-renderer-ng/projects/renderer/src/parser/schema-parser.ts
@@ -1,4 +1,4 @@
-import { getComponent, iconMap } from './material-getter';
+import { getComponent } from './material-getter';
 import { newFn } from './parser-utils';
 // import { renderDefault } from '../renderer';
 import { Notify } from './notify';
@@ -174,7 +174,6 @@ export const parseLoopArgs = (_loop: any) => {
   }
   return undefined;
 };
-export const getIcon = (name: string) => iconMap[name]?.() || '';
 const parseObjectData = (data: any, scope: any, ctx: any) => {
   if (!data) {
     return data;
@@ -185,10 +184,6 @@ const parseObjectData = (data: any, scope: any, ctx: any) => {
     return parseData(data.defaultValue, scope, ctx);
   }
 
-  // 解析通过属性传递icon图标组件
-  if (data.componentName === 'Icon') {
-    return getIcon(data.props.name);
-  }
   const res: Record<string, any> = {};
   Object.entries(data).forEach(([key, value]) => {
     // 如果是插槽则需要进行特殊处理

--- a/projects/tiny-schema-renderer-ng/src/app/materials/materials.ts
+++ b/projects/tiny-schema-renderer-ng/src/app/materials/materials.ts
@@ -14,6 +14,8 @@ import {
   TiDateRangeModule,
   TiFormfieldComponent,
   TiFormfieldModule,
+  TiIconComponent,
+  TiIconModule,
   TiItemComponent,
   TiModalComponent,
   TiModalModule,
@@ -52,6 +54,7 @@ import type { IRendererMaterials } from '../../../projects/renderer/src/renderer
 
 const components: Record<string, Type<any>> = {
   TiButton: TiButtonComponent,
+  TiIcon: TiIconComponent,
   TiSelect: TiSelectComponent,
   TiText: TiTextComponent,
   TiTable: TiTableComponent,
@@ -78,6 +81,7 @@ const components: Record<string, Type<any>> = {
 
 const modules: Record<string, Type<any>> = {
   TiButton: TiButtonModule,
+  TiIcon: TiIconModule,
   TiSelect: TiSelectModule,
   TiText: TiTextModule,
   TiTable: TiTableModule,


### PR DESCRIPTION
## Summary

- 为 Angular（TinyNG）补齐 Icon 物料化：注册官方 `TiIcon`，白名单开放，并在 `bundle.json` 写清用法与精选 name
- 协议与 Vue/EP **故意不一致**：TinyNG 的 `TiButton.icon` / `onlyIcon` 是 **boolean**（样式开关），不能传组件，因此不用 JSSlot；真实图标放 `children` 里的 `TiIcon`
- 文字+图标时文案用 `span` 包裹；`icon` 与 `onlyIcon` 二选一；NG 渲染器去掉旧的 `iconMap` / `getIcon` / `Icon` 特判

### 与 Vue 的差异

| | Vue / EP | Angular（TinyNG） |
|--|----------|-------------------|
| 图标 | 物料包自研包装（SVG） | 官方 `TiIcon`（字体图标） |
| name | `IconSearch` / `Search` | 小写字体名，如 `search` |
| 按钮挂图标 | `props.icon = JSSlot → Icon 节点` | `icon` / `onlyIcon` 为 boolean；图标放 children |

### Schema 示例

文字 + 图标：

```json
{
  "componentName": "TiButton",
  "props": { "icon": true, "color": "default" },
  "children": [
    { "componentName": "span", "children": "搜索" },
    { "componentName": "TiIcon", "props": { "name": "search" } }
  ]
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### 生成效果如图
<img width="2048" height="1030" alt="image" src="https://github.com/user-attachments/assets/77f3e0ca-bfc3-4a12-965d-9996d56597be" />
