### PR TITLE
perf(homepage): extract lib build assets and lazy-load videos

### DIFF
--- a/sites/homepage/web/src/components/HomeBuilderContent.vue
+++ b/sites/homepage/web/src/components/HomeBuilderContent.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue';
 import { TinyButton } from '@opentiny/vue';
-import genuiBuilderDemoChat from '@/assets/genui_builder_demo_chat.png';
-import genuiBuilderDemoVersion from '@/assets/genui_builder_demo_version.png';
-import genuiBuilderDemoPreview from '@/assets/genui_builder_demo_preview.png';
+import genuiBuilderDemoChat from '@/assets/genui_builder_demo_chat.png?no-inline';
+import genuiBuilderDemoVersion from '@/assets/genui_builder_demo_version.png?no-inline';
+import genuiBuilderDemoPreview from '@/assets/genui_builder_demo_preview.png?no-inline';
 import genuiBuilderIconChat from '@/assets/genui_builder_icon_chat.svg';
 import genuiBuilderIconVersion from '@/assets/genui_builder_icon_version.svg';
 import genuiBuilderIconPreview from '@/assets/genui_builder_icon_preview.svg';

--- a/sites/homepage/web/src/components/HomeMcpToolMobile.vue
+++ b/sites/homepage/web/src/components/HomeMcpToolMobile.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import genuiAbility3 from '@/assets/create-github.webp';
+import genuiAbility3 from '@/assets/create-github.webp?no-inline';
 import { TinyTag } from '@opentiny/vue';
 import { t } from '@/i18n';
 const wrapperClass = 'home-mcp-tool-mobile';

--- a/sites/homepage/web/src/views/home.vue
+++ b/sites/homepage/web/src/views/home.vue
@@ -103,9 +103,8 @@ const { videoSrc: flowVideoSrc } = useLazyVideo(flowVideoRef, searchTicketVedio)
         controls
         preload="none"
         :poster="genuiActionVedioCover"
-      >
-        <source v-if="actionVideoSrc" :src="actionVideoSrc" type="video/mp4" />
-      </video>
+        :src="actionVideoSrc"
+      />
     </home-ability>
 
     <home-mcp-tool-mobile v-if="isMobile"></home-mcp-tool-mobile>
@@ -151,9 +150,8 @@ const { videoSrc: flowVideoSrc } = useLazyVideo(flowVideoRef, searchTicketVedio)
         controls
         preload="none"
         :poster="genuiFlowVedioCover"
-      >
-        <source v-if="flowVideoSrc" :src="flowVideoSrc" type="video/mp4" />
-      </video>
+        :src="flowVideoSrc"
+      />
     </home-ability>
 
     <home-extend></home-extend>

--- a/sites/homepage/web/src/views/home.vue
+++ b/sites/homepage/web/src/views/home.vue
@@ -1,15 +1,16 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue';
 import { TinyButton, TinyTag } from '@opentiny/vue';
-import genuiAbility1 from '@/assets/genui_ability_1.svg';
-import genuiAbility2 from '@/assets/genui_ability_2.webp';
-import genuiAbility3 from '@/assets/create-github.webp';
-import genuiActionVedioCover from '@/assets/order-milk-tea.webp';
-import orderMilkTeaVedio from '@/assets/video/order-milk-tea.mp4';
-import genuiFlowVedioCover from '@/assets/search-ticket.webp';
-import searchTicketVedio from '@/assets/video/search-ticket.mp4';
+import genuiAbility1 from '@/assets/genui_ability_1.svg?no-inline';
+import genuiAbility2 from '@/assets/genui_ability_2.webp?no-inline';
+import genuiAbility3 from '@/assets/create-github.webp?no-inline';
+import genuiActionVedioCover from '@/assets/order-milk-tea.webp?no-inline';
+import orderMilkTeaVedio from '@/assets/video/order-milk-tea.mp4?no-inline';
+import genuiFlowVedioCover from '@/assets/search-ticket.webp?no-inline';
+import searchTicketVedio from '@/assets/video/search-ticket.mp4?no-inline';
 import { LinkKey, linkMap } from '@/utils/link';
 import { useMobile } from '@/composables/useMobile';
+import { useLazyVideo } from '@/composables/useLazyVideo';
 import HomeAbility from '@/components/HomeAbility.vue';
 import HomeGuide from '@/components/HomeGuide.vue';
 import HomeFeature from '@/components/HomeFeature.vue';
@@ -54,6 +55,11 @@ const { isMobile } = useMobile();
 const buttonSize = computed(() => {
   return isMobile.value ? 'default' : 'medium';
 });
+
+const actionVideoRef = ref<HTMLVideoElement | null>(null);
+const flowVideoRef = ref<HTMLVideoElement | null>(null);
+const { videoSrc: actionVideoSrc } = useLazyVideo(actionVideoRef, orderMilkTeaVedio);
+const { videoSrc: flowVideoSrc } = useLazyVideo(flowVideoRef, searchTicketVedio);
 </script>
 
 <template>
@@ -91,13 +97,14 @@ const buttonSize = computed(() => {
     <!-- 第三屏 -->
     <home-ability :title="t('ability.interaction.title')" :subtitle="t('ability.interaction.subtitle')">
       <video
+        ref="actionVideoRef"
         class="cover-image ability-image"
         id="genui-action-vedio"
         controls
         preload="none"
         :poster="genuiActionVedioCover"
       >
-        <source :src="orderMilkTeaVedio" type="video/mp4" />
+        <source v-if="actionVideoSrc" :src="actionVideoSrc" type="video/mp4" />
       </video>
     </home-ability>
 
@@ -138,14 +145,14 @@ const buttonSize = computed(() => {
 
     <home-ability class="home-ability-5" :title="t('ability.stream.title')" :subtitle="t('ability.stream.subtitle')">
       <video
-        ref="videoRef"
+        ref="flowVideoRef"
         class="cover-image ability-image"
         id="genui-flow-vedio"
         controls
         preload="none"
         :poster="genuiFlowVedioCover"
       >
-        <source :src="searchTicketVedio" type="video/mp4" />
+        <source v-if="flowVideoSrc" :src="flowVideoSrc" type="video/mp4" />
       </video>
     </home-ability>
 

--- a/sites/homepage/web/vite.config.ts
+++ b/sites/homepage/web/vite.config.ts
@@ -64,6 +64,7 @@ export default defineConfig({
       fileName: 'index',
       formats: ['es']
     },
+    emitAssets: true,
     cssCodeSplit: false,
     rollupOptions: {
       external: [


### PR DESCRIPTION
## 优化首屏加载速度

- 修复 homepage lib 构建将约 27MB 媒体资源 base64 内联进 `index.js` 的问题：为大体积资源 import 添加 `?no-inline`，并在 `vite.config.ts` 中启用 `emitAssets: true`
- 为首页两个演示视频接入 `useLazyVideo` 懒加载：视频进入视口附近后再注入 `<source>`，首屏不请求 mp4
- `HomeBuilderContent`、`HomeMcpToolMobile` 中的大图同样使用 `?no-inline`，保证 lib 构建产物一致

## 构建对比

**优化前：**
<img width="1023" height="511" alt="image" src="https://github.com/user-attachments/assets/7a9509e4-a0fe-455f-9026-aa9a46a18178" />
**优化后：**

<img width="944" height="578" alt="image" src="https://github.com/user-attachments/assets/8bcfb3de-2371-4853-8319-0c401138b1b0" />
## 已验证功能

- `pnpm build:homepage` 构建通过，`dist/index.js` 从约 27MB 降至约 8KB
- `pnpm build:web` 构建通过，视频输出至 `dist/assets/mp4/` 独立文件

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Homepage demo videos now load on demand, improving initial page load performance.
  * Media assets use optimized loading behavior to help reduce unnecessary data transfer.

* **Improvements**
  * Homepage demonstrations and mobile content now load media more reliably.
  * Demo assets are emitted consistently for deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->