### PR TITLE
docs: rename components nav to reference

### DIFF
--- a/docs/.vitepress/config/en-theme.ts
+++ b/docs/.vitepress/config/en-theme.ts
@@ -38,7 +38,7 @@ export const enThemeConfig: DefaultTheme.Config = {
     ],
     '/en/components/': [
       {
-        text: 'Vue Components',
+        text: 'Vue Docs',
         items: [
           { text: 'GenuiRenderer', link: '/en/components/renderer' },
           { text: 'GenuiChat', link: '/en/components/chat' },
@@ -46,21 +46,21 @@ export const enThemeConfig: DefaultTheme.Config = {
         ],
       },
       {
-        text: 'Angular Components',
+        text: 'Angular Docs',
         items: [
           { text: 'GenuiRenderer', link: '/en/components/angular/renderer' },
           { text: 'GenuiConfigProvider', link: '/en/components/angular/config-provider' },
         ],
       },
       {
-        text: 'Server',
+        text: 'Server Docs',
         items: [
           { text: 'API Reference', link: '/en/components/server/api' },
           { text: 'CLI', link: '/en/components/server/cli' },
         ],
       },
       {
-        text: 'Core',
+        text: 'Core Docs',
         items: [{ text: 'API Docs', link: '/en/components/core/api' }],
       },
       {

--- a/docs/.vitepress/config/en-theme.ts
+++ b/docs/.vitepress/config/en-theme.ts
@@ -38,7 +38,7 @@ export const enThemeConfig: DefaultTheme.Config = {
     ],
     '/en/components/': [
       {
-        text: 'Vue Docs',
+        text: 'Vue',
         items: [
           { text: 'GenuiRenderer', link: '/en/components/renderer' },
           { text: 'GenuiChat', link: '/en/components/chat' },
@@ -46,21 +46,21 @@ export const enThemeConfig: DefaultTheme.Config = {
         ],
       },
       {
-        text: 'Angular Docs',
+        text: 'Angular',
         items: [
           { text: 'GenuiRenderer', link: '/en/components/angular/renderer' },
           { text: 'GenuiConfigProvider', link: '/en/components/angular/config-provider' },
         ],
       },
       {
-        text: 'Server Docs',
+        text: 'Server',
         items: [
           { text: 'API Reference', link: '/en/components/server/api' },
           { text: 'CLI', link: '/en/components/server/cli' },
         ],
       },
       {
-        text: 'Core Docs',
+        text: 'Core',
         items: [{ text: 'API Docs', link: '/en/components/core/api' }],
       },
       {

--- a/docs/.vitepress/config/zh-theme.ts
+++ b/docs/.vitepress/config/zh-theme.ts
@@ -7,7 +7,7 @@ export const zhThemeConfig: DefaultTheme.Config = {
   },
   nav: [
     { text: '快速开始', link: '/guide/quick-start', activeMatch: '/guide/' },
-    { text: '组件文档', link: '/components/renderer', activeMatch: '/components/' },
+    { text: '参考文档', link: '/components/renderer', activeMatch: '/components/' },
     { text: '特性示例', link: '/examples/renderer/custom-actions', activeMatch: '/examples/' },
     { text: '协议规范', link: '/schema/protocol', activeMatch: '/schema/' },
   ],
@@ -34,7 +34,7 @@ export const zhThemeConfig: DefaultTheme.Config = {
     ],
     '/components/': [
       {
-        text: 'Vue 组件文档',
+        text: 'Vue 文档',
         items: [
           { text: 'GenuiRenderer', link: '/components/renderer' },
           { text: 'GenuiChat', link: '/components/chat' },
@@ -42,21 +42,21 @@ export const zhThemeConfig: DefaultTheme.Config = {
         ],
       },
       {
-        text: 'Angular 组件文档',
+        text: 'Angular 文档',
         items: [
           { text: 'GenuiRenderer', link: '/components/angular/renderer' },
           { text: 'GenuiConfigProvider', link: '/components/angular/config-provider' },
         ],
       },
       {
-        text: 'Server 库文档',
+        text: 'Server 文档',
         items: [
           { text: 'API 参考', link: '/components/server/api' },
           { text: 'CLI', link: '/components/server/cli' },
         ],
       },
       {
-        text: 'Core 库文档',
+        text: 'Core 文档',
         items: [{ text: 'API 文档', link: '/components/core/api' }],
       },
       {

--- a/docs/src/en/index.md
+++ b/docs/src/en/index.md
@@ -10,7 +10,7 @@ hero:
       text: Quick Start
       link: /en/guide/quick-start
     - theme: alt
-      text: Components
+      text: Reference
       link: /en/components/renderer
 features:
   - title: AI Ecosystem Compatible

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -11,7 +11,7 @@ hero:
       text: 快速开始
       link: /guide/quick-start
     - theme: alt
-      text: 组件文档
+      text: 参考文档
       link: /components/renderer
 features:
   - title: 现有AI生态兼容


### PR DESCRIPTION
## 导航文案改为「参考文档」

### 变更简述
- 顶栏「组件文档」改为「参考文档」，与该分区已覆盖 Vue / Angular / Server / Core 的范围对齐
- 侧栏分组去掉「组件 / 库」措辞，改为 Vue / Angular / Server / Core 文档
- 首页入口按钮同步改名；英文侧栏与首页 CTA 对齐为 Docs / Reference

<img width="1414" height="831" alt="image" src="https://github.com/user-attachments/assets/55b2670a-74fc-441f-b2f7-be7a094ff77c" />
<img width="1444" height="732" alt="image" src="https://github.com/user-attachments/assets/fa530ce0-e089-4187-b7df-cfea050c3914" />


### 相关
- Issue: 无

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated English navigation labels to clearly distinguish Vue, Angular, Server, and Core documentation sections.
  - Renamed Chinese navigation and sidebar labels to use consistent reference-documentation terminology.
  - Updated English and Chinese homepage action buttons to display “Reference”/“参考文档” while keeping their existing links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->