### PR TITLE
fix(homepage): hide playground link when playground env is not config

### DIFF
--- a/sites/homepage/web/src/components/HomeBuilderContent.vue
+++ b/sites/homepage/web/src/components/HomeBuilderContent.vue
@@ -88,7 +88,7 @@ function handleFeatureClick(index: number) {
           <div class="home-builder-content-feature-description">{{ feature.description }}</div>
         </div>
       </div>
-      <a v-if="linkMap[LinkKey.PlaygroundBuilder]" v-bind="$attrs" :href="linkMap[LinkKey.PlaygroundBuilder]" target="_blank" rel="noopener noreferrer" class="btn-link">
+      <a v-if="linkMap[LinkKey.PlaygroundBuilder]" :href="linkMap[LinkKey.PlaygroundBuilder]" target="_blank" rel="noopener noreferrer" class="btn-link">
         <tiny-button class="home-builder-content-button" size="medium" round ghost>
           {{ t('ability.builder.tryNow') }}
           <img :src="arrowRightIcon" alt="arrow-right" />

--- a/sites/homepage/web/src/components/HomeBuilderContent.vue
+++ b/sites/homepage/web/src/components/HomeBuilderContent.vue
@@ -88,7 +88,7 @@ function handleFeatureClick(index: number) {
           <div class="home-builder-content-feature-description">{{ feature.description }}</div>
         </div>
       </div>
-      <a :href="linkMap[LinkKey.PlaygroundBuilder]" target="_blank" rel="noopener noreferrer" class="btn-link">
+      <a v-if="linkMap[LinkKey.PlaygroundBuilder]" v-bind="$attrs" :href="linkMap[LinkKey.PlaygroundBuilder]" target="_blank" rel="noopener noreferrer" class="btn-link">
         <tiny-button class="home-builder-content-button" size="medium" round ghost>
           {{ t('ability.builder.tryNow') }}
           <img :src="arrowRightIcon" alt="arrow-right" />

--- a/sites/homepage/web/src/components/HomeExtend.vue
+++ b/sites/homepage/web/src/components/HomeExtend.vue
@@ -297,6 +297,7 @@ onUnmounted(() => {
           <div class="home-extend-schema-header-action-exit"></div>
         </div>
         <a
+          v-if="linkMap[LinkKey.Playground]"
           class="home-extend-schema-header-subtitle is-link"
           :href="linkMap[LinkKey.Playground] + inputMessage"
           target="_blank"

--- a/sites/homepage/web/src/components/HomeLink.vue
+++ b/sites/homepage/web/src/components/HomeLink.vue
@@ -24,7 +24,7 @@ const buttonSize = computed(() => {
         <div>{{ t('link.descriptionLine2') }}</div>
       </div>
       <div class="home-link-button-group">
-        <a :href="linkMap[LinkKey.Playground]" target="_blank" rel="noopener noreferrer" class="btn-link">
+        <a v-if="linkMap[LinkKey.Playground]" v-bind="$attrs" :href="linkMap[LinkKey.Playground]" target="_blank" rel="noopener noreferrer" class="btn-link">
           <tiny-button type="primary" :size="buttonSize" round>{{ t('link.tryNow') }}</tiny-button>
         </a>
         <a :href="linkMap[LinkKey.DevDoc]" target="_blank" rel="noopener noreferrer" class="btn-link">

--- a/sites/homepage/web/src/components/HomeLink.vue
+++ b/sites/homepage/web/src/components/HomeLink.vue
@@ -24,7 +24,7 @@ const buttonSize = computed(() => {
         <div>{{ t('link.descriptionLine2') }}</div>
       </div>
       <div class="home-link-button-group">
-        <a v-if="linkMap[LinkKey.Playground]" v-bind="$attrs" :href="linkMap[LinkKey.Playground]" target="_blank" rel="noopener noreferrer" class="btn-link">
+        <a v-if="linkMap[LinkKey.Playground]" :href="linkMap[LinkKey.Playground]" target="_blank" rel="noopener noreferrer" class="btn-link">
           <tiny-button type="primary" :size="buttonSize" round>{{ t('link.tryNow') }}</tiny-button>
         </a>
         <a :href="linkMap[LinkKey.DevDoc]" target="_blank" rel="noopener noreferrer" class="btn-link">

--- a/sites/homepage/web/src/utils/link.ts
+++ b/sites/homepage/web/src/utils/link.ts
@@ -1,10 +1,10 @@
 const DOCS_BASE = import.meta.env.VITE_GENUI_DOCS_BASE || 'https://docs.opentiny.design/genui-sdk';
-const PLAYGROUND_HREF = import.meta.env.VITE_GENUI_PLAYGROUND_HREF || 'https://opentiny.github.io/genui-sdk/playground/';
+const PLAYGROUND_HREF = import.meta.env.VITE_GENUI_PLAYGROUND_HREF
 
 export const linkMap = {
   devDoc: `${DOCS_BASE}/guide/quick-start`,
-  playground: `${PLAYGROUND_HREF}#/chat`,
-  playgroundBuilder: `${PLAYGROUND_HREF}#/builder`,
+  playground: PLAYGROUND_HREF ? `${PLAYGROUND_HREF}#/chat` : null,
+  playgroundBuilder: PLAYGROUND_HREF ? `${PLAYGROUND_HREF}#/builder` : null,
   chatDoc: `${DOCS_BASE}/components/chat`,
   dcologicalCompatibility: `${DOCS_BASE}/examples/chat/custom-fetch`,
   defineTheme: `${DOCS_BASE}/examples/config-provider/theme`,

--- a/sites/homepage/web/src/views/home.vue
+++ b/sites/homepage/web/src/views/home.vue
@@ -68,7 +68,7 @@ const buttonSize = computed(() => {
           <a :href="linkMap[LinkKey.DevDoc]" target="_blank" rel="noopener noreferrer" class="btn-link">
             <tiny-button :reset-time="0" round type="primary" :size="buttonSize">{{ t('hero.devDoc') }}</tiny-button>
           </a>
-          <a v-if="linkMap[LinkKey.Playground]" v-bind="$attrs" :href="linkMap[LinkKey.Playground]" target="_blank" rel="noopener noreferrer" class="btn-link">
+          <a v-if="linkMap[LinkKey.Playground]" :href="linkMap[LinkKey.Playground]" target="_blank" rel="noopener noreferrer" class="btn-link">
             <tiny-button :reset-time="0" round ghost :size="buttonSize">{{ t('hero.playground') }}</tiny-button>
           </a>
           <a href="https://github.com/opentiny/genui-sdk" target="_blank" rel="noopener noreferrer" class="btn-link">

--- a/sites/homepage/web/src/views/home.vue
+++ b/sites/homepage/web/src/views/home.vue
@@ -68,7 +68,7 @@ const buttonSize = computed(() => {
           <a :href="linkMap[LinkKey.DevDoc]" target="_blank" rel="noopener noreferrer" class="btn-link">
             <tiny-button :reset-time="0" round type="primary" :size="buttonSize">{{ t('hero.devDoc') }}</tiny-button>
           </a>
-          <a :href="linkMap[LinkKey.Playground]" target="_blank" rel="noopener noreferrer" class="btn-link">
+          <a v-if="linkMap[LinkKey.Playground]" v-bind="$attrs" :href="linkMap[LinkKey.Playground]" target="_blank" rel="noopener noreferrer" class="btn-link">
             <tiny-button :reset-time="0" round ghost :size="buttonSize">{{ t('hero.playground') }}</tiny-button>
           </a>
           <a href="https://github.com/opentiny/genui-sdk" target="_blank" rel="noopener noreferrer" class="btn-link">


### PR DESCRIPTION
当playground链接环境变量未配置的时候，隐藏相关跳转链接

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Playground and “Try Now” links are now hidden when no destination is configured, preventing non-functional links from appearing.
  * Removed the default fallback Playground URL when no URL is provided.
  * Updated link behavior so these links use their configured destinations and open in a new tab when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->