### PR TITLE
feat/non streaming support

### DIFF
--- a/packages/frameworks/vue/src/chat/CustomModelProvider.ts
+++ b/packages/frameworks/vue/src/chat/CustomModelProvider.ts
@@ -1,8 +1,7 @@
 import { BaseModelProvider, type ChatCompletionRequest, type ChatCompletionResponse } from '@opentiny/tiny-robot-kit';
 import { chat } from './chat-api';
 import type { IChatConfig, ICustomComponentItem, CustomFetch, ICustomActionItem } from './chat.types';
-import type { IGenPromptSnippet, IGenPromptExample } from '@opentiny/genui-sdk-core';
-import type { IChatMessage, IStreamData } from '@opentiny/genui-sdk-core';
+import type { IGenPromptSnippet, IGenPromptExample, IChatMessage, IStreamData, IStreamDelta } from '@opentiny/genui-sdk-core';
 import type { IResponseHandler } from './response-handler';
 
 async function readChunk(reader: ReadableStreamDefaultReader<Uint8Array>, handler: (data: string) => void) {
@@ -73,6 +72,7 @@ export class CustomModelProvider extends BaseModelProvider {
       model,
       temperature,
       signal: request.options?.signal,
+      stream: request.options?.stream ?? true,
       customComponents,
       customSnippets,
       customExamples,
@@ -81,8 +81,97 @@ export class CustomModelProvider extends BaseModelProvider {
     });
   }
 
-  async chat(_: ChatCompletionRequest) {
-    return {} as ChatCompletionResponse;
+  /**
+   * 非流式聊天：一次请求拿到完整响应后，复用流式的 responseHandlers 管线
+   * 构建出与 chatStream 对齐的 IChatMessage，再包装成 ChatCompletionResponse。
+   *
+   * 返回对象除契约字段外，额外挂载 role / content / messages / finishInfo，
+   * 与 chatStream 推给渲染层的消息结构一致（GenuiChat 会把返回值整体入列并按 messages 渲染）。
+   * 构建过程中 handlerEnd 等会触发 notification 事件，此时无监听者（loading 组件尚未挂载），
+   * 属无害的空发。
+   */
+  async chat(request: ChatCompletionRequest): Promise<ChatCompletionResponse> {
+    let response: Response;
+    try {
+      response = await this.getData(request);
+    } catch (error) {
+      throw error;
+    }
+    const json = await response.json();
+
+    const chatMessage = this.buildChatMessageFromResponse(json, request);
+
+    const choice = json.choices?.[0] ?? {};
+    const message = choice.message ?? {};
+
+    return {
+      id: json.id,
+      object: json.object ?? 'chat.completion',
+      created: json.created,
+      model: json.model,
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: 'assistant',
+            content: chatMessage.content,
+            reasoning_content: message.reasoning_content,
+            tool_calls: message.tool_calls,
+          },
+          finish_reason: choice.finish_reason ?? 'stop',
+        },
+      ],
+      usage: json.usage,
+      // 渲染相关字段：与 chatStream 推送的 IChatMessage 对齐
+      role: chatMessage.role,
+      content: chatMessage.content,
+      messages: chatMessage.messages,
+      finishInfo: chatMessage.finishInfo,
+    } as ChatCompletionResponse & IChatMessage;
+  }
+
+  /**
+   * 将 OpenAI 兼容的非流式响应（choices[0].message 完整消息）折叠成单个 IStreamData delta，
+   * 喂给与流式完全相同的 responseHandlers 管线，构建出 IChatMessage。
+   */
+  private buildChatMessageFromResponse(json: any, request: ChatCompletionRequest): IChatMessage {
+    const message = json.choices?.[0]?.message ?? {};
+    const delta: IStreamDelta = {
+      content: message.content,
+      reasoning_content: message.reasoning_content,
+      tool_calls: message.tool_calls,
+      tool_calls_result: message.tool_calls_result,
+    };
+    const streamData: IStreamData = {
+      id: json.id,
+      object: 'chat.completion.chunk',
+      model: json.model,
+      created: json.created,
+      choices: [
+        {
+          index: 0,
+          delta,
+          finish_reason: json.choices?.[0]?.finish_reason ?? 'stop',
+        },
+      ],
+      usage: json.usage,
+    };
+
+    const context: any = {};
+    this.setupStreamContext(context, request);
+
+    let chatMessage!: IChatMessage;
+    this.handlerStart(context, {
+      onData: (data: IChatMessage) => {
+        chatMessage = data;
+      },
+      onDone: () => {},
+      onError: () => {},
+    });
+    this.handlerChunk(JSON.stringify(streamData), context);
+    this.handlerEnd(context);
+
+    return chatMessage;
   }
 
   async chatStream(request: any, handler: { onData: any; onDone: any; onError: any }) {

--- a/packages/frameworks/vue/src/chat/CustomModelProvider.ts
+++ b/packages/frameworks/vue/src/chat/CustomModelProvider.ts
@@ -81,15 +81,6 @@ export class CustomModelProvider extends BaseModelProvider {
     });
   }
 
-  /**
-   * 非流式聊天：一次请求拿到完整响应后，复用流式的 responseHandlers 管线
-   * 构建出与 chatStream 对齐的 IChatMessage，再包装成 ChatCompletionResponse。
-   *
-   * 返回对象除契约字段外，额外挂载 role / content / messages / finishInfo，
-   * 与 chatStream 推给渲染层的消息结构一致（GenuiChat 会把返回值整体入列并按 messages 渲染）。
-   * 构建过程中 handlerEnd 等会触发 notification 事件，此时无监听者（loading 组件尚未挂载），
-   * 属无害的空发。
-   */
   async chat(request: ChatCompletionRequest): Promise<ChatCompletionResponse> {
     let response: Response;
     try {
@@ -99,6 +90,7 @@ export class CustomModelProvider extends BaseModelProvider {
     }
     const json = await response.json();
 
+    // 将非流式伪装成流式
     const chatMessage = this.buildChatMessageFromResponse(json, request);
 
     const choice = json.choices?.[0] ?? {};
@@ -122,7 +114,6 @@ export class CustomModelProvider extends BaseModelProvider {
         },
       ],
       usage: json.usage,
-      // 渲染相关字段：与 chatStream 推送的 IChatMessage 对齐
       role: chatMessage.role,
       content: chatMessage.content,
       messages: chatMessage.messages,
@@ -130,15 +121,6 @@ export class CustomModelProvider extends BaseModelProvider {
     } as ChatCompletionResponse & IChatMessage;
   }
 
-  /**
-   * 将 OpenAI 兼容的非流式响应（choices[0].message 完整消息）喂给与流式完全相同的
-   * responseHandlers 管线，构建出 IChatMessage。
-   *
-   * 不能把 content / reasoning_content / tool_calls / finish_reason+usage 塞进同一个
-   * delta：handlerChunk 的管线「命中即 break」（finish-info 排在最前，遇到
-   * finish_reason && usage 就短路），且一个 chunk 只能被首个命中处理器消费。因此按流式
-   * 顺序逐条拆分：推理 → 工具调用 → 工具结果 → 正文 → finish-info。
-   */
   private buildChatMessageFromResponse(json: any, request: ChatCompletionRequest): IChatMessage {
     const message = json.choices?.[0]?.message ?? {};
 
@@ -161,7 +143,6 @@ export class CustomModelProvider extends BaseModelProvider {
       created: json.created,
     };
 
-    // 每种 delta 单独成 chunk（与流式一致），工具结果须在工具调用之后处理
     const deltas: IStreamDelta[] = [];
     if (message.reasoning_content) {
       deltas.push({ reasoning_content: message.reasoning_content });
@@ -185,7 +166,6 @@ export class CustomModelProvider extends BaseModelProvider {
       );
     }
 
-    // finish-info：finish_reason + usage 单独成 chunk，避免打断内容/工具的匹配
     this.handlerChunk(
       JSON.stringify({
         ...base,

--- a/packages/frameworks/vue/src/chat/CustomModelProvider.ts
+++ b/packages/frameworks/vue/src/chat/CustomModelProvider.ts
@@ -131,31 +131,16 @@ export class CustomModelProvider extends BaseModelProvider {
   }
 
   /**
-   * 将 OpenAI 兼容的非流式响应（choices[0].message 完整消息）折叠成单个 IStreamData delta，
-   * 喂给与流式完全相同的 responseHandlers 管线，构建出 IChatMessage。
+   * 将 OpenAI 兼容的非流式响应（choices[0].message 完整消息）喂给与流式完全相同的
+   * responseHandlers 管线，构建出 IChatMessage。
+   *
+   * 不能把 content / reasoning_content / tool_calls / finish_reason+usage 塞进同一个
+   * delta：handlerChunk 的管线「命中即 break」（finish-info 排在最前，遇到
+   * finish_reason && usage 就短路），且一个 chunk 只能被首个命中处理器消费。因此按流式
+   * 顺序逐条拆分：推理 → 工具调用 → 工具结果 → 正文 → finish-info。
    */
   private buildChatMessageFromResponse(json: any, request: ChatCompletionRequest): IChatMessage {
     const message = json.choices?.[0]?.message ?? {};
-    const delta: IStreamDelta = {
-      content: message.content,
-      reasoning_content: message.reasoning_content,
-      tool_calls: message.tool_calls,
-      tool_calls_result: message.tool_calls_result,
-    };
-    const streamData: IStreamData = {
-      id: json.id,
-      object: 'chat.completion.chunk',
-      model: json.model,
-      created: json.created,
-      choices: [
-        {
-          index: 0,
-          delta,
-          finish_reason: json.choices?.[0]?.finish_reason ?? 'stop',
-        },
-      ],
-      usage: json.usage,
-    };
 
     const context: any = {};
     this.setupStreamContext(context, request);
@@ -168,7 +153,48 @@ export class CustomModelProvider extends BaseModelProvider {
       onDone: () => {},
       onError: () => {},
     });
-    this.handlerChunk(JSON.stringify(streamData), context);
+
+    const base = {
+      id: json.id,
+      object: 'chat.completion.chunk',
+      model: json.model,
+      created: json.created,
+    };
+
+    // 每种 delta 单独成 chunk（与流式一致），工具结果须在工具调用之后处理
+    const deltas: IStreamDelta[] = [];
+    if (message.reasoning_content) {
+      deltas.push({ reasoning_content: message.reasoning_content });
+    }
+    if (message.tool_calls?.length) {
+      deltas.push({ tool_calls: message.tool_calls });
+    }
+    if (message.tool_calls_result?.length) {
+      deltas.push({ tool_calls_result: message.tool_calls_result });
+    }
+    if (message.content) {
+      deltas.push({ content: message.content });
+    }
+    for (const delta of deltas) {
+      this.handlerChunk(
+        JSON.stringify({
+          ...base,
+          choices: [{ index: 0, delta, finish_reason: null }],
+        }),
+        context,
+      );
+    }
+
+    // finish-info：finish_reason + usage 单独成 chunk，避免打断内容/工具的匹配
+    this.handlerChunk(
+      JSON.stringify({
+        ...base,
+        choices: [{ index: 0, delta: {}, finish_reason: json.choices?.[0]?.finish_reason ?? 'stop' }],
+        usage: json.usage,
+      }),
+      context,
+    );
+
     this.handlerEnd(context);
 
     return chatMessage;

--- a/packages/frameworks/vue/src/chat/GenuiChat.vue
+++ b/packages/frameworks/vue/src/chat/GenuiChat.vue
@@ -255,6 +255,7 @@ const client = new AIClient({
 let conversation = useConversation({
   client,
   autoSave: false,
+  useStreamByDefault: props.stream ?? true,
   events: {
     onReceiveData(data, messages, preventDefault) {
       messages.value.push(data as any);

--- a/packages/frameworks/vue/src/chat/chat-api.ts
+++ b/packages/frameworks/vue/src/chat/chat-api.ts
@@ -27,6 +27,7 @@ export const chat = async (
     model: string,
     temperature: number,
     signal: any,
+    stream: boolean,
     customComponents: ICustomComponentItem[],
     customSnippets: IGenPromptSnippet[],
     customExamples: IGenPromptExample[],
@@ -34,7 +35,7 @@ export const chat = async (
     customFetch?: CustomFetch,
   }
 ) => {
-  const { url, messages, model, temperature, signal, customComponents, customSnippets, customExamples, customActions, customFetch } = chatOptions;
+  const { url, messages, model, temperature, signal, stream, customComponents, customSnippets, customExamples, customActions, customFetch } = chatOptions;
   const tgCustomConfig = {
     customComponents: removeRefFromCustomComponents(customComponents),
     customSnippets: customSnippets,
@@ -56,6 +57,7 @@ export const chat = async (
       messages: messages,
       model: model,
       temperature: temperature,
+      stream: stream ?? true,
       metadata: requestMetadata,
     }),
   };

--- a/packages/frameworks/vue/src/chat/chat.types.ts
+++ b/packages/frameworks/vue/src/chat/chat.types.ts
@@ -87,7 +87,6 @@ export interface IChatProps {
   url?: string;
   model?: string;
   temperature?: number;
-  /** 是否使用流式响应，默认 true；设为 false 走非流式（一次返回完整 JSON） */
   stream?: boolean;
   messages?: IMessage[];
   chatConfig?: IChatConfig;

--- a/packages/frameworks/vue/src/chat/chat.types.ts
+++ b/packages/frameworks/vue/src/chat/chat.types.ts
@@ -87,6 +87,8 @@ export interface IChatProps {
   url?: string;
   model?: string;
   temperature?: number;
+  /** 是否使用流式响应，默认 true；设为 false 走非流式（一次返回完整 JSON） */
+  stream?: boolean;
   messages?: IMessage[];
   chatConfig?: IChatConfig;
   requiredCompleteFieldSelectors?: string[];

--- a/packages/frameworks/vue/src/chat/tiny-robot-patch/useMessage.ts
+++ b/packages/frameworks/vue/src/chat/tiny-robot-patch/useMessage.ts
@@ -128,8 +128,6 @@ export function useMessage(options: UseMessageOptions): UseMessageReturn {
 
     chatOnReceiveData(response);
 
-    // 非流式响应一次性返回，收到后即完成，需置 FINISHED 结束生成态
-    // （与流式 onDone 的行为对齐，并触发 onFinish 回调）
     const onFinish = options.events?.onFinish;
     let defaultPrevented = false;
     if (onFinish) {

--- a/packages/frameworks/vue/src/chat/tiny-robot-patch/useMessage.ts
+++ b/packages/frameworks/vue/src/chat/tiny-robot-patch/useMessage.ts
@@ -127,6 +127,19 @@ export function useMessage(options: UseMessageOptions): UseMessageReturn {
     });
 
     chatOnReceiveData(response);
+
+    // 非流式响应一次性返回，收到后即完成，需置 FINISHED 结束生成态
+    // （与流式 onDone 的行为对齐，并触发 onFinish 回调）
+    const onFinish = options.events?.onFinish;
+    let defaultPrevented = false;
+    if (onFinish) {
+      onFinish(response.choices?.[0]?.finish_reason ?? 'stop', { messages, messageState }, () => {
+        defaultPrevented = true;
+      });
+    }
+    if (!defaultPrevented && messageState.status !== STATUS.ABORTED) {
+      messageState.status = STATUS.FINISHED;
+    }
   };
 
   const streamChatOnReceiveData = (data: ChatCompletionStreamResponse) => {

--- a/sites/playground/server/src/chat-genui.ts
+++ b/sites/playground/server/src/chat-genui.ts
@@ -31,10 +31,6 @@ type StreamTextOptions = Parameters<typeof streamText>[0];
 
 const BUSY_ERROR_MESSAGE = '算力繁忙，请切换其他模型或稍后重试';
 
-/**
- * 将 AI SDK generateText 的返回结果转换成 OpenAI 兼容的非流式响应（object: "chat.completion"）。
- * 多步（工具调用）场景下按 steps 顺序拼接各步的 text / reasoningText，并归并 toolCalls / toolResults。
- */
 function buildCompletionFromGenerateText(result: GenerateTextResult<any, any>): any {
   const message: any = { role: 'assistant', content: '' };
   const reasoningParts: string[] = [];
@@ -324,7 +320,6 @@ export function createChatGenui() {
   const chatGenuiHandler = async (req: Request, res: Response): Promise<void> => {
     const abort = new AbortController();
     const body = JSON.parse(await getRawBody(req, { encoding: 'utf-8' }));
-    // OpenAI 兼容：请求带 stream:false 时向 AI 发非流式请求，并返回 chat.completion JSON；缺省仍走流式
     const isStreaming = body.stream !== false;
     if (process.env.CHAT_UI_REPLAY_MODE === 'true') {
       res.setHeader('Content-Type', 'text/event-stream');
@@ -467,16 +462,14 @@ export function createChatGenui() {
       }
     });
 
-    // 非流式：向 AI 发送 stream:false 的非流式请求，把 generateText 的完整结果转成
-    // OpenAI 兼容的 chat.completion JSON 一次性返回（不走 SSE）
     if (!isStreaming) {
       const generateOptions = {
-        model: model!, // 与流式路径一致：generateLlmConfig 必带 model，运行时不会为 undefined
+        model: model!,
         temperature,
         system: options.system,
         messages: options.messages,
         abortSignal: abort.signal,
-        tools: tools as ToolSet, // 显式化 tools，避免 generateText 泛型从联合类型推断出不合法的 TOOLS
+        tools: tools as ToolSet,
         toolChoice: 'auto' as const,
         stopWhen: stepCountIs(maxSteps),
         ...(providerOptions ? { providerOptions } : {}),

--- a/sites/playground/server/src/chat-genui.ts
+++ b/sites/playground/server/src/chat-genui.ts
@@ -1,5 +1,5 @@
 import { type Request, type Response } from 'express';
-import { streamText, stepCountIs, tool } from 'ai';
+import { streamText, generateText, stepCountIs, tool, type GenerateTextResult, type ToolSet } from 'ai';
 import getRawBody from 'raw-body';
 import fs from 'node:fs/promises';
 import path from 'node:path';
@@ -30,6 +30,84 @@ import { normalizeMessagesForAiSdk } from './normalize-messages.js';
 type StreamTextOptions = Parameters<typeof streamText>[0];
 
 const BUSY_ERROR_MESSAGE = '算力繁忙，请切换其他模型或稍后重试';
+
+/**
+ * 将 AI SDK generateText 的返回结果转换成 OpenAI 兼容的非流式响应（object: "chat.completion"）。
+ * 多步（工具调用）场景下按 steps 顺序拼接各步的 text / reasoningText，并归并 toolCalls / toolResults。
+ */
+function buildCompletionFromGenerateText(result: GenerateTextResult<any, any>): any {
+  const message: any = { role: 'assistant', content: '' };
+  const reasoningParts: string[] = [];
+  const toolCalls: any[] = [];
+  const toolResults: any[] = [];
+
+  for (const step of result.steps) {
+    if (step.reasoningText) reasoningParts.push(step.reasoningText);
+    if (step.text) message.content += step.text;
+    for (const toolCall of step.toolCalls) {
+      toolCalls.push({
+        id: toolCall.toolCallId,
+        type: 'function',
+        function: {
+          name: toolCall.toolName,
+          arguments: stringifyToolInput(toolCall.input),
+        },
+      });
+    }
+    for (const toolResult of step.toolResults) {
+      toolResults.push({
+        id: toolResult.toolCallId,
+        type: 'function',
+        function: {
+          name: toolResult.toolName,
+          arguments: stringifyToolInput(toolResult.input),
+          result: toolResult.output,
+        },
+      });
+    }
+  }
+
+  if (reasoningParts.length) message.reasoning_content = reasoningParts.join('');
+  if (toolCalls.length) message.tool_calls = toolCalls;
+  if (toolResults.length) message.tool_calls_result = toolResults;
+
+  const { inputTokens, outputTokens, totalTokens } = result.totalUsage;
+  return {
+    id: result.response?.id ?? `chatcmpl-${Date.now()}`,
+    object: 'chat.completion',
+    created: Date.now(),
+    model: result.response?.modelId ?? '',
+    choices: [
+      {
+        index: 0,
+        message,
+        finish_reason: mapFinishReason(result.finishReason),
+      },
+    ],
+    usage: {
+      prompt_tokens: inputTokens,
+      completion_tokens: outputTokens,
+      total_tokens: totalTokens,
+    },
+  };
+}
+
+/** 工具入参序列化为 OpenAI 协议要求的 JSON 字符串 */
+function stringifyToolInput(input: unknown): string {
+  if (typeof input === 'string') return input;
+  try {
+    return JSON.stringify(input ?? {});
+  } catch {
+    return '{}';
+  }
+}
+
+/** AI SDK 的 finishReason 映射为 OpenAI 协议的取值 */
+function mapFinishReason(finishReason: string): string {
+  if (finishReason === 'tool-calls') return 'tool_calls';
+  if (finishReason === 'content-filter') return 'content_filter';
+  return finishReason;
+}
 
 function extractStatusCode(error: any): number | undefined {
   if (!error) {
@@ -246,6 +324,8 @@ export function createChatGenui() {
   const chatGenuiHandler = async (req: Request, res: Response): Promise<void> => {
     const abort = new AbortController();
     const body = JSON.parse(await getRawBody(req, { encoding: 'utf-8' }));
+    // OpenAI 兼容：请求带 stream:false 时向 AI 发非流式请求，并返回 chat.completion JSON；缺省仍走流式
+    const isStreaming = body.stream !== false;
     if (process.env.CHAT_UI_REPLAY_MODE === 'true') {
       res.setHeader('Content-Type', 'text/event-stream');
       const text = await fs.readFile(path.join(fileURLToPath(import.meta.url), '../replay/replay.txt'), 'utf-8');
@@ -386,6 +466,38 @@ export function createChatGenui() {
         }
       }
     });
+
+    // 非流式：向 AI 发送 stream:false 的非流式请求，把 generateText 的完整结果转成
+    // OpenAI 兼容的 chat.completion JSON 一次性返回（不走 SSE）
+    if (!isStreaming) {
+      const generateOptions = {
+        model: model!, // 与流式路径一致：generateLlmConfig 必带 model，运行时不会为 undefined
+        temperature,
+        system: options.system,
+        messages: options.messages,
+        abortSignal: abort.signal,
+        tools: tools as ToolSet, // 显式化 tools，避免 generateText 泛型从联合类型推断出不合法的 TOOLS
+        toolChoice: 'auto' as const,
+        stopWhen: stepCountIs(maxSteps),
+        ...(providerOptions ? { providerOptions } : {}),
+      };
+
+      try {
+        const result = await generateText(generateOptions);
+        if (abort.signal.aborted) {
+          res.status(499).json({ message: 'Request aborted', type: 'AbortedError', param: null, code: 499 });
+          return;
+        }
+        res.json(buildCompletionFromGenerateText(result));
+      } catch (error: any) {
+        const statusCode = error?.statusCode ?? 500;
+        const message = error?.message || 'Internal Server Error';
+        console.error('Error in chat-genui generateText:', error);
+        const errorResponse = { message, type: 'Internal Server Error', param: null, code: 'Internal Server Error' };
+        res.status(statusCode).json(errorResponse);
+      }
+      return;
+    }
 
     try {
       const stream = streamText(options);

--- a/sites/playground/web/src/views/ChatView.vue
+++ b/sites/playground/web/src/views/ChatView.vue
@@ -28,6 +28,7 @@ const setChatRef = (el) => {
   <PlaygroundViewShell>
     <GenuiConfigProvider :theme="theme" :locale="locale" :materials="materials" style="height: 100%">
       <GenuiChat
+        :stream="false"
         :url="url"
         :ref="setChatRef"
         :messages="messages"


### PR DESCRIPTION
给chat组件添加一个布尔类型的stream属性，来控制是否使用流式渲染，并增加非流式渲染功能

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for both streaming and non-streaming chat responses.
  * Chat requests now stream by default, with an option to disable streaming.
  * Non-streaming responses return complete, OpenAI-compatible chat completion data.
  * Added support for finish reasons, usage details, reasoning, and tool interactions in non-streaming responses.

* **Bug Fixes**
  * Non-streaming conversations now correctly trigger completion events and finalize message state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->