### PR TITLE
feat(genui-sdk-vue): export code-generator as a package subpath

### DIFF
--- a/docs/.vitepress/config/en-theme.ts
+++ b/docs/.vitepress/config/en-theme.ts
@@ -43,6 +43,7 @@ export const enThemeConfig: DefaultTheme.Config = {
           { text: 'GenuiRenderer', link: '/en/components/renderer' },
           { text: 'GenuiChat', link: '/en/components/chat' },
           { text: 'GenuiConfigProvider', link: '/en/components/config-provider' },
+          { text: 'generateCode', link: '/en/components/code-generator' },
         ],
       },
       {

--- a/docs/.vitepress/config/zh-theme.ts
+++ b/docs/.vitepress/config/zh-theme.ts
@@ -39,6 +39,7 @@ export const zhThemeConfig: DefaultTheme.Config = {
           { text: 'GenuiRenderer', link: '/components/renderer' },
           { text: 'GenuiChat', link: '/components/chat' },
           { text: 'GenuiConfigProvider', link: '/components/config-provider' },
+          { text: 'generateCode', link: '/components/code-generator' },
         ],
       },
       {

--- a/docs/src/components/code-generator.md
+++ b/docs/src/components/code-generator.md
@@ -1,0 +1,135 @@
+# generateCode
+
+`generateCode` 将 SchemaJSON 转成可落地的 Vue SFC（`<template>` + `<script setup>` + `<style>`），用于导出页面源码、离线预览或二次开发。
+
+仅使用代码生成时可从 `@opentiny/genui-sdk-vue/code-generator` 按需引入，见 [快速开始 - 按需引入](../guide/quick-start#按需引入)。主入口 `@opentiny/genui-sdk-vue` 同样会再导出该能力。
+
+## 基本用法
+
+```ts
+import { generateCode } from '@opentiny/genui-sdk-vue/code-generator';
+
+const { panelName, panelValue, errors } = await generateCode({
+  pageInfo: {
+    name: 'OrderForm',
+    schema: {
+      componentName: 'Page',
+      children: [
+        {
+          componentName: 'TinyButton',
+          props: { text: '提交', type: 'primary' },
+        },
+      ],
+    },
+  },
+  componentsMap: [
+    {
+      componentName: 'TinyButton',
+      package: '@opentiny/vue',
+      exportName: 'TinyButton',
+    },
+  ],
+  formatWithPrettier: true,
+});
+
+if (errors.length) {
+  console.error(errors);
+}
+
+console.log(panelName); // OrderForm.vue
+console.log(panelValue); // Vue SFC 源码
+```
+
+`schema` 可以是对象，也可以是 JSON 字符串。解析失败或为空时，会回退为空的 `Page`。
+
+## generateCode()
+
+- **类型**
+
+```ts
+function generateCode(params: ICodeGeneratorParams): Promise<ICodeGeneratorResult>
+```
+
+内部等价于 `new VueCodeGenerator().generate(params)`，默认开启编译校验。
+
+- **参数**
+
+| 参数 | 类型 | 必填 | 默认值 | 说明 |
+|------|------|------|--------|------|
+| `pageInfo.schema` | `CardSchema \| string` | 是 | — | 页面 Schema |
+| `pageInfo.name` | `string` | 否 | `'SchemaCard'` | 输出文件名（不含扩展名），结果为 `{name}.vue` |
+| `componentsMap` | `IComponentMapItem[]` | 否 | `[]` | Schema 中组件名到 npm 包的映射，用于生成 `import` |
+| `formatWithPrettier` | `boolean` | 否 | `false` | 是否用 Prettier 格式化；失败时返回未格式化源码 |
+
+- **返回值**: `Promise<ICodeGeneratorResult>`
+
+## ICodeGeneratorResult
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `panelName` | `string` | 文件名，如 `SchemaCard.vue` |
+| `panelValue` | `string` | Vue SFC 源码 |
+| `panelType` | `'vue'` | 固定为 Vue |
+| `type` | `'page'` | 固定为页面 |
+| `prettierOpts` | `Record<string, unknown>` | 本次使用的 Prettier 配置 |
+| `errors` | `{ message: string }[]` | 编译校验错误；无错误时为空数组 |
+
+## IComponentMapItem
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `componentName` | `string` | 是 | Schema 里的组件名，需与 `componentName` 一致 |
+| `package` | `string` | 是 | npm 包名，用于 `from '...'` |
+| `exportName` | `string` | 否 | 包内导出名；与 `componentName` 不同时生成 `exportName as componentName` |
+
+缺少 `componentName` 或 `package` 的项会被忽略。Schema 中出现、但未出现在 `componentsMap` 中的组件不会生成对应 import。
+
+可从物料协议的 `npm` 字段组装，例如：
+
+```ts
+import { materialsMeta } from '@opentiny/genui-sdk-materials-vue-opentiny-vue/meta';
+
+const componentsMap = materialsMeta.materials.flatMap((material) =>
+  (material.data?.materials?.components ?? []).map((item) => ({
+    componentName: item.component,
+    package: item.npm.package,
+    exportName: item.npm.exportName,
+  })),
+);
+```
+
+## VueCodeGenerator
+
+需要自定义 Prettier 配置，或关闭编译校验时，直接实例化生成器：
+
+```ts
+import { VueCodeGenerator } from '@opentiny/genui-sdk-vue/code-generator';
+
+const generator = new VueCodeGenerator({
+  prettierOpts: { printWidth: 100, singleQuote: true },
+  enableCompileValidation: false,
+});
+
+const result = await generator.generate({
+  pageInfo: { schema },
+  formatWithPrettier: true,
+});
+```
+
+### 构造选项 `IVueCodeGeneratorOptions`
+
+| 字段 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `prettierOpts` | `Record<string, unknown>` | 内置 Vue 默认项 | 与内置配置合并后用于格式化 |
+| `enableCompileValidation` | `boolean` | `true` | 是否用 `@vue/compiler-sfc` 校验生成结果 |
+
+## 生成内容
+
+生成的 SFC 会尽量还原 Schema 语义，包括：
+
+- 组件树对应的 `<template>`
+- `state`、`methods`、`lifeCycles`、`refs` 对应的 `<script setup>`
+- Schema `css` 对应的 `<style>`
+- 按 `componentsMap` 写入的组件 import
+
+Playground 的「导出 Vue 源码」即调用该 API。

--- a/docs/src/en/components/code-generator.md
+++ b/docs/src/en/components/code-generator.md
@@ -1,0 +1,135 @@
+# generateCode
+
+`generateCode` turns SchemaJSON into a Vue SFC (`<template>` + `<script setup>` + `<style>`). Use it to export page source, preview offline, or continue development from generated code.
+
+When you only need code generation, import from `@opentiny/genui-sdk-vue/code-generator`. See [Quick Start - Subpath Imports](../guide/quick-start#subpath-imports). The main entry `@opentiny/genui-sdk-vue` also re-exports this API.
+
+## Basic Usage
+
+```ts
+import { generateCode } from '@opentiny/genui-sdk-vue/code-generator';
+
+const { panelName, panelValue, errors } = await generateCode({
+  pageInfo: {
+    name: 'OrderForm',
+    schema: {
+      componentName: 'Page',
+      children: [
+        {
+          componentName: 'TinyButton',
+          props: { text: 'Submit', type: 'primary' },
+        },
+      ],
+    },
+  },
+  componentsMap: [
+    {
+      componentName: 'TinyButton',
+      package: '@opentiny/vue',
+      exportName: 'TinyButton',
+    },
+  ],
+  formatWithPrettier: true,
+});
+
+if (errors.length) {
+  console.error(errors);
+}
+
+console.log(panelName); // OrderForm.vue
+console.log(panelValue); // Vue SFC source
+```
+
+`schema` can be an object or a JSON string. Invalid or empty input falls back to an empty `Page`.
+
+## generateCode()
+
+- **Type**
+
+```ts
+function generateCode(params: ICodeGeneratorParams): Promise<ICodeGeneratorResult>
+```
+
+This is equivalent to `new VueCodeGenerator().generate(params)`. Compile validation is on by default.
+
+- **Parameters**
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `pageInfo.schema` | `CardSchema \| string` | Yes | — | Page schema |
+| `pageInfo.name` | `string` | No | `'SchemaCard'` | Output file name without extension; result is `{name}.vue` |
+| `componentsMap` | `IComponentMapItem[]` | No | `[]` | Maps schema component names to npm packages for generated `import`s |
+| `formatWithPrettier` | `boolean` | No | `false` | Format with Prettier; returns unformatted source if formatting fails |
+
+- **Returns**: `Promise<ICodeGeneratorResult>`
+
+## ICodeGeneratorResult
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `panelName` | `string` | File name, e.g. `SchemaCard.vue` |
+| `panelValue` | `string` | Vue SFC source |
+| `panelType` | `'vue'` | Always Vue |
+| `type` | `'page'` | Always a page |
+| `prettierOpts` | `Record<string, unknown>` | Prettier options used for this run |
+| `errors` | `{ message: string }[]` | Compile-validation errors; empty when none |
+
+## IComponentMapItem
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `componentName` | `string` | Yes | Component name in the schema; must match `componentName` |
+| `package` | `string` | Yes | npm package name for `from '...'` |
+| `exportName` | `string` | No | Export from the package; if it differs from `componentName`, generates `exportName as componentName` |
+
+Items missing `componentName` or `package` are ignored. Components present in the schema but absent from `componentsMap` do not get an import.
+
+You can build the map from materials protocol `npm` fields, for example:
+
+```ts
+import { materialsMeta } from '@opentiny/genui-sdk-materials-vue-opentiny-vue/meta';
+
+const componentsMap = materialsMeta.materials.flatMap((material) =>
+  (material.data?.materials?.components ?? []).map((item) => ({
+    componentName: item.component,
+    package: item.npm.package,
+    exportName: item.npm.exportName,
+  })),
+);
+```
+
+## VueCodeGenerator
+
+Instantiate the generator when you need custom Prettier options or want to disable compile validation:
+
+```ts
+import { VueCodeGenerator } from '@opentiny/genui-sdk-vue/code-generator';
+
+const generator = new VueCodeGenerator({
+  prettierOpts: { printWidth: 100, singleQuote: true },
+  enableCompileValidation: false,
+});
+
+const result = await generator.generate({
+  pageInfo: { schema },
+  formatWithPrettier: true,
+});
+```
+
+### Constructor options `IVueCodeGeneratorOptions`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `prettierOpts` | `Record<string, unknown>` | Built-in Vue defaults | Merged with built-in options for formatting |
+| `enableCompileValidation` | `boolean` | `true` | Validate output with `@vue/compiler-sfc` |
+
+## Generated Output
+
+The SFC preserves schema semantics as much as possible:
+
+- `<template>` from the component tree
+- `<script setup>` from `state`, `methods`, `lifeCycles`, and `refs`
+- `<style>` from schema `css`
+- component imports from `componentsMap`
+
+Playground “Export Vue source” uses this API.

--- a/docs/src/en/guide/quick-start.md
+++ b/docs/src/en/guide/quick-start.md
@@ -228,13 +228,14 @@ You are ready to try generative UI.
 
 ## Subpath Imports
 
-Besides the main entry, `@opentiny/genui-sdk-vue` provides subpath exports. Import only Chat or Renderer when needed to avoid bundling unused modules when tree-shaking is limited.
+Besides the main entry, `@opentiny/genui-sdk-vue` provides subpath exports. Import only Chat, Renderer, or the code generator when needed to avoid bundling unused modules when tree-shaking is limited.
 
 | Subpath | Use case | Main exports |
 | --- | --- | --- |
 | `@opentiny/genui-sdk-vue/chat` | Chat only | `GenuiChat` |
 | `@opentiny/genui-sdk-vue/renderer` | Renderer only (custom chat UI) | `GenuiRenderer` |
 | `@opentiny/genui-sdk-vue/config-provider` | Theme / i18n / materials container | `GenuiConfigProvider` |
+| `@opentiny/genui-sdk-vue/code-generator` | SchemaJSON → Vue SFC | `generateCode` |
 
 ```ts
 import { GenuiChat } from '@opentiny/genui-sdk-vue/chat';
@@ -243,6 +244,9 @@ import { materials } from '@opentiny/genui-sdk-materials-vue-opentiny-vue/materi
 
 // Renderer only
 import { GenuiRenderer } from '@opentiny/genui-sdk-vue/renderer';
+
+// Code generation only
+import { generateCode } from '@opentiny/genui-sdk-vue/code-generator';
 ```
 
 ::: tip

--- a/docs/src/en/guide/quick-start.md
+++ b/docs/src/en/guide/quick-start.md
@@ -235,7 +235,7 @@ Besides the main entry, `@opentiny/genui-sdk-vue` provides subpath exports. Impo
 | `@opentiny/genui-sdk-vue/chat` | Chat only | `GenuiChat` |
 | `@opentiny/genui-sdk-vue/renderer` | Renderer only (custom chat UI) | `GenuiRenderer` |
 | `@opentiny/genui-sdk-vue/config-provider` | Theme / i18n / materials container | `GenuiConfigProvider` |
-| `@opentiny/genui-sdk-vue/code-generator` | SchemaJSON → Vue SFC | `generateCode` |
+| `@opentiny/genui-sdk-vue/code-generator` | SchemaJSON → Vue SFC | [`generateCode`](../components/code-generator) |
 
 ```ts
 import { GenuiChat } from '@opentiny/genui-sdk-vue/chat';
@@ -256,5 +256,6 @@ In v1.3.0, materials were decoupled from the SDK. If you need the built-in TinyV
 ## Related Docs
 
 - [GenuiChat API](../components/chat)
+- [generateCode](../components/code-generator) — SchemaJSON to Vue SFC
 - [Using Renderer](start-with-renderer)
 - [Examples](../examples/chat/custom-actions)

--- a/docs/src/guide/quick-start.md
+++ b/docs/src/guide/quick-start.md
@@ -225,13 +225,14 @@ html {
 
 ## 按需引入
 
-`@opentiny/genui-sdk-vue` 除主入口外，还提供按功能拆分的子路径导出。只需 Chat 或只需 Renderer 时，可从对应子路径引入，在构建工具对摇树不友好时，避免打入未使用的模块。
+`@opentiny/genui-sdk-vue` 除主入口外，还提供按功能拆分的子路径导出。只需 Chat、Renderer 或代码生成时，可从对应子路径引入，在构建工具对摇树不友好时，避免打入未使用的模块。
 
 | 子路径 | 适用场景 | 主要导出内容 |
 | --- | --- | --- |
 | `@opentiny/genui-sdk-vue/chat` | 仅需对话组件 | `GenuiChat` |
 | `@opentiny/genui-sdk-vue/renderer` | 仅需渲染器（自建对话 UI） | `GenuiRenderer` |
 | `@opentiny/genui-sdk-vue/config-provider` | 主题/国际化/物料配置容器 | `GenuiConfigProvider` |
+| `@opentiny/genui-sdk-vue/code-generator` | 将 SchemaJSON 转为 Vue SFC | `generateCode` |
 
 ```ts
 import { GenuiChat } from '@opentiny/genui-sdk-vue/chat';
@@ -240,6 +241,9 @@ import { materials } from '@opentiny/genui-sdk-materials-vue-opentiny-vue/materi
 
 // 仅使用 Renderer
 import { GenuiRenderer } from '@opentiny/genui-sdk-vue/renderer';
+
+// 仅使用代码生成
+import { generateCode } from '@opentiny/genui-sdk-vue/code-generator';
 ```
 
 ::: tip

--- a/docs/src/guide/quick-start.md
+++ b/docs/src/guide/quick-start.md
@@ -232,7 +232,7 @@ html {
 | `@opentiny/genui-sdk-vue/chat` | 仅需对话组件 | `GenuiChat` |
 | `@opentiny/genui-sdk-vue/renderer` | 仅需渲染器（自建对话 UI） | `GenuiRenderer` |
 | `@opentiny/genui-sdk-vue/config-provider` | 主题/国际化/物料配置容器 | `GenuiConfigProvider` |
-| `@opentiny/genui-sdk-vue/code-generator` | 将 SchemaJSON 转为 Vue SFC | `generateCode` |
+| `@opentiny/genui-sdk-vue/code-generator` | 将 SchemaJSON 转为 Vue SFC | [`generateCode`](../components/code-generator) |
 
 ```ts
 import { GenuiChat } from '@opentiny/genui-sdk-vue/chat';
@@ -253,5 +253,6 @@ import { generateCode } from '@opentiny/genui-sdk-vue/code-generator';
 ## 其他相关文档
 
 - 查看 [组件文档](../components/chat) 了解 `GenuiChat` 的详细 API
+- 查看 [generateCode](../components/code-generator) 了解如何将 SchemaJSON 转为 Vue SFC
 - 查看 [Renderer 使用指南](start-with-renderer) 了解如何使用 `GenuiRenderer` 进行更精细的控制
 - 查看 [特性示例](../examples/chat/custom-actions) 学习高级用法

--- a/packages/frameworks/vue/README.md
+++ b/packages/frameworks/vue/README.md
@@ -33,6 +33,12 @@ import { materials } from '@opentiny/genui-sdk-materials-vue-opentiny-vue/materi
 </template>
 ```
 
+Import by feature via subpaths (`/chat`, `/renderer`, `/config-provider`, `/code-generator`) to avoid unused modules:
+
+```ts
+import { generateCode } from '@opentiny/genui-sdk-vue/code-generator';
+```
+
 ## Documentation
 
 * [quick-start](https://docs.opentiny.design/genui-sdk/guide/quick-start)

--- a/packages/frameworks/vue/README.md
+++ b/packages/frameworks/vue/README.md
@@ -49,3 +49,4 @@ import { generateCode } from '@opentiny/genui-sdk-vue/code-generator';
 * [GenuiRender](https://docs.opentiny.design/genui-sdk/components/renderer)
 * [GenuiChat](https://docs.opentiny.design/genui-sdk/components/chat)
 * [GenuiConfigProvider](https://docs.opentiny.design/genui-sdk/components/config-provider)
+* [generateCode](https://docs.opentiny.design/genui-sdk/components/code-generator)

--- a/packages/frameworks/vue/package.json
+++ b/packages/frameworks/vue/package.json
@@ -50,6 +50,10 @@
     "./transform-jsx": {
       "types": "./dist/transform-jsx.d.ts",
       "import": "./dist/transform-jsx.js"
+    },
+    "./code-generator": {
+      "types": "./dist/code-generator.d.ts",
+      "import": "./dist/code-generator.js"
     }
   },
   "type": "module",

--- a/packages/frameworks/vue/vite.config.ts
+++ b/packages/frameworks/vue/vite.config.ts
@@ -40,6 +40,7 @@ export default defineConfig(({ mode }) => {
           'legacy-renderer': path.resolve(__dirname, './src/legacy-renderer/index.ts'),
           'config-provider': path.resolve(__dirname, './src/config-provider/index.ts'),
           'transform-jsx': path.resolve(__dirname, './src/transform-jsx.ts'),
+          'code-generator': path.resolve(__dirname, './src/code-generator/index.ts'),
         },
         formats: ['es'],
         fileName: (_, entryName) => `${entryName}.js`,

--- a/packages/integrate/skill/genui-integration/references/vue.md
+++ b/packages/integrate/skill/genui-integration/references/vue.md
@@ -50,7 +50,7 @@ for await (const line of readSseLines(response.body)) {
 
 ## 按需导入
 
-`@opentiny/genui-sdk-vue` 提供 `chat`、`renderer`、`config-provider` 等子路径，可按需引入以减小打包体积。详见 [快速开始 - 按需引入](https://docs.opentiny.design/genui-sdk/guide/quick-start#按需引入)。
+`@opentiny/genui-sdk-vue` 提供 `chat`、`renderer`、`config-provider`、`code-generator` 等子路径，可按需引入以减小打包体积。详见 [快速开始 - 按需引入](https://docs.opentiny.design/genui-sdk/guide/quick-start#按需引入)。
 
 ## 兼容组件
 

--- a/sites/playground/web/src/hooks/use-generate-vue-code.ts
+++ b/sites/playground/web/src/hooks/use-generate-vue-code.ts
@@ -1,5 +1,5 @@
 import type { IMaterialsMeta, IMaterialsProtocol } from '@opentiny/genui-sdk-core';
-import { generateCode as generateVueCode } from '@opentiny/genui-sdk-vue';
+import { generateCode as generateVueCode } from '@opentiny/genui-sdk-vue/code-generator';
 import { materialsMeta } from '@opentiny/genui-sdk-materials-vue-opentiny-vue/meta';
 
 type IComponentMapItem = {


### PR DESCRIPTION
## 导出 Vue code-generator 子路径

### 变更简述
- `@opentiny/genui-sdk-vue` 增加 `./code-generator` 子路径导出，和 chat / renderer 一样可单独引入
- Playground 的 Vue 代码导出改为从该子路径 import，不再走主包 barrel
- 新增 `generateCode` 组件文档页（中/英），挂在「Vue 组件文档」侧栏
- 同步按需引入文档：快速开始（中/英，链到新文档页）、包 README、Vue 集成 skill





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Vue code generator import path for generating Vue components from schemas.
  * Added TypeScript type definitions for the code generator export.

* **Documentation**
  * Added code generator API documentation, examples, and navigation links.
  * Updated quick-start guides, package documentation, and integration guidance with code generator import examples.
  * Documented feature-specific imports for using only the required Vue SDK modules.

* **Improvements**
  * Updated the playground to use the dedicated Vue code generator import path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->