### PR TITLE
chore: optimize word and home extend link

### DIFF
--- a/sites/homepage/web/src/components/HomeExtend.vue
+++ b/sites/homepage/web/src/components/HomeExtend.vue
@@ -278,7 +278,7 @@ onUnmounted(() => {
         </div>
         <a
           class="home-extend-schema-header-subtitle is-link"
-          :href="linkMap[LinkKey.PlaygroundBuilder] + inputMessage"
+          :href="linkMap[LinkKey.Playground] + inputMessage"
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/sites/playground/web/src/components/tab-components/ModelConfig.vue
+++ b/sites/playground/web/src/components/tab-components/ModelConfig.vue
@@ -138,7 +138,7 @@ const createNewTemplate = () => {
     />
   </template>
   <div class="config-title prompt-title">
-    <span>{{ t('model.prompt') }}</span>
+    <span>{{ t('model.additionalPrompt') }}</span>
     <span>
       <tiny-button type="text" :icon="IconPlus" @click="showAddPromptBox = true"> </tiny-button>
     </span>

--- a/sites/playground/web/src/i18n/en.json
+++ b/sites/playground/web/src/i18n/en.json
@@ -47,7 +47,7 @@
     "promptVariantMini": "Mini",
     "promptVariantStandard": "Standard",
     "promptVariantPlus": "Plus",
-    "prompt": "Prompts",
+    "additionalPrompt": "Additional prompts",
     "edit": "Edit",
     "delete": "Delete",
     "editPrompt": "Edit prompt",

--- a/sites/playground/web/src/i18n/zh.json
+++ b/sites/playground/web/src/i18n/zh.json
@@ -47,7 +47,7 @@
     "promptVariantMini": "Mini（轻量）",
     "promptVariantStandard": "Standard（标准）",
     "promptVariantPlus": "Plus（增强）",
-    "prompt": "提示词",
+    "additionalPrompt": "追加提示词",
     "edit": "编辑",
     "delete": "删除",
     "editPrompt": "编辑提示词",


### PR DESCRIPTION
## 概述

- 将 Playground 模型配置中的「提示词」文案改为「追加提示词」，更准确地表达其作为附加提示词拼接在主提示词之后的语义；同时将 i18n key 由 `model.prompt` 重命名为 `model.additionalPrompt`（中英同步）。
- 修复首页扩展区「体验搭建」入口的跳转链接，由 `LinkKey.PlaygroundBuilder` 改为 `LinkKey.Playground`，确保携带 `inputMessage` 后跳转到正确的 Playground 页面。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the homepage Playground link to use the correct destination while preserving existing parameters.
  * Clarified the model configuration label from “Prompts” to “Additional prompts.”
* **Localization**
  * Updated English and Chinese translations for the revised model configuration label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->