### PR TITLE
fix(playground/web): angular chat card disappear after change router

### DIFF
--- a/docs/demos/angular/renderer/adapter.vue
+++ b/docs/demos/angular/renderer/adapter.vue
@@ -1,11 +1,13 @@
 <template>
-  <genui-renderer-ng-element v-bind="props"></genui-renderer-ng-element>
+  <genui-renderer-ng-element v-if="mounted" v-bind="props"></genui-renderer-ng-element>
 </template>
 
 <script setup lang="ts">
+import { onActivated, onDeactivated, ref } from 'vue';
 import '@opentiny/genui-sdk-angular/dist/renderer-element/browser/polyfills.js';
 import '@opentiny/genui-sdk-angular/dist/renderer-element/browser/main.js';
 import '@opentiny/genui-sdk-angular/dist/renderer-element/browser/styles.css';
+
 const props = defineProps<{
   id?: string;
   state?: Record<string, any>;
@@ -17,4 +19,23 @@ const props = defineProps<{
   customActions?: Record<string, any>;
   requiredCompleteFieldSelectors?: string[];
 }>();
+
+/**
+ * Vue keep-alive detaches the tree → CE disconnectedCallback → Angular Elements
+ * destroy() removes the host node from its Vue parent (nativeRemoveNode on the
+ * component host). After that `genui-renderer-ng-element` is gone from the DOM,
+ * while Vue still holds the orphaned vnode and will not recreate it on activate.
+ *
+ * Unmount on deactivate / remount on activate so Vue creates a fresh CE and
+ * re-binds props.
+ */
+const mounted = ref(true);
+
+onDeactivated(() => {
+  mounted.value = false;
+});
+
+onActivated(() => {
+  mounted.value = true;
+});
 </script>

--- a/sites/playground/schema-renderer-ng-adpater/src/SchemaRendererNgAdapter.vue
+++ b/sites/playground/schema-renderer-ng-adpater/src/SchemaRendererNgAdapter.vue
@@ -1,11 +1,13 @@
 <template>
-  <genui-renderer-ng-element v-bind="props"></genui-renderer-ng-element>
+  <genui-renderer-ng-element v-if="mounted" v-bind="props"></genui-renderer-ng-element>
 </template>
 
 <script setup lang="ts">
+import { onActivated, onDeactivated, ref } from 'vue';
 import '@opentiny/genui-sdk-angular/dist/renderer-element/browser/polyfills.js';
 import '@opentiny/genui-sdk-angular/dist/renderer-element/browser/main.js';
 import '@opentiny/genui-sdk-angular/dist/renderer-element/browser/styles.css';
+
 const props = defineProps<{
   id?: string;
   state?: Record<string, any>;
@@ -17,4 +19,23 @@ const props = defineProps<{
   customActions?: Record<string, any>;
   requiredCompleteFieldSelectors?: string[];
 }>();
+
+/**
+ * Vue keep-alive detaches the tree → CE disconnectedCallback → Angular Elements
+ * destroy() removes the host node from its Vue parent (nativeRemoveNode on the
+ * component host). After that `genui-renderer-ng-element` is gone from the DOM,
+ * while Vue still holds the orphaned vnode and will not recreate it on activate.
+ *
+ * Unmount on deactivate / remount on activate so Vue creates a fresh CE and
+ * re-binds props.
+ */
+const mounted = ref(true);
+
+onDeactivated(() => {
+  mounted.value = false;
+});
+
+onActivated(() => {
+  mounted.value = true;
+});
 </script>


### PR DESCRIPTION
keep‑alive 断开时移除 DOM，触发 ng‑element 自动销毁，重连后无法恢复，新增 v‑if 强制重新渲染。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Angular renderer behavior when switching views with Vue’s keep-alive feature.
  * Ensured the custom element is properly unmounted and recreated when views are deactivated and reactivated.
  * Restored component properties after remounting to maintain the expected renderer state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->