### PR TITLE
fix(playground): only show Vue framework in builder mode

### DIFF
--- a/sites/playground/web/src/components/PlaygroundSidebar.vue
+++ b/sites/playground/web/src/components/PlaygroundSidebar.vue
@@ -73,7 +73,10 @@ watch(
     if (mode === PlaygroundMode.Builder && activeName.value === 'history') {
       activeName.value = ENABLE_TEMPLATE ? 'template' : 'model';
     }
-    if (mode === PlaygroundMode.Builder && framework.value === 'Angular') {
+    if (
+      mode === PlaygroundMode.Builder &&
+      (framework.value === 'Angular' || framework.value === 'React')
+    ) {
       setFramework('Vue');
     }
   },

--- a/sites/playground/web/src/components/materials-tab/materials-options.ts
+++ b/sites/playground/web/src/components/materials-tab/materials-options.ts
@@ -10,7 +10,7 @@ export const FRAMEWORK_OPTIONS = [
 
 export function getFrameworkOptions(mode: PlaygroundMode) {
   if (mode === PlaygroundMode.Builder) {
-    return FRAMEWORK_OPTIONS.filter((item) => item.name !== 'Angular');
+    return FRAMEWORK_OPTIONS.filter((item) => item.name === 'Vue');
   }
   return [...FRAMEWORK_OPTIONS];
 }


### PR DESCRIPTION
## Summary

修复 Builder 模式下错误显示 React 框架选择的问题。Builder 模式基于 `@opentiny/genui-sdk-vue`，仅支持 Vue materials，不应展示 React。


## Changes

1. **`materials-options.ts`** - `getFrameworkOptions` 从 denylist 方式改为 allowlist 方式，Builder 模式仅保留 Vue
2. **`PlaygroundSidebar.vue`** - 切换到 Builder 模式时，如果当前选中 React 则自动重置为 Vue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Builder mode now consistently uses Vue when switching from React or Angular.
  * Framework selection in Builder mode now displays only the Vue option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->