### PR TITLE
fix(react-antd): support string values on AntDatePicker

### DIFF
--- a/packages/materials/react-antd/package.json
+++ b/packages/materials/react-antd/package.json
@@ -39,6 +39,7 @@
     "antd": "^5.24.0"
   },
   "peerDependencies": {
+    "dayjs": "^1.11.10",
     "react": ">=18",
     "react-dom": ">=18"
   },

--- a/packages/materials/react-antd/src/materials/components/AntDatePickerWrap.tsx
+++ b/packages/materials/react-antd/src/materials/components/AntDatePickerWrap.tsx
@@ -1,0 +1,44 @@
+import { DatePicker, type DatePickerProps } from 'antd';
+import dayjs, { type Dayjs } from 'dayjs';
+import { forwardRef } from 'react';
+
+type DateInput = DatePickerProps['value'] | string | number | Date | null | undefined;
+type AntDatePickerProps = Omit<DatePickerProps, 'value' | 'defaultValue'> & {
+  value?: DateInput;
+  defaultValue?: DateInput;
+};
+
+function isDayjsValue(value: unknown): value is Dayjs {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    typeof (value as Dayjs).isValid === 'function' &&
+    typeof (value as Dayjs).toISOString === 'function'
+  );
+}
+
+function normalizeDateValue(value: DateInput): DatePickerProps['value'] {
+  if (value == null || value === '') return null;
+  if (isDayjsValue(value)) return value.isValid() ? value : null;
+
+  const parsed =
+    typeof value === 'object' && value !== null && '$d' in value
+      ? dayjs((value as { $d: string | Date }).$d)
+      : dayjs(value as string | number | Date);
+
+  return parsed.isValid() ? parsed : null;
+}
+
+export const AntDatePicker = forwardRef<any, AntDatePickerProps>(function AntDatePicker(
+  { value, defaultValue, ...rest },
+  ref,
+) {
+  return (
+    <DatePicker
+      {...rest}
+      ref={ref}
+      value={normalizeDateValue(value)}
+      defaultValue={normalizeDateValue(defaultValue)}
+    />
+  );
+});

--- a/packages/materials/react-antd/src/materials/components/components.ts
+++ b/packages/materials/react-antd/src/materials/components/components.ts
@@ -2,7 +2,6 @@ import {
   Button,
   Card,
   Checkbox,
-  DatePicker,
   Form,
   Input,
   Modal,
@@ -14,6 +13,7 @@ import {
 import type { IMaterialsMap } from '@opentiny/genui-sdk-core';
 
 import { AntTabsWrap } from './AntTabsWrap';
+import { AntDatePicker } from './AntDatePickerWrap';
 
 export const components: IMaterialsMap = {
   AntButton: Button,
@@ -28,5 +28,5 @@ export const components: IMaterialsMap = {
   AntSwitch: Switch,
   AntCheckbox: Checkbox,
   AntRadio: Radio,
-  AntDatePicker: DatePicker,
+  AntDatePicker,
 };

--- a/packages/materials/react-antd/src/meta/examples/antd-form.json
+++ b/packages/materials/react-antd/src/meta/examples/antd-form.json
@@ -3,7 +3,8 @@
     "formData": {
       "name": "",
       "email": "",
-      "department": ""
+      "department": "",
+      "joinDate": ""
     }
   },
   "methods": {
@@ -112,6 +113,28 @@
                     "onChange": {
                       "type": "JSFunction",
                       "value": "function(value) { this.state.formData.department = value; }"
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "componentName": "AntFormItem",
+              "props": {
+                "label": "Join date"
+              },
+              "children": [
+                {
+                  "componentName": "AntDatePicker",
+                  "props": {
+                    "placeholder": "Select join date",
+                    "value": {
+                      "type": "JSExpression",
+                      "value": "this.state.formData.joinDate"
+                    },
+                    "onChange": {
+                      "type": "JSFunction",
+                      "value": "function(date, dateString) { this.state.formData.joinDate = dateString; }"
                     }
                   }
                 }

--- a/packages/materials/react-antd/src/meta/materials/bundle.json
+++ b/packages/materials/react-antd/src/meta/materials/bundle.json
@@ -679,7 +679,7 @@
                     "property": "value",
                     "type": "string",
                     "description": {
-                      "zh_CN": "日期值，可用 model:true 双向绑定"
+                      "zh_CN": "日期字符串（如 YYYY-MM-DD)"
                     }
                   },
                   {
@@ -705,14 +705,14 @@
                       "name": "date",
                       "type": "Object",
                       "description": {
-                        "zh_CN": "dayjs 日期对象，未选时为 null"
+                        "zh_CN": "内部日期对象，未选时为 null。禁止写入 state"
                       }
                     },
                     {
                       "name": "dateString",
                       "type": "string",
                       "description": {
-                        "zh_CN": "格式化后的日期字符串"
+                        "zh_CN": "格式化后的日期字符串。写入 state 时必须使用该参数，例如 this.state.formData.joinDate = dateString"
                       }
                     }
                   ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -497,6 +497,9 @@ importers:
       antd:
         specifier: ^5.24.0
         version: 5.29.3(date-fns@2.30.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      dayjs:
+        specifier: ^1.11.10
+        version: 1.11.20
     devDependencies:
       '@types/react':
         specifier: ^18.3.0
@@ -1605,6 +1608,7 @@ packages:
   '@angular/animations@20.3.15':
     resolution: {integrity: sha512-ikyKfhkxoqQA6JcBN0B9RaN6369sM1XYX81Id0lI58dmWCe7gYfrTp8ejqxxKftl514psQO3pkW8Gn1nJ131Gw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    deprecated: '@angular/animations is deprecated. Use `animate.enter` and `animate.leave` instead. For more information see: https://v22.angular.dev/guide/animations.'
     peerDependencies:
       '@angular/core': 20.3.15
 
@@ -3003,49 +3007,42 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/nice-linux-arm64-musl@1.1.1':
     resolution: {integrity: sha512-+2Rzdb3nTIYZ0YJF43qf2twhqOCkiSrHx2Pg6DJaCPYhhaxbLcdlV8hCRMHghQ+EtZQWGNcS2xF4KxBhSGeutg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/nice-linux-ppc64-gnu@1.1.1':
     resolution: {integrity: sha512-4FS8oc0GeHpwvv4tKciKkw3Y4jKsL7FRhaOeiPei0X9T4Jd619wHNe4xCLmN2EMgZoeGg+Q7GY7BsvwKpL22Tg==}
     engines: {node: '>= 10'}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/nice-linux-riscv64-gnu@1.1.1':
     resolution: {integrity: sha512-HU0nw9uD4FO/oGCCk409tCi5IzIZpH2agE6nN4fqpwVlCn5BOq0MS1dXGjXaG17JaAvrlpV5ZeyZwSon10XOXw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/nice-linux-s390x-gnu@1.1.1':
     resolution: {integrity: sha512-2YqKJWWl24EwrX0DzCQgPLKQBxYDdBxOHot1KWEq7aY2uYeX+Uvtv4I8xFVVygJDgf6/92h9N3Y43WPx8+PAgQ==}
     engines: {node: '>= 10'}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/nice-linux-x64-gnu@1.1.1':
     resolution: {integrity: sha512-/gaNz3R92t+dcrfCw/96pDopcmec7oCcAQ3l/M+Zxr82KT4DljD37CpgrnXV+pJC263JkW572pdbP3hP+KjcIg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/nice-linux-x64-musl@1.1.1':
     resolution: {integrity: sha512-xScCGnyj/oppsNPMnevsBe3pvNaoK7FGvMjT35riz9YdhB2WtTG47ZlbxtOLpjeO9SqqQ2J2igCmz6IJOD5JYw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/nice-openharmony-arm64@1.1.1':
     resolution: {integrity: sha512-6uJPRVwVCLDeoOaNyeiW0gp2kFIM4r7PL2MczdZQHkFi9gVlgm+Vn+V6nTWRcu856mJ2WjYJiumEajfSm7arPQ==}
@@ -5789,42 +5786,36 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.1':
     resolution: {integrity: sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.1':
     resolution: {integrity: sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.1':
     resolution: {integrity: sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.1':
     resolution: {integrity: sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.1':
     resolution: {integrity: sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.1':
     resolution: {integrity: sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==}
@@ -6010,133 +6001,111 @@ packages:
     resolution: {integrity: sha512-IoerZJ4l1wRMopEHRKOO16e04iXRDyZFZnNZKrWeNquh5d6bucjezgd+OxG03mOMTnS1x7hilzb3uURPkJ0OfA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.54.0':
     resolution: {integrity: sha512-EHMUcDwhtdRGlXZsGSIuXSYwD5kOT9NVnx9sqzYiwAc91wfYOE1g1djOEDseZJKKqtHAHGwnGPQu3kytmfaXLQ==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.52.3':
     resolution: {integrity: sha512-ZYdtqgHTDfvrJHSh3W22TvjWxwOgc3ThK/XjgcNGP2DIwFIPeAPNsQxrJO5XqleSlgDux2VAoWQ5iJrtaC1TbA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm-musleabihf@4.54.0':
     resolution: {integrity: sha512-+pBrqEjaakN2ySv5RVrj/qLytYhPKEUwk+e3SFU5jTLHIcAtqh2rLrd/OkbNuHJpsBgxsD8ccJt5ga/SeG0JmA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.52.3':
     resolution: {integrity: sha512-NcViG7A0YtuFDA6xWSgmFb6iPFzHlf5vcqb2p0lGEbT+gjrEEz8nC/EeDHvx6mnGXnGCC1SeVV+8u+smj0CeGQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-gnu@4.54.0':
     resolution: {integrity: sha512-NSqc7rE9wuUaRBsBp5ckQ5CVz5aIRKCwsoa6WMF7G01sX3/qHUw/z4pv+D+ahL1EIKy6Enpcnz1RY8pf7bjwng==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.52.3':
     resolution: {integrity: sha512-d3pY7LWno6SYNXRm6Ebsq0DJGoiLXTb83AIPCXl9fmtIQs/rXoS8SJxxUNtFbJ5MiOvs+7y34np77+9l4nfFMw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-musl@4.54.0':
     resolution: {integrity: sha512-gr5vDbg3Bakga5kbdpqx81m2n9IX8M6gIMlQQIXiLTNeQW6CucvuInJ91EuCJ/JYvc+rcLLsDFcfAD1K7fMofg==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.52.3':
     resolution: {integrity: sha512-3y5GA0JkBuirLqmjwAKwB0keDlI6JfGYduMlJD/Rl7fvb4Ni8iKdQs1eiunMZJhwDWdCvrcqXRY++VEBbvk6Eg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-gnu@4.54.0':
     resolution: {integrity: sha512-gsrtB1NA3ZYj2vq0Rzkylo9ylCtW/PhpLEivlgWe0bpgtX5+9j9EZa0wtZiCjgu6zmSeZWyI/e2YRX1URozpIw==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.52.3':
     resolution: {integrity: sha512-AUUH65a0p3Q0Yfm5oD2KVgzTKgwPyp9DSXc3UA7DtxhEb/WSPfbG4wqXeSN62OG5gSo18em4xv6dbfcUGXcagw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.54.0':
     resolution: {integrity: sha512-y3qNOfTBStmFNq+t4s7Tmc9hW2ENtPg8FeUD/VShI7rKxNW7O4fFeaYbMsd3tpFlIg1Q8IapFgy7Q9i2BqeBvA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.52.3':
     resolution: {integrity: sha512-1makPhFFVBqZE+XFg3Dkq+IkQ7JvmUrwwqaYBL2CE+ZpxPaqkGaiWFEWVGyvTwZace6WLJHwjVh/+CXbKDGPmg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.54.0':
     resolution: {integrity: sha512-89sepv7h2lIVPsFma8iwmccN7Yjjtgz0Rj/Ou6fEqg3HDhpCa+Et+YSufy27i6b0Wav69Qv4WBNl3Rs6pwhebQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.52.3':
     resolution: {integrity: sha512-OOFJa28dxfl8kLOPMUOQBCO6z3X2SAfzIE276fwT52uXDWUS178KWq0pL7d6p1kz7pkzA0yQwtqL0dEPoVcRWg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-musl@4.54.0':
     resolution: {integrity: sha512-ZcU77ieh0M2Q8Ur7D5X7KvK+UxbXeDHwiOt/CPSBTI1fBmeDMivW0dPkdqkT4rOgDjrDDBUed9x4EgraIKoR2A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.52.3':
     resolution: {integrity: sha512-jMdsML2VI5l+V7cKfZx3ak+SLlJ8fKvLJ0Eoa4b9/vCUrzXKgoKxvHqvJ/mkWhFiyp88nCkM5S2v6nIwRtPcgg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.54.0':
     resolution: {integrity: sha512-2AdWy5RdDF5+4YfG/YesGDDtbyJlC9LHmL6rZw6FurBJ5n4vFGupsOBGfwMRjBYH7qRQowT8D/U4LoSvVwOhSQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.52.3':
     resolution: {integrity: sha512-tPgGd6bY2M2LJTA1uGq8fkSPK8ZLYjDjY+ZLK9WHncCnfIz29LIXIqUgzCR0hIefzy6Hpbe8Th5WOSwTM8E7LA==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.54.0':
     resolution: {integrity: sha512-WGt5J8Ij/rvyqpFexxk3ffKqqbLf9AqrTBbWDk7ApGUzaIs6V+s2s84kAxklFwmMF/vBNGrVdYgbblCOFFezMQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.52.3':
     resolution: {integrity: sha512-BCFkJjgk+WFzP+tcSMXq77ymAPIxsX9lFJWs+2JzuZTLtksJ2o5hvgTdIcZ5+oKzUDMwI0PfWzRBYAydAHF2Mw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-x64-musl@4.54.0':
     resolution: {integrity: sha512-JzQmb38ATzHjxlPHuTH6tE7ojnMKM2kYNzt44LO/jJi8BpceEC8QuXYA908n8r3CNuG/B3BV8VR3Hi1rYtmPiw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.52.3':
     resolution: {integrity: sha512-KTD/EqjZF3yvRaWUJdD1cW+IQBk4fbQaHYJUmP8N4XoKFZilVL8cobFSTDnjTtxWJQ3JYaMgF4nObY/+nYkumA==}
@@ -8282,7 +8251,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globby@10.0.2:
     resolution: {integrity: sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==}
@@ -10721,10 +10690,12 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
 
   tar@7.5.2:
     resolution: {integrity: sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
 
   temp-dir@1.0.0:
     resolution: {integrity: sha512-xZFXEGbG7SNC3itwBzI3RYjq/cEhBkx2hJuKGIUOcEULmkQExXiHat2z/qkISYsuR+IKumhEfKKbV5qXmhICFQ==}
@@ -10993,7 +10964,7 @@ packages:
 
   uuid@3.4.0:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
-    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   validate-npm-package-license@3.0.4:

--- a/projects/tiny-schema-renderer-react/__tests__/error-boundary.test.ts
+++ b/projects/tiny-schema-renderer-react/__tests__/error-boundary.test.ts
@@ -1,0 +1,36 @@
+import { createElement } from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { SchemaRenderer } from '../src/RenderMain';
+import { RendererContextProvider } from '../src/RendererContextProvider';
+
+function Boom(): never {
+  throw new Error('isValid is not a function');
+}
+
+describe('SchemaRenderer error boundary', () => {
+  it('contains render errors at the renderer root without crashing the host', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    render(
+      createElement(
+        'div',
+        { 'data-testid': 'host' },
+        createElement(
+          RendererContextProvider,
+          { 'render-settings': { materials: { components: { Boom } } } },
+          createElement(SchemaRenderer, {
+            schema: {
+              componentName: 'Page',
+              children: [{ componentName: 'Boom' }],
+            },
+          }),
+        ),
+      ),
+    );
+
+    expect(screen.getByTestId('host')).toBeTruthy();
+    expect(screen.getByText(/Page failed to render: isValid is not a function/)).toBeTruthy();
+    errorSpy.mockRestore();
+  });
+});

--- a/projects/tiny-schema-renderer-react/src/RenderMain.tsx
+++ b/projects/tiny-schema-renderer-react/src/RenderMain.tsx
@@ -7,6 +7,7 @@ import { PageContextProvider } from './page-context';
 import { setSchema, setState } from './set-schema';
 import type { LifeCycleFn } from './life-cycles';
 import { SchemaNodeRenderer, normalizeChildren } from './Render';
+import { SchemaErrorBoundary } from './SchemaErrorBoundary';
 import { Loading } from './Loading';
 import { useRendererSettings } from './RendererContextProvider';
 import { MATERIALS } from './materials';
@@ -117,11 +118,13 @@ export const SchemaRenderer = forwardRef<SchemaRendererHandle, SchemaRendererPro
 
   return (
     <PageContextProvider value={pageContext}>
-      {schema?.children?.length ? (
-        <SchemaNodeRenderer schema={rootChildrenSchema} parent={schema} />
-      ) : (
-        <Loading />
-      )}
+      <SchemaErrorBoundary componentName="Page">
+        {schema?.children?.length ? (
+          <SchemaNodeRenderer schema={rootChildrenSchema} parent={schema} />
+        ) : (
+          <Loading />
+        )}
+      </SchemaErrorBoundary>
     </PageContextProvider>
   );
 });

--- a/projects/tiny-schema-renderer-react/src/SchemaErrorBoundary.tsx
+++ b/projects/tiny-schema-renderer-react/src/SchemaErrorBoundary.tsx
@@ -1,0 +1,44 @@
+import { Component, type ErrorInfo, type PropsWithChildren } from 'react';
+import { Notify } from './engine/notify';
+
+type SchemaErrorBoundaryProps = PropsWithChildren<{
+  componentName?: string;
+}>;
+
+type SchemaErrorBoundaryState = {
+  error: Error | null;
+};
+
+export class SchemaErrorBoundary extends Component<SchemaErrorBoundaryProps, SchemaErrorBoundaryState> {
+  state: SchemaErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): SchemaErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    const name = this.props.componentName || 'Schema';
+    console.error(`SchemaRenderer ${name} render error:`, error, info.componentStack);
+    Notify({
+      type: 'warning',
+      title: `${name} rendering error`,
+      message: error.message,
+    });
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div
+          role="alert"
+          data-tag="schema-error"
+          style={{ color: '#c00', fontSize: 13, lineHeight: '20px', padding: '4px 0' }}
+        >
+          {this.props.componentName ? `${this.props.componentName} failed to render: ` : 'Failed to render: '}
+          {this.state.error.message}
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/projects/tiny-schema-renderer-react/test/components.tsx
+++ b/projects/tiny-schema-renderer-react/test/components.tsx
@@ -1,6 +1,7 @@
 import * as Antd from 'antd';
 import type { TabsProps } from 'antd';
 import { Fragment, type ComponentType } from 'react';
+import { AntDatePicker } from '../../../packages/materials/react-antd/src/materials/components/AntDatePickerWrap';
 
 const SKIP = new Set(['message', 'notification', 'unstableSetRender', 'version', 'theme', 'default']);
 
@@ -30,3 +31,4 @@ export const components: Record<string, ComponentType<any>> = Object.fromEntries
 
 components.AntFormItem = Antd.Form.Item;
 components.AntTabs = AntTabs;
+components.AntDatePicker = AntDatePicker;

--- a/projects/tiny-schema-renderer-react/test/mock/date-picker.json
+++ b/projects/tiny-schema-renderer-react/test/mock/date-picker.json
@@ -1,0 +1,48 @@
+{
+  "componentName": "Page",
+  "state": {
+    "formData": {
+      "joinDate": ""
+    }
+  },
+  "children": [
+    {
+      "componentName": "AntCard",
+      "props": {
+        "title": "日期选择"
+      },
+      "children": [
+        {
+          "componentName": "AntForm",
+          "props": {
+            "layout": "vertical"
+          },
+          "children": [
+            {
+              "componentName": "AntFormItem",
+              "props": {
+                "label": "入职日期"
+              },
+              "children": [
+                {
+                  "componentName": "AntDatePicker",
+                  "props": {
+                    "placeholder": "请选择入职日期",
+                    "value": {
+                      "type": "JSExpression",
+                      "value": "this.state.formData.joinDate"
+                    },
+                    "onChange": {
+                      "type": "JSFunction",
+                      "value": "function(date, dateString) { this.state.formData.joinDate = dateString; }"
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/projects/tiny-schema-renderer-react/test/mock/index.ts
+++ b/projects/tiny-schema-renderer-react/test/mock/index.ts
@@ -7,6 +7,7 @@ import stateTransitionsSchema from './state-transitions.json';
 import bindThisSchema from './bind-this.json';
 import jsxParseSchema from './jsx-parse.json';
 import cssScopeSchema from './css-scope.json';
+import datePickerSchema from './date-picker.json';
 
 export interface DemoItem {
   id: string;
@@ -16,6 +17,7 @@ export interface DemoItem {
 
 export const demos: DemoItem[] = [
   { id: 'form', label: '表单校验', schema: formValidationSchema as RootNode },
+  { id: 'date-picker', label: '日期选择', schema: datePickerSchema as RootNode },
   { id: 'table', label: '表格渲染', schema: tableSchema as RootNode },
   { id: 'tabs', label: 'Tabs 渲染', schema: tabsSchema as RootNode },
   { id: 'state', label: 'State 转换', schema: stateTransitionsSchema as RootNode },


### PR DESCRIPTION
## Summary

- 为 `AntDatePicker` 增加适配层，把 schema 中的空字符串 / 日期字符串转成 dayjs，避免点选日期时 `isValid is not a function`
- 在 React 渲染器根节点增加 Error Boundary，渲染期异常时 toast 提示并展示 fallback，避免整张卡片从宿主中卸掉
- 补充 DatePicker 表单示例、物料 API 说明，以及渲染器本地验证 mock



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a date picker that accepts and normalizes strings, numbers, native dates, and Dayjs values.
  - Added join-date fields to Ant Design form examples, including required-field validation.
  - Schema rendering now recovers automatically when the schema changes.
  - Schema error notifications now receive the current page context.

- **Bug Fixes**
  - Improved date picker handling for empty, invalid, null, and uncontrolled values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->