### PR TITLE
fix(playground): avoid keep-alive for ChatView with Angular cards

### DIFF
--- a/sites/playground/web/src/App.vue
+++ b/sites/playground/web/src/App.vue
@@ -380,7 +380,7 @@ onUnmounted(() => {
       @update-custom-examples="updateCustomExamples"
     >
       <router-view v-slot="{ Component }">
-        <keep-alive>
+        <keep-alive :include="['BuilderView']">
           <component :is="Component" />
         </keep-alive>
       </router-view>

--- a/sites/playground/web/src/views/BuilderView.vue
+++ b/sites/playground/web/src/views/BuilderView.vue
@@ -3,6 +3,8 @@ import { defineAsyncComponent } from 'vue';
 import PlaygroundViewShell from './PlaygroundViewShell.vue';
 import { usePlaygroundViewContext } from './usePlaygroundViewContext';
 
+defineOptions({ name: 'BuilderView' });
+
 const GenuiTemplate = defineAsyncComponent(() => import('../components/genui-template/GenuiTemplate.vue'));
 
 const { theme, llmConfig, chatConfig } = usePlaygroundViewContext();

--- a/sites/playground/web/src/views/ChatView.vue
+++ b/sites/playground/web/src/views/ChatView.vue
@@ -23,7 +23,7 @@ const {
 } = usePlaygroundViewContext();
 
 const setChatRef = (el) => {
-  if (el) chat.value = el;
+  chat.value = el || null;
 };
 
 const rendererSlots = {

--- a/sites/playground/web/src/views/ChatView.vue
+++ b/sites/playground/web/src/views/ChatView.vue
@@ -7,6 +7,8 @@ import { locale, t } from '../i18n';
 import PlaygroundViewShell from './PlaygroundViewShell.vue';
 import { usePlaygroundViewContext } from './usePlaygroundViewContext';
 
+defineOptions({ name: 'ChatView' });
+
 const {
   theme,
   llmConfig,


### PR DESCRIPTION
## Summary

- Playground 路由 `keep-alive` 改为仅缓存 `BuilderView`，`ChatView` 在 Builder ↔ Chat 切换时重新挂载。
- 为 `BuilderView` / `ChatView` 补充 `defineOptions({ name })`，供 `keep-alive` 的 `include` 按名称匹配。

## 问题

从 Builder 切回 Chat 时，若当前会话中存在 Angular schema 卡片，卡片会渲染失败（空白/无内容）；切换历史会话后又恢复正常。

**原因**：仅缓存 BuilderView。ChatView 必须重新挂载，否则 keep-alive 断开连接超过 10ms 后，Angular Elements 会销毁 GenuiRenderer 且不会回放输入属性，导致 Angular 卡片渲染失败。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved page navigation by limiting view caching to the intended builder view.
  * Improved navigation and state preservation for builder and chat views.
  * Fixed chat state cleanup when the chat view is no longer available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->