### PR TITLE
fix(indexedDBStrategy): indexDB saveError doesn't throw error to avoid cannot render

### DIFF
--- a/packages/frameworks/vue/src/chat/tiny-robot-patch/indexedDBStrategy.ts
+++ b/packages/frameworks/vue/src/chat/tiny-robot-patch/indexedDBStrategy.ts
@@ -74,7 +74,6 @@ export class IndexedDBStrategy implements ConversationStorageStrategy {
       });
     } catch (error) {
       console.error('保存会话失败:', error);
-      throw error;
     }
   }
 


### PR DESCRIPTION
修复 indexDB保存会话失败 不应该阻塞渲染

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Conversation saving now completes gracefully when an unexpected storage error occurs, while still recording the error for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->