### PR TITLE
fix(playground): total time show in time items bottom

### DIFF
--- a/sites/playground/web/src/components/FinishInfo.vue
+++ b/sites/playground/web/src/components/FinishInfo.vue
@@ -103,10 +103,6 @@ const titleContent = computed(() => {
             <dt>{{ t('finishInfo.time') }}</dt>
             <dd>{{ createdLabel }}</dd>
           </div>
-          <div v-if="durationLabel" class="stat-row stat-row--emphasis">
-            <dt>{{ t('finishInfo.duration') }}</dt>
-            <dd>{{ durationLabel }}</dd>
-          </div>
           <div v-if="ttfbLabel" class="stat-row">
             <dt>{{ t('finishInfo.ttfb') }}</dt>
             <dd>{{ ttfbLabel }}</dd>
@@ -114,6 +110,10 @@ const titleContent = computed(() => {
           <div v-if="renderDurationLabel" class="stat-row">
             <dt>{{ t('finishInfo.renderDuration') }}</dt>
             <dd>{{ renderDurationLabel }}</dd>
+          </div>
+          <div v-if="durationLabel" class="stat-row stat-row--emphasis">
+            <dt>{{ t('finishInfo.duration') }}</dt>
+            <dd>{{ durationLabel }}</dd>
           </div>
           <template v-if="usage">
             <div v-if="usage.prompt_tokens != null" class="stat-row">


### PR DESCRIPTION
将总消耗时间项放在所有时间项的最下面。
<img width="479" height="430" alt="PixPin_2026-09-10_16-35-50" src="https://github.com/user-attachments/assets/94d2fd69-2e39-4709-87d6-20771b9a177e" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reordered the duration statistic to appear after the TTFB and render-duration statistics in the completion information view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->