### PR TITLE
fix(materials): nest TiTable example srcData under data

### DIFF
--- a/packages/materials/angular-opentiny-ng/src/meta/examples/grid.json
+++ b/packages/materials/angular-opentiny-ng/src/meta/examples/grid.json
@@ -221,30 +221,32 @@
         "title": "操作"
       }
     ],
-    "srcData": [
-      {
-        "name": "李四",
-        "id": "2",
-        "sex": "女",
-        "department": "技术部",
-        "protocolStart": "2019-05-15",
-        "email": "lisi@test.com"
-      },
-      {
-        "name": "王五",
-        "id": "3",
-        "sex": "男",
-        "department": "市场部",
-        "protocolStart": "2020-03-20",
-        "email": "wangwu@test.com"
-      }
-    ],
+    "srcData": {
+      "data": [
+        {
+          "name": "李四",
+          "id": "2",
+          "sex": "女",
+          "department": "技术部",
+          "protocolStart": "2019-05-15",
+          "email": "lisi@test.com"
+        },
+        {
+          "name": "王五",
+          "id": "3",
+          "sex": "男",
+          "department": "市场部",
+          "protocolStart": "2020-03-20",
+          "email": "wangwu@test.com"
+        }
+      ]
+    },
     "displayedData": []
   },
   "methods": {
     "deleteRow": {
       "type": "JSFunction",
-      "value": "function(row) { this.state.srcData = this.state.srcData.filter(item => item.id !== row.id) }"
+      "value": "function(row) { this.state.srcData.data = this.state.srcData.data.filter(item => item.id !== row.id) }"
     }
   },
   "dataSource": {


### PR DESCRIPTION
修复 angular 表格示例格式问题 导致 只能渲染表头
<img width="1017" height="686" alt="image" src="https://github.com/user-attachments/assets/12b615b7-8c53-4b58-8c4c-b8f132367a93" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the grid example’s row data handling to ensure row deletion works correctly with the revised data structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->